### PR TITLE
feat: show Gamma pitch deck expanded by default

### DIFF
--- a/landing/src/components/GammaPresentation.jsx
+++ b/landing/src/components/GammaPresentation.jsx
@@ -120,7 +120,7 @@ function VideoPlayer({ video, isActive }) {
 
 export default function GammaPresentation() {
   const [activeVideo, setActiveVideo] = useState(0);
-  const [showDeck, setShowDeck] = useState(false);
+  const [showDeck, setShowDeck] = useState(true);
 
   return (
     <section


### PR DESCRIPTION
## Summary
- `GammaPresentation.jsx`: change `showDeck` initial state from `false` → `true` so the Gamma pitch deck iframe is visible when the page loads instead of hidden behind the toggle

## Why
The pitch deck was implemented as a collapsible section defaulting to collapsed. Users never saw it unless they knew to click "View Full Pitch Deck". Making it open by default restores the intended experience.

🤖 Generated with [Claude Code](https://claude.ai/code)