### PR TITLE
fix: waitlist form — use URLSearchParams for Apps Script compatibility

### DIFF
--- a/landing/src/components/Waitlist.jsx
+++ b/landing/src/components/Waitlist.jsx
@@ -127,14 +127,16 @@ export default function Waitlist() {
     setErrorMsg('');
 
     try {
-      const data = new FormData();
-      data.append('email', form.email);
-      data.append('company', form.company);
-      data.append('role', form.role);
-      data.append('timestamp', new Date().toISOString());
+      // URLSearchParams sends application/x-www-form-urlencoded, which Apps Script parses into e.parameter
+      // FormData (multipart) is NOT parsed by Apps Script — this is the correct encoding for no-cors + Apps Script
+      const params = new URLSearchParams();
+      params.append('email', form.email);
+      params.append('company', form.company);
+      params.append('role', form.role);
+      params.append('timestamp', new Date().toISOString());
 
       // no-cors: Apps Script doesn't set CORS headers; we can't read the response — assume success
-      await fetch(SHEETS_URL, { method: 'POST', mode: 'no-cors', body: data });
+      await fetch(SHEETS_URL, { method: 'POST', mode: 'no-cors', body: params });
 
       setStatus('success');
     } catch (err) {


### PR DESCRIPTION
## Summary

- **Root cause**: `FormData` sends `multipart/form-data` which Google Apps Script does **not** parse into `e.parameter` — submissions silently dropped
- **Fix**: Switch to `URLSearchParams` which sends `application/x-www-form-urlencoded`, correctly parsed by Apps Script
- **Verified**: Test submission on https://agentic-k8s-landing.fly.dev appeared in the Google Sheet with all 4 fields (email, company, role, timestamp)

## Test plan

- [x] Submit waitlist form on https://agentic-k8s-landing.fly.dev/#waitlist
- [x] UI shows "You're on the list!" success state
- [x] Row appears in Google Sheet with correct email, company, role, and ISO timestamp
- [x] No CORS errors (still using `mode: 'no-cors'` — opaque response is expected)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)