### PR TITLE
Security: rate limiting, CSP/HSTS headers, form submission cooldown

### DIFF
--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -9,6 +9,6 @@ RUN npm run build
 # Stage 2: Serve with nginx
 FROM nginx:1.27-alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/landing/nginx.conf
+++ b/landing/nginx.conf
@@ -1,8 +1,17 @@
-server {
-    listen 8080;
-    server_name _;
-    root /usr/share/nginx/html;
-    index index.html;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile on;
+    keepalive_timeout 65;
+
+    # Rate limiting: 10 req/s per IP, burst of 20
+    limit_req_zone $binary_remote_addr zone=general:10m rate=10r/s;
 
     # Gzip compression
     gzip on;
@@ -10,19 +19,37 @@ server {
     gzip_types text/plain text/css text/javascript application/javascript application/json image/svg+xml;
     gzip_min_length 1024;
 
-    # Cache static assets aggressively
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2|woff|ttf)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
+    server {
+        listen 8080;
+        server_name _;
+        root /usr/share/nginx/html;
+        index index.html;
 
-    # SPA fallback — all routes go to index.html
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
+        # Limit request body size (static site — no uploads)
+        client_max_body_size 1k;
 
-    # Security headers
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-Content-Type-Options "nosniff";
-    add_header Referrer-Policy "strict-origin-when-cross-origin";
+        # Apply rate limit
+        limit_req zone=general burst=20 nodelay;
+        limit_req_status 429;
+
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://api.github.com; frame-src https://gamma.app; object-src 'none'; base-uri 'self';" always;
+
+        # Cache static assets aggressively
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2|woff|ttf)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # SPA fallback — all routes go to index.html
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- **nginx rate limiting** — `limit_req_zone` (10 req/s per IP, burst 20) with `limit_req_status 429`; upgraded `nginx.conf` to full `http {}` context required for the directive
- **Security headers** — added `Content-Security-Policy` (CSP), `Strict-Transport-Security` (HSTS, 2yr + preload), `X-XSS-Protection`, `Permissions-Policy` — all with `always` flag so they apply to error responses too
- **Client-side form cooldown** — `Waitlist.jsx` now enforces a 30-second cooldown via `useRef` to prevent rapid bot resubmission to the Google Apps Script endpoint
- **Dockerfile** — updated `COPY` target from `conf.d/default.conf` to `/etc/nginx/nginx.conf` to match the new full-config format

## Out of scope
- Authentication (explicitly not needed per project decision)
- CORS (intentional `no-cors` fetch to Apps Script)

## Test plan
- [x] `curl -sI https://clawdlinux.org` — all 7 security headers present ✅
- [x] `flyctl deploy` — both machines updated, health checks passed ✅
- [ ] Manual: Submit waitlist form twice within 30s → "Please wait 30 seconds" error shown
- [ ] Manual: 20+ rapid curl requests → 429 responses after burst is exhausted