### PR TITLE
fix: nginx rate limit scope and add_header inheritance

### DIFF
--- a/landing/nginx.conf
+++ b/landing/nginx.conf
@@ -11,6 +11,7 @@ http {
     keepalive_timeout 65;
 
     # Rate limiting: 10 req/s per IP, burst of 20
+    # Zone defined here (http context) — applied only in location / below
     limit_req_zone $binary_remote_addr zone=general:10m rate=10r/s;
 
     # Gzip compression
@@ -28,11 +29,10 @@ http {
         # Limit request body size (static site — no uploads)
         client_max_body_size 1k;
 
-        # Apply rate limit
-        limit_req zone=general burst=20 nodelay;
-        limit_req_status 429;
-
-        # Security headers
+        # Security headers (server block — inherited by location blocks that add NO
+        # add_header directives of their own; repeated in each location block below
+        # because nginx replaces, not merges, add_header lists when a location block
+        # defines any add_header of its own)
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -41,14 +41,27 @@ http {
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://api.github.com; frame-src https://gamma.app; object-src 'none'; base-uri 'self';" always;
 
-        # Cache static assets aggressively
+        # Cache static assets aggressively.
+        # Security headers are repeated here because any add_header in a location
+        # block causes nginx to discard all add_header directives from parent blocks.
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2|woff|ttf)$ {
             expires 1y;
             add_header Cache-Control "public, immutable";
+
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
+            add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://script.google.com https://api.github.com; frame-src https://gamma.app; object-src 'none'; base-uri 'self';" always;
         }
 
-        # SPA fallback — all routes go to index.html
+        # SPA fallback — all routes go to index.html.
+        # Rate limit applied here only so static asset subrequests are never throttled.
         location / {
+            limit_req zone=general burst=20 nodelay;
+            limit_req_status 429;
             try_files $uri $uri/ /index.html;
         }
     }


### PR DESCRIPTION
## Summary

Addresses the two issues flagged in the [PR #14 code review](https://github.com/shreyanshjain7174/agentic-k8s-operator/pull/14#issuecomment-3980552759).

### Fix 1 — Rate limit scope

`limit_req` was at the `server {}` level, throttling every request including JS/CSS/font assets. A cold-cache React SPA page load fires ~20–50 parallel subrequests; with `burst=20 nodelay` the burst exhausts instantly, returning 429 on page assets.

Moved `limit_req` and `limit_req_status` inside `location /` only — static assets are never rate-limited.

### Fix 2 — `add_header` inheritance

nginx replaces (not merges) `add_header` lists when a `location {}` block defines any `add_header` of its own. The static assets location had `Cache-Control`, which silently dropped all 7 security headers (CSP, HSTS, X-Frame-Options, etc.) from every JS/CSS/font/image response.

All security headers are now repeated inside the static assets `location` block with a comment explaining why.

🤖 Generated with [Claude Code](https://claude.ai/code)