### PR TITLE
feat(landing): Products section linking Agentic Operator + ACP, refresh Discord URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,11 @@ enterprise/licensing/*
 !assets/*.gif
 !assets/*.png
 video/package-lock.json
+
+# Local IDE / agent / cluster artefacts (not part of the codebase)
+.vscode/
+.obsidian/
+.github/copilot-instructions.md
+_artifacts/
+# Built CLI binary lives at bin/agentctl-web; never commit at repo root
+/agentctl-web

--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -6,6 +6,7 @@ import Hero from './components/Hero';
 import StatsBar from './components/StatsBar';
 import Positioning from './components/Positioning';
 import Comparison from './components/Comparison';
+import ProductsAcl from './components/ProductsAcl';
 import Features from './components/Features';
 import Architecture from './components/Architecture';
 import OpenSource from './components/OpenSource';
@@ -37,6 +38,8 @@ export default function App() {
         <Positioning />
 
         <Comparison />
+
+        <ProductsAcl />
 
         <section id="architecture">
           <Architecture />

--- a/landing/src/components/Navigation.jsx
+++ b/landing/src/components/Navigation.jsx
@@ -7,13 +7,14 @@ import ThemeToggle from './ThemeToggle';
 const NAV_LINKS = [
   { label: 'Why Now', href: '#positioning' },
   { label: 'Compare', href: '#comparison' },
+  { label: 'Products', href: '#products' },
   { label: 'How It Works', href: '#architecture' },
   { label: 'Features', href: '#features' },
   { label: 'Open Source', href: '#open-source' },
 ];
 
 const GITHUB_URL = 'https://github.com/Clawdlinux/agentic-operator-core';
-const DISCORD_URL = 'https://discord.gg/2yJsjhPe';
+const DISCORD_URL = 'https://discord.gg/XtxRdBzZcK';
 const DEMO_EMAIL_URL = 'mailto:007ssancheti@gmail.com?subject=Agentic%20Operator%20Inquiry';
 const NAV_SCROLL_OFFSET = 88;
 

--- a/landing/src/components/ProductsAcl.jsx
+++ b/landing/src/components/ProductsAcl.jsx
@@ -1,0 +1,360 @@
+import { motion } from 'framer-motion';
+import {
+  Boxes,
+  Code2,
+  ArrowRight,
+  CheckCircle2,
+  TrendingDown,
+  Github,
+} from 'lucide-react';
+import { useTheme } from '../hooks/useTheme';
+
+const ACL_GITHUB = 'https://github.com/Clawdlinux/ninevigil-acp';
+const OPERATOR_GITHUB = 'https://github.com/Clawdlinux/agentic-operator-core';
+
+const PRODUCTS = [
+  {
+    badge: 'PRODUCT 01',
+    icon: Boxes,
+    name: 'Agentic Operator',
+    tag: 'Run agents in Kubernetes',
+    summary:
+      'Zero-egress, FedRAMP-ready operator that turns kubectl apply into a sandboxed, observable, cost-attributed agent workload. Argo DAGs, Cilium policy, OPA guardrails, per-tenant budgets — production from day one.',
+    highlights: [
+      { icon: CheckCircle2, text: 'AgentWorkload, AgentCard, Tenant CRDs' },
+      { icon: CheckCircle2, text: 'Cilium FQDN egress + OPA admission' },
+      { icon: CheckCircle2, text: 'Argo Workflows DAG orchestration' },
+      { icon: CheckCircle2, text: 'Per-workload OpenMeter cost attribution' },
+    ],
+    cta: { label: 'Operator on GitHub', href: OPERATOR_GITHUB },
+    accentKey: 'teal',
+  },
+  {
+    badge: 'PRODUCT 02 · NEW',
+    icon: Code2,
+    name: 'ACL — Agent Context Language',
+    tag: 'Feed agents 90% fewer tokens',
+    summary:
+      'A compact, machine-native representation of structured data, designed for LLM agents instead of humans. Three translators ship today (Kubernetes, OpenAPI, Postgres). Same fact-extraction accuracy at one-tenth the prompt tokens, validated on a 1,620-trial Anthropic benchmark.',
+    highlights: [
+      { icon: TrendingDown, text: '132× on live K8s namespace' },
+      { icon: TrendingDown, text: '68× on the GitHub OpenAPI spec' },
+      { icon: TrendingDown, text: '3.5× on realistic pg_dump output' },
+      { icon: CheckCircle2, text: 'Spec CC BY 4.0 · SDKs Apache 2.0 · CLI + Python decoder' },
+    ],
+    cta: { label: 'ACL on GitHub', href: ACL_GITHUB },
+    accentKey: 'teal',
+  },
+];
+
+const SHARED_THESIS = [
+  {
+    title: 'Same audience',
+    detail:
+      'Platform teams shipping agents into regulated environments — finance, healthcare, government, sovereign cloud.',
+  },
+  {
+    title: 'Same thesis',
+    detail:
+      'Agents need infrastructure that was designed for them, not retrofitted from human-shaped tooling.',
+  },
+  {
+    title: 'Same control plane',
+    detail:
+      'ACL is the data layer the Operator pre-injects into every Execution Manifest. Two products, one stack.',
+  },
+];
+
+export default function ProductsAcl() {
+  const { currentTheme } = useTheme();
+  const t = currentTheme;
+
+  return (
+    <section
+      id="products"
+      style={{
+        padding: '100px 24px',
+        maxWidth: 1200,
+        margin: '0 auto',
+      }}
+    >
+      {/* Header */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+        style={{ textAlign: 'center', marginBottom: 56 }}
+      >
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '6px 16px',
+            borderRadius: 20,
+            background: `${t.accent.teal}15`,
+            border: `1px solid ${t.accent.teal}30`,
+            marginBottom: 20,
+          }}
+        >
+          <span
+            style={{
+              color: t.accent.teal,
+              fontSize: 13,
+              fontWeight: 600,
+              fontFamily: 'IBM Plex Mono, monospace',
+            }}
+          >
+            TWO PRODUCTS · ONE STACK
+          </span>
+        </div>
+        <h2
+          style={{
+            fontFamily: 'Syne, sans-serif',
+            fontSize: 'clamp(28px, 4vw, 44px)',
+            fontWeight: 800,
+            color: t.text.primary,
+            margin: '0 0 16px',
+            lineHeight: 1.15,
+          }}
+        >
+          Run agents. Feed agents.
+          <br />
+          <span style={{ color: t.accent.teal }}>Same problem, two layers.</span>
+        </h2>
+        <p
+          style={{
+            fontSize: 18,
+            color: t.text.secondary,
+            maxWidth: 720,
+            margin: '0 auto',
+            lineHeight: 1.6,
+          }}
+        >
+          NineVigil ships the operational layer (Kubernetes operator) and the
+          data layer (compact agent-native representation format) for
+          production AI agents in regulated environments.
+        </p>
+      </motion.div>
+
+      {/* Two product cards */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(420px, 1fr))',
+          gap: 24,
+          marginBottom: 64,
+        }}
+      >
+        {PRODUCTS.map((p, i) => {
+          const Icon = p.icon;
+          return (
+            <motion.a
+              key={p.name}
+              href={p.cta.href}
+              target="_blank"
+              rel="noreferrer"
+              initial={{ opacity: 0, y: 24 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+              whileHover={{ y: -4, transition: { duration: 0.2 } }}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                padding: '32px 28px',
+                borderRadius: 16,
+                background: t.bg.card,
+                border: `1px solid ${t.border.default}`,
+                textDecoration: 'none',
+                color: 'inherit',
+                cursor: 'pointer',
+                transition: 'border-color 0.2s, transform 0.2s',
+              }}
+            >
+              {/* Badge */}
+              <div
+                style={{
+                  display: 'inline-block',
+                  alignSelf: 'flex-start',
+                  padding: '4px 10px',
+                  borderRadius: 6,
+                  background: `${t.accent.teal}15`,
+                  color: t.accent.teal,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  fontFamily: 'IBM Plex Mono, monospace',
+                  letterSpacing: 0.5,
+                  marginBottom: 20,
+                }}
+              >
+                {p.badge}
+              </div>
+
+              {/* Icon + name */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 14,
+                  marginBottom: 8,
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 44,
+                    height: 44,
+                    borderRadius: 10,
+                    background: `${t.accent.teal}20`,
+                  }}
+                >
+                  <Icon size={22} style={{ color: t.accent.teal }} />
+                </div>
+                <div>
+                  <h3
+                    style={{
+                      fontFamily: 'Syne, sans-serif',
+                      fontSize: 22,
+                      fontWeight: 700,
+                      color: t.text.primary,
+                      margin: 0,
+                      lineHeight: 1.2,
+                    }}
+                  >
+                    {p.name}
+                  </h3>
+                </div>
+              </div>
+
+              <p
+                style={{
+                  fontSize: 14,
+                  color: t.text.secondary,
+                  fontFamily: 'IBM Plex Mono, monospace',
+                  margin: '0 0 16px',
+                }}
+              >
+                {p.tag}
+              </p>
+
+              <p
+                style={{
+                  fontSize: 15,
+                  color: t.text.secondary,
+                  lineHeight: 1.65,
+                  margin: '0 0 24px',
+                }}
+              >
+                {p.summary}
+              </p>
+
+              {/* Highlights */}
+              <ul
+                style={{
+                  listStyle: 'none',
+                  padding: 0,
+                  margin: '0 0 28px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 10,
+                }}
+              >
+                {p.highlights.map((h) => {
+                  const HIcon = h.icon;
+                  return (
+                    <li
+                      key={h.text}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        gap: 10,
+                        fontSize: 14,
+                        color: t.text.primary,
+                        lineHeight: 1.5,
+                      }}
+                    >
+                      <HIcon
+                        size={16}
+                        style={{
+                          color: t.accent.teal,
+                          flexShrink: 0,
+                          marginTop: 2,
+                        }}
+                      />
+                      <span>{h.text}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {/* CTA */}
+              <div
+                style={{
+                  marginTop: 'auto',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  fontSize: 14,
+                  fontWeight: 600,
+                  color: t.accent.teal,
+                  fontFamily: 'IBM Plex Mono, monospace',
+                }}
+              >
+                <Github size={16} />
+                {p.cta.label}
+                <ArrowRight size={14} />
+              </div>
+            </motion.a>
+          );
+        })}
+      </div>
+
+      {/* Shared thesis row */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+          gap: 20,
+          padding: '32px',
+          borderRadius: 16,
+          background: t.bg.card,
+          border: `1px solid ${t.border.default}`,
+        }}
+      >
+        {SHARED_THESIS.map((s) => (
+          <div key={s.title}>
+            <h4
+              style={{
+                fontFamily: 'Syne, sans-serif',
+                fontSize: 16,
+                fontWeight: 700,
+                color: t.accent.teal,
+                margin: '0 0 8px',
+              }}
+            >
+              {s.title}
+            </h4>
+            <p
+              style={{
+                fontSize: 14,
+                color: t.text.secondary,
+                lineHeight: 1.6,
+                margin: 0,
+              }}
+            >
+              {s.detail}
+            </p>
+          </div>
+        ))}
+      </motion.div>
+    </section>
+  );
+}

--- a/video/src/MainComposition.tsx
+++ b/video/src/MainComposition.tsx
@@ -474,7 +474,7 @@ const Scene5CTA: React.FC = () => {
           marginTop: 24,
         }}
       >
-        clawdlinux.org · discord.gg/2yJsjhPe
+        clawdlinux.org · discord.gg/XtxRdBzZcK
       </div>
     </AbsoluteFill>
   );


### PR DESCRIPTION
## What

- New `ProductsAcl` component: a 'Products' band between Comparison and Architecture surfacing both flagship repos (Agentic Operator + [ninevigil-acp](https://github.com/Clawdlinux/ninevigil-acp)) with taglines + GitHub CTAs.
- Nav link: 'Products' added to desktop nav.
- Discord URL refresh `2yJsjhPe → XtxRdBzZcK` across landing nav + video CTA. Companion change in agentic-operator-private's video composition.
- `.gitignore` extended to stop tracking local-only IDE / agent / cluster artefacts (`.vscode/`, `.obsidian/`, `_artifacts/`, `.github/copilot-instructions.md`, stray `./agentctl-web` binary at root). The intended built artefact still lives at `bin/agentctl-web` and `/agentctl-web` is now ignored to prevent the 63 MB binary getting committed by accident.

## Verified

- `npm run build` in `landing/` is green (415 KB JS, 32 KB CSS).
- `git status` is clean after this commit.

## Why now

The git tree had been carrying these as untracked changes across sessions; consolidating them into one signed PR before the next release window so the working tree stays disciplined.