### PR TITLE
ci: reject AI-attributed commit trailers

### DIFF
--- a/.github/workflows/ai-attribution-guard.yml
+++ b/.github/workflows/ai-attribution-guard.yml
@@ -1,0 +1,59 @@
+name: AI Attribution Guard
+
+# Rejects PRs whose commit trailers attribute authorship to AI assistants.
+# Human contributors only: Signed-off-by and Co-authored-by must name people.
+# Extend PATTERNS below as new AI co-authoring tools appear.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  reject-ai-attribution:
+    name: reject-ai-attribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Inspect PR commit trailers
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Case-insensitive substrings that must not appear in
+          # Signed-off-by: or Co-authored-by: trailer lines.
+          PATTERNS='claude|anthropic|copilot|openai|gpt-[0-9]|cursor|codex|aider|devin|ai-bot|bot@users\.noreply'
+
+          violations=$(
+            gh api --paginate "/repos/${REPO}/pulls/${PR}/commits" \
+              --jq '.[].commit.message' \
+              | grep -inE '^(signed-off-by|co-authored-by):.*('"$PATTERNS"')' \
+              || true
+          )
+
+          if [ -n "$violations" ]; then
+            echo "::error::AI attribution found in commit trailers."
+            echo ""
+            echo "Offending lines:"
+            echo "$violations" | sed 's/^/  /'
+            echo ""
+            echo "Policy: this repo accepts only human authorship in commit trailers."
+            echo "Signed-off-by and Co-authored-by must name people, not AI tools."
+            echo ""
+            echo "To fix locally:"
+            echo "  git rebase -i origin/${{ github.event.pull_request.base.ref }}"
+            echo "  # for each offending commit: mark 'reword',"
+            echo "  # remove the Signed-off-by/Co-authored-by line that names the AI,"
+            echo "  # save and exit."
+            echo "  git push --force-with-lease"
+            exit 1
+          fi
+
+          echo "OK: no AI attribution found in commit trailers."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ If your change touches Python runtime code under `agents/`, run the relevant Pyt
 - Avoid unrelated refactors in the same PR.
 - Keep reconciliation behavior idempotent.
 
+## Commit Authorship
+
+- Human authorship only. `Signed-off-by` and `Co-authored-by` trailers must name people, not AI assistants.
+- The `AI Attribution Guard` CI check rejects PRs whose commit trailers contain names or emails matching common AI tools (Claude, Copilot, Cursor, GPT-*, Codex, etc.).
+- You may use AI tooling to help write code — just author and sign off the commits yourself.
+
 ## Issue Guidelines
 
 - Use the bug template for defects.


### PR DESCRIPTION
Adds a CI gate that rejects PRs whose commits attribute authorship to AI assistants via `Signed-off-by` or `Co-authored-by` trailers.

## What's blocked

Commit trailers matching (case-insensitive): `claude`, `anthropic`, `copilot`, `openai`, `gpt-[0-9]`, `cursor`, `codex`, `aider`, `devin`, `ai-bot`, `bot@users.noreply`.

You can still use AI tooling to write code — just sign off the commits yourself.

## How it works

Uses `gh api /repos/.../pulls/N/commits` to read commit messages without checking out fork code. Single bash step, ~2s. Works for both internal and external contributor PRs.

## Files

- `.github/workflows/ai-attribution-guard.yml` — new workflow, runs on `pull_request` (opened, synchronize, reopened)
- `CONTRIBUTING.md` — adds "Commit Authorship" section so contributors see the policy before they push

## Self-test

This PR itself will run the new workflow on its own commit. Commit message contains no AI trailers, so the check should pass.
