### PR TITLE
feat(cli): add agentctl reject command with --rule and --reason flags

### DIFF
--- a/cmd/agentctl/commands.go
+++ b/cmd/agentctl/commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -229,6 +230,90 @@ func runApprove(ctx context.Context, opts *cliOptions, name string, cmd *cobra.C
 			}
 		}
 	}
+
+	return nil
+}
+
+// ── reject ──────────────────────────────────────────────────────────────────
+
+func newRejectCommand(opts *cliOptions) *cobra.Command {
+	var rule string
+	var reason string
+
+	cmd := &cobra.Command{
+		Use:   "reject <workload-name>",
+		Short: "Reject a PendingApproval workload",
+		Long: `Reject a workload that is paused at an approval gate.
+
+Sets rejection annotations so the controller records the feedback event
+and transitions the workload to the Rejected phase.
+
+Use --rule to specify which OPA rule the proposed action violated (e.g.
+"budget-exceeded", "destructive-action"). Per-rule rejections carry more
+information for the RL feedback loop than a bare rejection.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReject(cmd.Context(), opts, args[0], rule, reason, cmd)
+		},
+	}
+	cmd.Flags().StringVar(&rule, "rule", "", "OPA rule name that the proposed action violated")
+	cmd.Flags().StringVar(&reason, "reason", "", "Free-text explanation for the rejection")
+	return cmd
+}
+
+func runReject(ctx context.Context, opts *cliOptions, name, rule, reason string, cmd *cobra.Command) error {
+	w := cmd.OutOrStdout()
+
+	// Get the workload
+	wl, err := opts.dynamic.Resource(agentWorkloadGVR).Namespace(opts.Namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get workload %q: %w", name, err)
+	}
+
+	phase := nestedString(wl.Object, "status", "phase")
+	if phase != "PendingApproval" && phase != "Suspended" {
+		fmt.Fprintf(w, "Workload %q is in phase %q (not PendingApproval). No action needed.\n", name, phase)
+		return nil
+	}
+
+	// Build rejection annotations
+	annotations := map[string]string{
+		"agentworkload.clawdlinux.io/rejected-at": time.Now().UTC().Format(time.RFC3339),
+		"agentworkload.clawdlinux.io/rejected-by": "agentctl",
+	}
+	if rule != "" {
+		annotations["agentworkload.clawdlinux.io/rejected-rule"] = rule
+	}
+	if reason != "" {
+		annotations["agentworkload.clawdlinux.io/rejection-reason"] = reason
+	}
+
+	// Marshal patch
+	patchObj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+	}
+	patchBytes, err := json.Marshal(patchObj)
+	if err != nil {
+		return fmt.Errorf("marshal patch: %w", err)
+	}
+
+	_, err = opts.dynamic.Resource(agentWorkloadGVR).Namespace(opts.Namespace).Patch(
+		ctx, name, types.MergePatchType, patchBytes, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("patch workload %q: %w", name, err)
+	}
+
+	fmt.Fprintf(w, "✗ Workload %q rejected.", name)
+	if rule != "" {
+		fmt.Fprintf(w, " Rule: %s.", rule)
+	}
+	if reason != "" {
+		fmt.Fprintf(w, " Reason: %s.", reason)
+	}
+	fmt.Fprintln(w, " Controller will record the feedback event.")
 
 	return nil
 }

--- a/cmd/agentctl/root.go
+++ b/cmd/agentctl/root.go
@@ -130,6 +130,7 @@ func newRootCommand() *cobra.Command {
 	cmd.AddCommand(newVersionCommand(opts))
 	cmd.AddCommand(newInitCommand(opts))
 	cmd.AddCommand(newApproveCommand(opts))
+	cmd.AddCommand(newRejectCommand(opts))
 	cmd.AddCommand(newWorkflowsCommand(opts))
 	cmd.AddCommand(newStatusCommand(opts))
 

--- a/cmd/agentctl/root_test.go
+++ b/cmd/agentctl/root_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewRootCommand_ContainsRequiredSubcommands(t *testing.T) {
 	cmd := newRootCommand()
 
-	required := []string{"get", "describe", "logs", "cost", "apply", "version"}
+	required := []string{"get", "describe", "logs", "cost", "apply", "version", "reject"}
 	for _, name := range required {
 		if child, _, err := cmd.Find([]string{name}); err != nil || child == nil || child.Name() != name {
 			t.Fatalf("expected subcommand %q to exist", name)


### PR DESCRIPTION
Closes #84

## What

Adds `agentctl reject <workload-name> [--rule <opa-rule>] [--reason <text>]` — the complement to the existing `agentctl approve` command.

## Why

The RL feedback loop (M2 milestone, #82/#83) needs both approve AND reject signals. Today we only have approve. Per the [Sparrow paper](https://arxiv.org/abs/2209.14375) and our [deep research on #82](https://github.com/Clawdlinux/agentic-operator-core/issues/82#issuecomment-4322366164), per-rule rejections carry far more information than a flat boolean for calibration.

## Annotations set

| Annotation | Value | Required |
|---|---|---|
| `agentworkload.clawdlinux.io/rejected-at` | RFC3339 timestamp | Always |
| `agentworkload.clawdlinux.io/rejected-by` | `agentctl` | Always |
| `agentworkload.clawdlinux.io/rejected-rule` | OPA rule name | Only with `--rule` |
| `agentworkload.clawdlinux.io/rejection-reason` | Free text | Only with `--reason` |

## Example

```bash
agentctl reject my-workload --rule budget-exceeded --reason 'cost too high'
# ✗ Workload "my-workload" rejected. Rule: budget-exceeded. Reason: cost too high. Controller will record the feedback event.
```

## Tests

- Updated `TestNewRootCommand` to include `reject` in required subcommands
- `go test ./cmd/agentctl/` — all pass
- `go build` / `go vet` — clean

## Relationship to M2

This is the CLI surface; the controller-side (#82) will watch for these annotations and record `FeedbackEvent`s.