### PR TITLE
chore(security): add core secret scan gate

### DIFF
--- a/.github/workflows/secret-scan-gate.yml
+++ b/.github/workflows/secret-scan-gate.yml
@@ -1,0 +1,35 @@
+name: Secret Scan Gate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run repo secret scanner
+        run: |
+          chmod +x scripts/scan_secrets.sh
+          ./scripts/scan_secrets.sh --ci
+
+      - name: Run gitleaks (optional when license is configured)
+        if: ${{ env.GITLEAKS_LICENSE != '' }}
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ env.GITLEAKS_LICENSE }}

--- a/scripts/scan_secrets.sh
+++ b/scripts/scan_secrets.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-local}"
+
+PATTERN='(dop_v1_[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{70,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|-----BEGIN (RSA|EC|OPENSSH|DSA)? ?PRIVATE KEY-----|xox[baprs]-[A-Za-z0-9-]{10,}|sk_live_[0-9a-zA-Z]{16,}|AIza[0-9A-Za-z\-_]{35})'
+ALLOWLIST_PATHS_REGEX='^(agents/tests/test_credential_sanitizer\.py):'
+
+collect_files() {
+  if [[ "$MODE" == "--ci" ]]; then
+    git ls-files
+    return
+  fi
+
+  local upstream_ref
+  upstream_ref=""
+  if git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" >/dev/null 2>&1; then
+    upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}")"
+  elif git show-ref --verify --quiet refs/remotes/origin/main; then
+    upstream_ref="origin/main"
+  fi
+
+  if [[ -n "$upstream_ref" ]]; then
+    git diff --name-only --diff-filter=AM "$upstream_ref"...HEAD
+    return
+  fi
+
+  git diff --cached --name-only --diff-filter=AM
+}
+
+raw_files=()
+while IFS= read -r file; do
+  if [[ -n "$file" ]]; then
+    raw_files+=("$file")
+  fi
+done < <(collect_files | sort -u)
+
+if [[ ${#raw_files[@]} -eq 0 ]]; then
+  echo "✅ Secret scan: no candidate files to scan"
+  exit 0
+fi
+
+scan_files=()
+for file in "${raw_files[@]}"; do
+  if [[ -f "$file" ]]; then
+    scan_files+=("$file")
+  fi
+done
+
+if [[ ${#scan_files[@]} -eq 0 ]]; then
+  echo "✅ Secret scan: no existing files to scan"
+  exit 0
+fi
+
+blocked_name_hits=()
+for file in "${scan_files[@]}"; do
+  case "$file" in
+    .dockerconfigjson-temp|*.key|*id_rsa*|*id_ed25519*)
+      blocked_name_hits+=("$file")
+      ;;
+  esac
+done
+
+if [[ ${#blocked_name_hits[@]} -gt 0 ]]; then
+  echo "❌ Secret scan failed: blocked filename(s) detected"
+  printf '  - %s\n' "${blocked_name_hits[@]}"
+  echo "Rename/remove these files and use managed secrets instead."
+  exit 1
+fi
+
+tmp_results="$(mktemp)"
+tmp_filtered_results="$(mktemp)"
+trap 'rm -f "$tmp_results" "$tmp_filtered_results"' EXIT
+
+if git grep -I -nE "$PATTERN" -- "${scan_files[@]}" >"$tmp_results"; then
+  grep -E -v "$ALLOWLIST_PATHS_REGEX" "$tmp_results" >"$tmp_filtered_results" || true
+
+  if [[ ! -s "$tmp_filtered_results" ]]; then
+    echo "✅ Secret scan passed (allowlisted test fixture matches ignored)"
+    exit 0
+  fi
+
+  echo "❌ Secret scan failed: potential credentials detected"
+  cat "$tmp_filtered_results"
+  echo "Rotate and remove exposed values, then retry push."
+  exit 1
+fi
+
+echo "✅ Secret scan passed"


### PR DESCRIPTION
## Summary
Adds CI secret leak protection to core by introducing a dedicated Secret Scan Gate workflow and repository scanner script.

## Changes
- Added `scripts/scan_secrets.sh` for pattern-based secret scanning (CI mode scans tracked files).
- Added `.github/workflows/secret-scan-gate.yml` to run scanner on PRs and `main` pushes.
- Runs `gitleaks` only when `GITLEAKS_LICENSE` is configured.

## Validation
- `bash -n scripts/scan_secrets.sh`
- `bash scripts/scan_secrets.sh --ci`

## Notes
- Keeps setup license-independent by default while allowing stricter gitleaks coverage when licensed.