### PR TITLE
fix: point Docs nav link to GitHub README

### DIFF
--- a/landing/src/components/Navigation.jsx
+++ b/landing/src/components/Navigation.jsx
@@ -6,7 +6,7 @@ const NAV_LINKS = [
   { label: 'Features', href: '#features' },
   { label: 'Use Cases', href: '#use-cases' },
   { label: 'GitHub', href: 'https://github.com/shreyanshjain7174/agentic-k8s-operator', external: true },
-  { label: 'Docs', href: '#docs' },
+  { label: 'Docs', href: 'https://github.com/shreyanshjain7174/agentic-k8s-operator#readme', external: true },
 ];
 
 const GITHUB_URL = 'https://github.com/shreyanshjain7174/agentic-k8s-operator';


### PR DESCRIPTION
## Summary

The Docs nav link had `href: '#docs'` but no element with `id="docs"` exists on the page. `handleSmoothScroll` called `document.querySelector('#docs')` which returned `null`, so clicking Docs did nothing.

**Fix:** Change `href` to `https://github.com/shreyanshjain7174/agentic-k8s-operator#readme` and add `external: true` — same pattern as the GitHub link — so it opens the README in a new tab.

🤖 Generated with [Claude Code](https://claude.ai/code)