### PR TITLE
docs(quickstart): replace 2 broken Phase docs links with real targets

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -162,7 +162,8 @@ kubectl port-forward -n monitoring svc/grafana 3000:3000
 
 ## Next Steps
 
-- [Full Architecture Guide](../README.md)
-- [Phase 3: Model Tiering](../PHASE_3_MODEL_TIERING.md)
-- [Phase 4: Agent Evaluation](../PHASE_4_AGENT_EVALUATION.md)
-- [Helm Values Reference](../charts/values.yaml)
+- [Architecture overview](./04-architecture.md)
+- [Cost-aware model routing](./06-cost-management.md)
+- [Security & threat model](./threat-model.md)
+- [Helm values reference](../charts/values.yaml)
+- [Project README](../README.md)


### PR DESCRIPTION
## What

`docs/QUICKSTART.md` Next Steps section pointed at:
- `../PHASE_3_MODEL_TIERING.md` — does not exist
- `../PHASE_4_AGENT_EVALUATION.md` — does not exist

`grep -r` confirms both are referenced nowhere else in the repo. They appear to be leftovers from an early phased-development naming convention.

## Why

Quickstart is the highest-traffic doc page on the project. Broken links there are a credibility tax we pay on every visitor.

## Fix

Replaced with real existing docs:

| Was | Is |
|---|---|
| `PHASE_3_MODEL_TIERING.md` | `docs/06-cost-management.md` (cost-aware model routing) |
| `PHASE_4_AGENT_EVALUATION.md` | `docs/04-architecture.md` (architecture overview) |
| (added) | `docs/threat-model.md` — was a notable omission for a security-positioned project |

All 5 destination paths verified with `test -f`.

## Validation

```text
docs/04-architecture.md                  exists
docs/06-cost-management.md               exists
docs/threat-model.md                     exists
README.md                                exists
charts/values.yaml                       exists
```