### PR TITLE
feat: runtime-agnostic adapter + booth demo + attestation-led README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Agentic Operator Core
+
+K8s-native agent orchestration platform. Go operator + Python agents.
+
+Read `graphify-out/GRAPH_REPORT.md` if it exists before answering architecture questions.
+
+## Writing Style (applies to all output)
+
+Follow ../WRITING_STYLE.md for all text generation. Quick summary:
+- No em dashes. Use periods.
+- Short sentences. Max 20 words each.
+- No corporate words: comprehensive, robust, seamless, leverage, utilize, facilitate.
+- No AI patterns: "Here's the thing", rhetorical questions as openers, triple parallel structure.
+- Write like a backend engineer over coffee. Direct. Casual. No fluff.
+- Technical terms fine. Don't dumb things down.
+- Numbers as digits. "$8K" not "eight thousand dollars".

--- a/RALPH_BACKLOG.md
+++ b/RALPH_BACKLOG.md
@@ -1,0 +1,28 @@
+# Ralph Backlog — agentic-operator-core
+
+Ordered task queue for the review-execution ralph loop. One task = one signed-off
+commit on a feature branch. States: `[ ]` todo, `[~]` in progress, `[x]` done,
+`[HUMAN]` needs the human gate (loop stops and flags).
+
+Pre-flight gates before any new branch or issue (do not skip):
+- `gh pr list --state open` before branching. Build on an existing branch if scope overlaps.
+- `gh issue list --state open --search "<keywords>"` before filing any issue.
+- Feature branch + PR, squash merge, delete branch. `git commit -s`. No coauthor. No emojis.
+
+## Lane B — public readiness
+- [ ] B1 Commit in-flight runtime-agnostic work on feat/runtime-agnostic-adapter (README, ROADMAP, charts, RFC-0001, adapter.go+_test, strategist sample) + untracked (CLAUDE.md, STRATEGY doc, agentworkload.yaml, tenants CRD). Verify `go build ./...` + `go test ./pkg/runtime/...` first.
+- [ ] B2 Review adapter interface for 3-runtime parity (BYO pod / AgentWorkload / kagent Agent), identical egress-seal + attestation. Confirm v1alpha2 runtimeClassName note current. skills: code-reviewer + architect-review.
+- [ ] B3 README rewrite: lead with zero-egress seal + tamper-evident in-cluster attestation artifact. Move "For VCs & Reviewers" below the fold. Add `helm install` one-liner. Keep runtime-agnostic framing; never make kagent the subject of a problem sentence. (name from A3 when ready). skill: dx-optimizer.
+- [ ] B4 Hygiene: `git rm -r --cached .serena`, add to .gitignore. Confirm videos/pptx/.DS_Store/.keys already gone.
+- [HUMAN] B5 Open PR for B1-B4, security-auditor quick pass, squash-merge to main, delete branch.
+- [ ] B6 After merge: file/refresh roadmap issues for social proof (search existing first). skill: docs-architect.
+
+## Lane A — naming (blocks B3 title, repo slug, module path)
+- [ ] A1 Acronym-collision matrix + one recommendation -> naming-decision.md (shared with ACP).
+- [HUMAN] A2 Approve the name.
+- [ ] A3 Mechanical local rename: README, docs, badges, chart metadata. LOCAL only.
+- [HUMAN] A4 Irreversible: GitHub repo slug + Go module path (github.com/shreyansh/agentic-operator). Staged as rename-module.sh.
+
+## Notes
+- Go module today: github.com/shreyansh/agentic-operator (not under Clawdlinux org — naming debt).
+- Strategy of record: STRATEGY_positioning_runtime_agnostic.md. Runtime-agnostic, kagent is one adapter.

--- a/RALPH_BACKLOG.md
+++ b/RALPH_BACKLOG.md
@@ -10,15 +10,15 @@ Pre-flight gates before any new branch or issue (do not skip):
 - Feature branch + PR, squash merge, delete branch. `git commit -s`. No coauthor. No emojis.
 
 ## Lane B — public readiness
-- [ ] B1 Commit in-flight runtime-agnostic work on feat/runtime-agnostic-adapter (README, ROADMAP, charts, RFC-0001, adapter.go+_test, strategist sample) + untracked (CLAUDE.md, STRATEGY doc, agentworkload.yaml, tenants CRD). Verify `go build ./...` + `go test ./pkg/runtime/...` first.
+- [x] B1 Commit in-flight runtime-agnostic work on feat/runtime-agnostic-adapter (README, ROADMAP, charts, RFC-0001, adapter.go+_test, strategist sample) + untracked (CLAUDE.md, STRATEGY doc, agentworkload.yaml, tenants CRD). Verify `go build ./...` + `go test ./pkg/runtime/...` first.
 - [ ] B2 Review adapter interface for 3-runtime parity (BYO pod / AgentWorkload / kagent Agent), identical egress-seal + attestation. Confirm v1alpha2 runtimeClassName note current. skills: code-reviewer + architect-review.
 - [ ] B3 README rewrite: lead with zero-egress seal + tamper-evident in-cluster attestation artifact. Move "For VCs & Reviewers" below the fold. Add `helm install` one-liner. Keep runtime-agnostic framing; never make kagent the subject of a problem sentence. (name from A3 when ready). skill: dx-optimizer.
-- [ ] B4 Hygiene: `git rm -r --cached .serena`, add to .gitignore. Confirm videos/pptx/.DS_Store/.keys already gone.
+- [x] B4 Hygiene: already clean as of 2026-06-16. .serena/ untracked, .gitignore covers .keys/ .DS_Store .serena/. No videos/pptx/demo-day at root. (Review hygiene complaint was stale.)
 - [HUMAN] B5 Open PR for B1-B4, security-auditor quick pass, squash-merge to main, delete branch.
 - [ ] B6 After merge: file/refresh roadmap issues for social proof (search existing first). skill: docs-architect.
 
 ## Lane A — naming (blocks B3 title, repo slug, module path)
-- [ ] A1 Acronym-collision matrix + one recommendation -> naming-decision.md (shared with ACP).
+- [x] A1 Acronym-collision matrix + one recommendation -> naming-decision.md (shared with ACP). Recommend: drop ACP acronym, mark `Concord`, operator module path github.com/clawdlinux/agentic-operator.
 - [HUMAN] A2 Approve the name.
 - [ ] A3 Mechanical local rename: README, docs, badges, chart metadata. LOCAL only.
 - [HUMAN] A4 Irreversible: GitHub repo slug + Go module path (github.com/shreyansh/agentic-operator). Staged as rename-module.sh.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  gVisor isolation. Audit trails. FinOps. ACP compression. Works with any Kubernetes-native agent runtime or your own custom pods.
+  A tamper-evident attestation artifact and a zero-egress seal for every agent run. Air-gapped, verifiable offline, runtime-agnostic. Plus gVisor isolation, audit trails, and FinOps.
 </p>
 
 <p align="center">
@@ -64,6 +64,8 @@ Platform teams running AI agents on Kubernetes face the same regulated-ops quest
 Who can the agent call? Which runtime isolates it? What did it cost? What did it do? Can an auditor replay it later?
 
 NineVigil is a governance plane that answers those questions. It adds regulated controls around any agent workload.
+
+The wedge: NineVigil emits a signed, tamper-evident attestation artifact for each run and applies a zero-egress seal at the network boundary. The artifact is hash-chained and verifiable offline with `audit-verify`, so an auditor can replay what an agent did months later inside an air-gapped cluster. The same seal and attestation contract applies to a NineVigil AgentWorkload, a CNCF runtime, or your own labeled pods. This is the part most agent runtimes leave to you. NineVigil ships it in-cluster.
 
 | Capability | What NineVigil provides |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  gVisor isolation. Audit trails. FinOps. ACP compression. Works with your own runtime or a CNCF agent runtime like kagent.
+  gVisor isolation. Audit trails. FinOps. ACP compression. Works with any Kubernetes-native agent runtime or your own custom pods.
 </p>
 
 <p align="center">
@@ -59,24 +59,30 @@
 
 ## Why NineVigil?
 
-kagent (Solo.io, CNCF Sandbox) proves the base runtime layer is real. That is good for the ecosystem.
-
-NineVigil does not need to replace that layer. It adds the controls regulated teams need before agents can touch internal data.
-
-| Layer | What kagent covers | What NineVigil adds |
-|---|---|---|
-| Agent runtime | Agent CRDs, tools, model config | Compatible deployment controls |
-| Runtime isolation | Pod and service controls | gVisor `RuntimeClass` injection |
-| Context | Agent memory and compaction | ACP for MCP tool discovery compression |
-| Audit | Observability hooks | Tamper-evident audit chain |
-| Cost | Basic usage visibility | Per-workload budget and chargeback hooks |
-| Delivery | Helm and public OCI | Air-gapped install path and offline licensing |
-
-Platform teams running agents on Kubernetes still face the same regulated-ops questions.
+Platform teams running AI agents on Kubernetes face the same regulated-ops questions regardless of which agent runtime they use.
 
 Who can the agent call? Which runtime isolates it? What did it cost? What did it do? Can an auditor replay it later?
 
-**NineVigil focuses on that layer.** Use the built-in `AgentWorkload` path, or add NineVigil controls around kagent-managed pods with labels.
+NineVigil is a governance plane that answers those questions. It adds regulated controls around any agent workload.
+
+| Capability | What NineVigil provides |
+|---|---|
+| Runtime isolation | gVisor `RuntimeClass` injection for labeled pods |
+| Audit | Tamper-evident audit chain |
+| Cost | Per-workload budget and chargeback hooks |
+| Context | ACP for MCP tool discovery compression |
+| Delivery | Air-gapped install path and offline licensing |
+| Orchestration | Argo Workflows DAG orchestration |
+
+### Supported runtimes
+
+NineVigil works with any Kubernetes agent runtime:
+
+- **NineVigil AgentWorkload** (built-in CRD)
+- **CNCF agent runtimes** like kagent
+- **Custom agent pods** with the right labels
+
+The runtime handles agent lifecycle, tools, and model dispatch. NineVigil handles isolation, audit, spend, and compliance. Use both.
 
 | Problem | NineVigil |
 |---------|-----------------|
@@ -87,9 +93,9 @@ Who can the agent call? Which runtime isolates it? What did it cost? What did it
 | Vendor lock-in | Any LLM via LiteLLM proxy routing |
 | Cloud-only runtimes | Full air-gapped, offline-first deployment |
 
-### kagent-compatible runtime sandbox
+### Runtime sandbox for labeled pods
 
-kagent Agent deployments can opt into NineVigil's gVisor injector with one label:
+Any agent deployment can opt into NineVigil's gVisor injector with one label:
 
 ```yaml
 agentic.clawdlinux.org/runtime-sandbox: gvisor
@@ -101,7 +107,7 @@ The NineVigil webhook mutates matching Pods on create:
 runtimeClassName: gvisor
 ```
 
-No fork required. No custom kagent build required.
+No fork required. No custom build required. Works with any pod that carries the label.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">NineVigil</h1>
 
 <p align="center">
-  <strong>The Kubernetes runtime API that AI agents call to provision their own air-gapped execution environments.</strong>
+  <strong>Regulated controls for AI agents on Kubernetes.</strong>
 </p>
 
 <p align="center">
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  One <code>AgentWorkload</code> manifest. Air-gapped by default. Argo DAG orchestration. Per-tenant cost attribution. Zero cloud lock-in.
+  gVisor isolation. Audit trails. FinOps. ACP compression. Works with your own runtime or a CNCF agent runtime like kagent.
 </p>
 
 <p align="center">
@@ -59,28 +59,24 @@
 
 ## Why NineVigil?
 
-kagent (Solo.io, CNCF Sandbox) validates this market completely. When Google, Microsoft, IBM, and Red Hat contribute to a Kubernetes agent runtime, the category is real.
+kagent (Solo.io, CNCF Sandbox) proves the base runtime layer is real. That is good for the ecosystem.
 
-But here's what kagent **structurally cannot do**:
+NineVigil does not need to replace that layer. It adds the controls regulated teams need before agents can touch internal data.
 
-| Capability | NineVigil | kagent (Solo.io) |
-|---|:---:|:---:|
-| **Air-gapped / zero-egress deployment** | ✅ | ❌ |
-| **Outcome-based billing per workload** | ✅ OpenMeter | ❌ |
-| **Argo DAG orchestration** | ✅ | ❌ |
-| **Per-tenant cost isolation** | ✅ | ❌ |
-| **JWT offline licensing** | ✅ | ❌ |
-| Kubernetes-native operator | ✅ | ✅ |
-| OTel observability | ✅ Langfuse + OTel | ✅ |
-| RBAC / identity | ✅ Cilium + RBAC | ✅ mTLS + OIDC |
-| MCP support | ✅ | ✅ |
-| Multi-framework support | ✅ LangGraph (Python) | ✅ LangChain, CrewAI, ADK |
+| Layer | What kagent covers | What NineVigil adds |
+|---|---|---|
+| Agent runtime | Agent CRDs, tools, model config | Compatible deployment controls |
+| Runtime isolation | Pod and service controls | gVisor `RuntimeClass` injection |
+| Context | Agent memory and compaction | ACP for MCP tool discovery compression |
+| Audit | Observability hooks | Tamper-evident audit chain |
+| Cost | Basic usage visibility | Per-workload budget and chargeback hooks |
+| Delivery | Helm and public OCI | Air-gapped install path and offline licensing |
 
-> **kagent is excellent for cloud-connected teams. We are the only option for environments where data cannot leave the network — air-gapped, FedRAMP, HIPAA-constrained, and sovereign cloud.** Those buyers have no other choice.
+Platform teams running agents on Kubernetes still face the same regulated-ops questions.
 
-Platform teams running AI agents on Kubernetes today face a painful reality: each agent framework expects its own runtime, its own secrets, its own network rules. You end up with a sprawl of bespoke Deployments, no cost visibility, and no guardrails.
+Who can the agent call? Which runtime isolates it? What did it cost? What did it do? Can an auditor replay it later?
 
-**NineVigil fixes this.** One CRD, one controller, full-stack isolation:
+**NineVigil focuses on that layer.** Use the built-in `AgentWorkload` path, or add NineVigil controls around kagent-managed pods with labels.
 
 | Problem | NineVigil |
 |---------|-----------------|
@@ -90,6 +86,22 @@ Platform teams running AI agents on Kubernetes today face a painful reality: eac
 | Manual DAG wiring | Argo Workflows orchestrates agent steps |
 | Vendor lock-in | Any LLM via LiteLLM proxy routing |
 | Cloud-only runtimes | Full air-gapped, offline-first deployment |
+
+### kagent-compatible runtime sandbox
+
+kagent Agent deployments can opt into NineVigil's gVisor injector with one label:
+
+```yaml
+agentic.clawdlinux.org/runtime-sandbox: gvisor
+```
+
+The NineVigil webhook mutates matching Pods on create:
+
+```yaml
+runtimeClassName: gvisor
+```
+
+No fork required. No custom kagent build required.
 
 ---
 
@@ -226,7 +238,7 @@ Enterprise inquiries: [shreyanshsancheti09@gmail.com](mailto:shreyanshsancheti09
 
 ## Security & Sandbox
 
-NineVigil ships **default-deny egress NetworkPolicies** for every agent namespace (Helm-toggleable via `networkPolicy.enabled`, default true) and runs agent pods on a **gVigil sandbox** — [gVisor](https://gvisor.dev/) as the default user-space kernel, with [Kata Containers](https://katacontainers.io/) as opt-in for full microVM isolation. See [docs/07-security.md](docs/07-security.md) for the syscall allowlist source and the Helm toggle.
+NineVigil ships **default-deny egress NetworkPolicies** for every agent namespace (Helm-toggleable via `networkPolicy.enabled`, default true). It can also create a gVisor `RuntimeClass` and register a pod mutating webhook for labeled agent pods. See [docs/07-security.md](docs/07-security.md) for details.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,8 +41,9 @@ Issues that build generic registries, Envoy routing, sidecar buses, or broad mul
 - [ ] Webhook admission controller for CRD validation
 - [x] OPA policy library for common agent guardrails
 - [x] gVisor RuntimeClass + pod admission injector for labeled agent pods
-- [ ] kagent compatibility guide for runtime sandbox labels
-- [ ] ACP RemoteMCPServer wrapper example for kagent
+- [ ] Runtime adapter interface (AgentWorkload, external pods, CNCF runtimes)
+- [ ] Per-runtime sandbox label guide
+- [ ] ACP RemoteMCPServer wrapper example
 - [ ] Air-gapped install smoke test
 
 ## Future (Q3-Q4 2026)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,21 @@
 # Roadmap
 
-Public roadmap for the Agentic Kubernetes Operator. Updated quarterly.
+Public roadmap for NineVigil. Updated quarterly.
+
+## Scope Note
+
+kagent is becoming a strong CNCF base runtime for agents on Kubernetes.
+
+NineVigil will not compete with that layer by default. The open-source core now focuses on regulated controls around agent workloads:
+
+- gVisor runtime isolation
+- audit trails
+- FinOps attribution
+- policy and egress controls
+- air-gapped packaging
+- ACP integration for MCP context compression
+
+Issues that build generic registries, Envoy routing, sidecar buses, or broad multi-cluster runtime features should move behind validation gates. They stay valid only if a regulated deployment needs them.
 
 ## Current (Q1 2026)
 
@@ -25,18 +40,33 @@ Public roadmap for the Agentic Kubernetes Operator. Updated quarterly.
 - [x] Cost dashboard with per-workload token spend visualization
 - [ ] Webhook admission controller for CRD validation
 - [x] OPA policy library for common agent guardrails
-- [ ] Agent marketplace: community-contributed agent templates
-- [ ] Horizontal pod autoscaling based on queue depth
+- [x] gVisor RuntimeClass + pod admission injector for labeled agent pods
+- [ ] kagent compatibility guide for runtime sandbox labels
+- [ ] ACP RemoteMCPServer wrapper example for kagent
+- [ ] Air-gapped install smoke test
 
-## Future (Q3–Q4 2026)
+## Future (Q3-Q4 2026)
 
-- [ ] Multi-cluster federation (workloads span clusters)
-- [ ] GPU-aware scheduling for local model inference
+- [ ] Multi-cluster federation (validation-gated)
+- [ ] GPU-aware scheduling for local model inference (only for regulated local model deployments)
 - [ ] Agent evaluation framework (evals-as-code)
 - [ ] Managed SaaS offering (hosted control plane)
 - [ ] SOC 2 Type II compliance certification
-- [ ] Plugin SDK for custom tool integrations
-- [ ] Visual workflow builder (web UI)
+- [ ] Plugin SDK for regulated control extensions
+- [ ] Web UI for audit, spend, and sandbox state
+
+## Issues To Re-Scope
+
+These open issues are likely too close to the base runtime layer unless a design partner asks for them:
+
+- #119 Envoy ExtProc capability routing
+- #120 Gateway API InferencePool / InferenceModel integration
+- #121 Multi-cluster discovery
+- #123 NATS/Kafka sidecar injection
+- #124 Backpressure signaling
+- #97-#112 Agent registry and identity backlog
+
+Keep these as research, not committed roadmap, until they pass a customer validation gate.
 
 ## Exploring (RFC stage — not yet committed)
 

--- a/STRATEGY_positioning_runtime_agnostic.md
+++ b/STRATEGY_positioning_runtime_agnostic.md
@@ -1,0 +1,46 @@
+# Strategy: Runtime-Agnostic Positioning
+
+Status: locked, June 2026. Read this before writing any public post, README, or pitch.
+
+## The play
+
+We sell the air-gapped agent governance and attestation plane. The runtime
+underneath is a supported detail, not our identity.
+
+We do not own kagent. Solo.io does. So we are not Databricks-over-Spark.
+We are closer to Snowflake: build our own category next to the incumbent,
+stay runtime-agnostic, never tether our identity to a project we do not
+control.
+
+## Messaging guardrails
+
+- Never make kagent the subject of a problem sentence. The problems (egress,
+  audit, air-gap) are generic to K8s agent stacks. State them that way.
+
+- Never claim kagent lacks something it has. Verified facts:
+  - Multi-agent with first-class delegation. Not single-agent.
+  - ModelConfig CRD centralizes LLM creds in a Secret. Not per-agent key sprawl.
+  - agentgateway is the tool-call chokepoint. It exists.
+  - NemoClaw (Solo.io, May 2026) adds identity, policy, HITL, auditability.
+
+- Concede what kagent and NemoClaw already do. Narrow our wedge to the one thing
+  they do not ship: fully air-gapped, in-cluster, tamper-evident attestation
+  artifact plus zero-egress seal.
+
+- Mention kagent at most once in any public asset, in a "supported runtimes"
+  context. Lead with the governance plane, not a competitor name.
+
+- No fights with maintainers. We win by being better at our layer, not by being
+  loud.
+
+## Refactor mandate
+
+1. Runtime adapter interface. kagent is one implementation, not a hard dependency.
+   Cover BYO pods, AgentWorkload, and kagent Agent behind one interface. Same
+   egress-seal and attestation behavior for all three.
+
+2. Audit every README, values.yaml comment, and competitive table. Remove kagent
+   as the subject of any problem sentence.
+
+3. Keep the gVisor label injector and the v1alpha2 runtimeClassName note. Both
+   correct and real value.

--- a/agentworkload.yaml
+++ b/agentworkload.yaml
@@ -1,0 +1,16 @@
+apiVersion: agentic.clawdlinux.org/v1alpha1
+kind: AgentWorkload
+metadata:
+  name: week1-pod-gate
+  namespace: agentic-system
+  labels:
+    app.kubernetes.io/part-of: ninevigil
+    gate: week1
+spec:
+  objective: "Run the Week 1 pod creation gate."
+  workloadType: generic
+  jobId: week1-pod-gate
+  orchestration:
+    type: argo
+  targetUrls:
+    - "https://example.com"

--- a/charts/charts/agentic-operator/templates/deployment.yaml
+++ b/charts/charts/agentic-operator/templates/deployment.yaml
@@ -51,6 +51,16 @@ spec:
                   name: {{ include "agentic-operator-sub.licenseName" . }}
                   key: LICENSE_PUBLIC_KEY_B64
                   optional: true
+            {{- with .Values.global.runtimeSandbox }}
+            {{- if .enabled }}
+            - name: RUNTIME_SANDBOX_CLASS
+              value: {{ .runtimeClassName | default "gvisor" | quote }}
+            - name: RUNTIME_SANDBOX_LABEL_KEY
+              value: {{ .selectorLabelKey | default "agentic.clawdlinux.org/runtime-sandbox" | quote }}
+            - name: RUNTIME_SANDBOX_LABEL_VALUE
+              value: {{ .selectorLabelValue | default "gvisor" | quote }}
+            {{- end }}
+            {{- end }}
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}

--- a/charts/templates/cilium-fqdn-policy.yaml
+++ b/charts/templates/cilium-fqdn-policy.yaml
@@ -1,0 +1,57 @@
+{{- /*
+Cilium FQDN egress policy for managed agent pods.
+
+Toggle with `ciliumPolicy.enabled` (default false). When enabled, selected
+agent pods may reach kube-dns, the in-cluster LiteLLM service, and the FQDNs in
+`ciliumPolicy.allowedFQDNs`. The selected endpoints are otherwise in egress
+default-deny mode.
+*/ -}}
+{{- if .Values.ciliumPolicy.enabled -}}
+{{- $ns := include "agentic-operator.namespace" . -}}
+{{- $litellmPort := default 4000 (((.Values.litellm).service).port) -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "agentic-operator.fullname" . }}-fqdn-egress
+  namespace: {{ $ns }}
+  labels:
+    {{- include "agentic-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: networkpolicy
+  annotations:
+    agentic.clawdlinux.org/policy-purpose: "cilium-fqdn-egress"
+spec:
+  endpointSelector:
+    matchLabels:
+      agentic.clawdlinux.org/managed: "true"
+  egress:
+    # Allow DNS resolution through kube-dns / CoreDNS.
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"
+    # In-cluster LiteLLM gateway.
+    - toServices:
+        - k8sService:
+            namespace: {{ $ns }}
+            serviceName: {{ printf "%s-litellm" .Release.Name | trunc 63 | trimSuffix "-" }}
+      toPorts:
+        - ports:
+            - port: {{ $litellmPort | quote }}
+              protocol: TCP
+    # Approved external LLM provider endpoints.
+    - toFQDNs:
+        {{- range .Values.ciliumPolicy.allowedFQDNs }}
+        - matchName: {{ . | quote }}
+        {{- end }}
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+{{- end -}}

--- a/charts/templates/runtimeclass.yaml
+++ b/charts/templates/runtimeclass.yaml
@@ -1,0 +1,21 @@
+{{- $runtimeSandbox := .Values.global.runtimeSandbox -}}
+{{- if and $runtimeSandbox.enabled $runtimeSandbox.createRuntimeClass -}}
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: {{ $runtimeSandbox.runtimeClassName | quote }}
+  labels:
+    {{- include "agentic-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: runtime-sandbox
+  annotations:
+    agentic.clawdlinux.org/runtime-purpose: "syscall-isolation"
+handler: {{ $runtimeSandbox.handler | quote }}
+{{- with $runtimeSandbox.overhead }}
+overhead:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $runtimeSandbox.scheduling }}
+scheduling:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/templates/webhook.yaml
+++ b/charts/templates/webhook.yaml
@@ -6,6 +6,7 @@
 {{- $webhookSecretName := printf "%s-agentic-operator-webhook-tls" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- $webhookServiceName := printf "%s-webhook-service" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- $selfSignedIssuerName := printf "%s-selfsigned-issuer" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- $runtimeSandbox := .Values.global.runtimeSandbox }}
 ---
 apiVersion: v1
 kind: Service
@@ -74,6 +75,26 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 10
+  {{- if $runtimeSandbox.enabled }}
+  - name: runtimeclass-pods.agentic.clawdlinux.org
+    clientConfig:
+      service:
+        name: {{ $webhookServiceName }}
+        namespace: {{ include "agentic-operator.namespace" . }}
+        path: /mutate-v1-pod-runtimeclass
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: 5
+    objectSelector:
+      matchLabels:
+        {{ $runtimeSandbox.selectorLabelKey }}: {{ $runtimeSandbox.selectorLabelValue | quote }}
+  {{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/tests/cilium_fqdn_test.yaml
+++ b/charts/tests/cilium_fqdn_test.yaml
@@ -1,0 +1,54 @@
+# helm-unittest spec for managed agent Cilium FQDN egress policy.
+# Run with: helm unittest charts
+suite: cilium fqdn egress policy
+templates:
+  - cilium-fqdn-policy.yaml
+tests:
+  - it: renders a CiliumNetworkPolicy when ciliumPolicy.enabled=true
+    set:
+      license:
+        key: "test"
+        publicKey: "test"
+      ciliumPolicy:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: CiliumNetworkPolicy
+      - equal:
+          path: apiVersion
+          value: cilium.io/v2
+      - equal:
+          path: spec.endpointSelector.matchLabels["agentic.clawdlinux.org/managed"]
+          value: "true"
+      - equal:
+          path: spec.egress[0].toPorts[0].ports[0].port
+          value: "53"
+      - equal:
+          path: spec.egress[1].toServices[0].k8sService.serviceName
+          value: RELEASE-NAME-litellm
+      - contains:
+          path: spec.egress[2].toFQDNs
+          content:
+            matchName: api.openai.com
+      - contains:
+          path: spec.egress[2].toFQDNs
+          content:
+            matchName: api.anthropic.com
+      - contains:
+          path: spec.egress[2].toFQDNs
+          content:
+            matchName: api.mistral.ai
+
+  - it: renders nothing when ciliumPolicy.enabled=false
+    set:
+      license:
+        key: "test"
+        publicKey: "test"
+      ciliumPolicy:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/tests/runtime_sandbox_test.yaml
+++ b/charts/tests/runtime_sandbox_test.yaml
@@ -1,0 +1,140 @@
+# helm-unittest spec for the regulated runtime sandbox addon.
+# Run with: helm unittest charts
+suite: regulated runtime sandbox
+templates:
+  - runtimeclass.yaml
+  - webhook.yaml
+  - charts/agentic-operator/templates/deployment.yaml
+tests:
+  - it: renders a gVisor RuntimeClass when runtimeSandbox.createRuntimeClass=true
+    set:
+      license:
+        key: "test"
+        publicKey: "test"
+      global:
+        runtimeSandbox:
+          enabled: true
+          createRuntimeClass: true
+          runtimeClassName: gvisor
+          handler: runsc
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: runtimeclass.yaml
+      - equal:
+          path: kind
+          value: RuntimeClass
+        template: runtimeclass.yaml
+      - equal:
+          path: metadata.name
+          value: gvisor
+        template: runtimeclass.yaml
+      - equal:
+          path: handler
+          value: runsc
+        template: runtimeclass.yaml
+
+  - it: adds a pod mutating webhook scoped to runtime sandbox labels
+    set:
+      license:
+        key: "test"
+        publicKey: "test"
+      agenticOperator:
+        webhook:
+          enabled: true
+      global:
+        runtimeSandbox:
+          enabled: true
+          runtimeClassName: gvisor
+          selectorLabelKey: agentic.clawdlinux.org/runtime-sandbox
+          selectorLabelValue: gvisor
+    asserts:
+      - documentIndex: 2
+        equal:
+          path: kind
+          value: MutatingWebhookConfiguration
+        template: webhook.yaml
+      - documentIndex: 2
+        equal:
+          path: apiVersion
+          value: admissionregistration.k8s.io/v1
+        template: webhook.yaml
+      - documentIndex: 2
+        equal:
+          path: webhooks[1].name
+          value: runtimeclass-pods.agentic.clawdlinux.org
+        template: webhook.yaml
+      - documentIndex: 2
+        equal:
+          path: webhooks[1].clientConfig.service.path
+          value: /mutate-v1-pod-runtimeclass
+        template: webhook.yaml
+      - documentIndex: 2
+        equal:
+          path: webhooks[1].objectSelector.matchLabels["agentic.clawdlinux.org/runtime-sandbox"]
+          value: gvisor
+        template: webhook.yaml
+
+  - it: propagates runtime sandbox values into the operator webhook environment
+    set:
+      license:
+        key: "test"
+        publicKey: "test"
+      global:
+        runtimeSandbox:
+          enabled: true
+          runtimeClassName: kata
+          selectorLabelKey: agentic.clawdlinux.org/runtime-sandbox
+          selectorLabelValue: kata
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_SANDBOX_CLASS
+            value: kata
+        template: charts/agentic-operator/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_SANDBOX_LABEL_KEY
+            value: agentic.clawdlinux.org/runtime-sandbox
+        template: charts/agentic-operator/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_SANDBOX_LABEL_VALUE
+            value: kata
+        template: charts/agentic-operator/templates/deployment.yaml
+
+  - it: uses the same custom selector value in webhook and operator env
+    set:
+      license:
+        key: "test"
+        publicKey: "test"
+      agenticOperator:
+        webhook:
+          enabled: true
+      global:
+        runtimeSandbox:
+          enabled: true
+          runtimeClassName: kata
+          selectorLabelKey: regulated.agentic.dev/sandbox
+          selectorLabelValue: strict
+    asserts:
+      - documentIndex: 2
+        equal:
+          path: webhooks[1].objectSelector.matchLabels["regulated.agentic.dev/sandbox"]
+          value: strict
+        template: webhook.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_SANDBOX_LABEL_KEY
+            value: regulated.agentic.dev/sandbox
+        template: charts/agentic-operator/templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNTIME_SANDBOX_LABEL_VALUE
+            value: strict
+        template: charts/agentic-operator/templates/deployment.yaml

--- a/charts/values.schema.json
+++ b/charts/values.schema.json
@@ -26,7 +26,8 @@
           }
         },
         "storageClass": { "type": "string" },
-        "namespace": { "type": "string" }
+        "namespace": { "type": "string" },
+        "runtimeSandbox": { "$ref": "#/$defs/runtimeSandbox" }
       }
     },
     "license": {
@@ -291,6 +292,20 @@
         "enabled": { "type": "boolean" },
         "size": { "type": "string" },
         "storageClass": { "type": "string" }
+      }
+    },
+    "runtimeSandbox": {
+      "type": "object",
+      "description": "RuntimeClass injection for regulated agent pods, including kagent-compatible label selection.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "createRuntimeClass": { "type": "boolean" },
+        "runtimeClassName": { "type": "string", "minLength": 1 },
+        "handler": { "type": "string", "minLength": 1 },
+        "selectorLabelKey": { "type": "string", "minLength": 1 },
+        "selectorLabelValue": { "type": "string", "minLength": 1 },
+        "overhead": { "type": "object" },
+        "scheduling": { "type": "object" }
       }
     }
   }

--- a/charts/values.schema.json
+++ b/charts/values.schema.json
@@ -307,7 +307,7 @@
     },
     "runtimeSandbox": {
       "type": "object",
-      "description": "RuntimeClass injection for regulated agent pods, including kagent-compatible label selection.",
+      "description": "RuntimeClass injection for labeled agent pods. Works with any Kubernetes agent runtime.",
       "properties": {
         "enabled": { "type": "boolean" },
         "createRuntimeClass": { "type": "boolean" },

--- a/charts/values.schema.json
+++ b/charts/values.schema.json
@@ -204,6 +204,17 @@
         }
       }
     },
+    "ciliumPolicy": {
+      "type": "object",
+      "description": "Optional CiliumNetworkPolicy FQDN egress allow-list for managed agent pods.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "allowedFQDNs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "ingress": {
       "type": "object",
       "properties": {

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -20,6 +20,27 @@ global:
   imagePullSecrets: []
   storageClass: ""           # Default StorageClass for PVCs
   namespace: agentic-system  # Target namespace (also rendered by namespace.yaml)
+  # Runtime sandbox (gVisor RuntimeClass injection)
+  #
+  # kagent v1alpha2 exposes labels, securityContext, env, sidecars, and volumes
+  # on Agent deployment specs, but not pod.spec.runtimeClassName. This addon lets
+  # a kagent Agent opt into gVisor by adding this label under
+  # spec.declarative.deployment.labels or spec.byo.deployment.labels:
+  #
+  #   agentic.clawdlinux.org/runtime-sandbox: gvisor
+  #
+  # The operator webhook mutates matching Pods on CREATE and sets
+  # runtimeClassName: gvisor unless the Pod already set a runtimeClassName.
+  # Nodes must already have gVisor/runsc installed.
+  runtimeSandbox:
+    enabled: true
+    createRuntimeClass: true
+    runtimeClassName: gvisor
+    handler: runsc
+    selectorLabelKey: agentic.clawdlinux.org/runtime-sandbox
+    selectorLabelValue: gvisor
+    overhead: {}
+    scheduling: {}
 
 # ---------------------------------------------------------------------------
 # License (REQUIRED)

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -22,10 +22,12 @@ global:
   namespace: agentic-system  # Target namespace (also rendered by namespace.yaml)
   # Runtime sandbox (gVisor RuntimeClass injection)
   #
-  # kagent v1alpha2 exposes labels, securityContext, env, sidecars, and volumes
-  # on Agent deployment specs, but not pod.spec.runtimeClassName. This addon lets
-  # a kagent Agent opt into gVisor by adding this label under
-  # spec.declarative.deployment.labels or spec.byo.deployment.labels:
+  # This feature injects the gVisor RuntimeClass into agent workload pods.
+  # It applies to any pod carrying the opt-in label, regardless of which
+  # agent runtime created it (NineVigil AgentWorkload, external runtimes,
+  # or custom pods).
+  #
+  # Add this label to a pod spec to opt in:
   #
   #   agentic.clawdlinux.org/runtime-sandbox: gvisor
   #

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -384,6 +384,17 @@ networkPolicy:
     fqdnAllowlist: []
 
 # ---------------------------------------------------------------------------
+# Cilium FQDN egress policy for managed agent pods.
+# Disabled by default because it requires the CiliumNetworkPolicy CRD.
+# ---------------------------------------------------------------------------
+ciliumPolicy:
+  enabled: false
+  allowedFQDNs:
+    - api.openai.com
+    - api.anthropic.com
+    - api.mistral.ai
+
+# ---------------------------------------------------------------------------
 # Clawdlinux Observability (clawd-observability subchart)
 #
 # Bundles OTel Collector + Tempo + Prometheus + Grafana + ClickHouse + Qdrant

--- a/cmd/agentctl-web/demo_test.go
+++ b/cmd/agentctl-web/demo_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleDemoRendersBoothStory(t *testing.T) {
+	server, err := NewServer(nil, nil, TemplatesFS())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/demo", nil)
+	res := httptest.NewRecorder()
+
+	server.handleDemo(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusOK)
+	}
+
+	body := res.Body.String()
+	for _, want := range []string{
+		"Secure Research Swarm",
+		"Policy Gate",
+		"Cost Attribution",
+		"Audit Proof",
+		"Run demo",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("demo body missing %q", want)
+		}
+	}
+}

--- a/cmd/agentctl-web/demo_test.go
+++ b/cmd/agentctl-web/demo_test.go
@@ -5,6 +5,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/shreyansh/agentic-operator/pkg/agentctl"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestHandleDemoRendersBoothStory(t *testing.T) {
@@ -29,9 +34,70 @@ func TestHandleDemoRendersBoothStory(t *testing.T) {
 		"Cost Attribution",
 		"Audit Proof",
 		"Run demo",
+		"every 5s",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("demo body missing %q", want)
 		}
 	}
+}
+
+func TestHandleDemoRendersLiveRuntimePods(t *testing.T) {
+	client := &agentctl.Client{
+		Kube: fake.NewClientset(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secure-research-swarm-runner",
+				Namespace: "argo-workflows",
+				Labels: map[string]string{
+					"agentic.io/job-id":         "secure-research-swarm",
+					agentctl.RoleLabelKey:       "researcher",
+					"app.kubernetes.io/part-of": "ninevigil",
+				},
+			},
+			Spec: corev1.PodSpec{
+				RuntimeClassName: stringPtr("gvisor"),
+				Containers: []corev1.Container{{
+					Name:  "agent",
+					Image: "ghcr.io/clawdlinux/research-agent:v0.2.0",
+				}},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		}),
+	}
+
+	server, err := NewServer(client, nil, TemplatesFS())
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/demo", nil)
+	res := httptest.NewRecorder()
+
+	server.handleDemo(res, req)
+
+	body := res.Body.String()
+	for _, want := range []string{
+		"Live cluster",
+		"Runtime pods",
+		"secure-research-swarm-runner",
+		"gvisor",
+		"ghcr.io/clawdlinux/research-agent:v0.2.0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("demo body missing %q", want)
+		}
+	}
+
+	controlPlaneIndex := strings.Index(body, "Live control plane")
+	heroIndex := strings.Index(body, "Run governed AI agents inside your cluster")
+	if controlPlaneIndex == -1 || heroIndex == -1 {
+		t.Fatalf("expected live control plane and hero content")
+	}
+	if controlPlaneIndex > heroIndex {
+		t.Fatalf("live control plane should appear before hero in cluster-connected demo")
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/cmd/agentctl-web/handlers.go
+++ b/cmd/agentctl-web/handlers.go
@@ -74,6 +74,21 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (s *Server) handleDemo(w http.ResponseWriter, r *http.Request) {
+	data := map[string]interface{}{
+		"CSRFToken": "demo",
+		"Demo":      true,
+		"User": &UserInfo{
+			Username: "booth-demo",
+		},
+	}
+
+	if err := s.tmpl.ExecuteTemplate(w, "demo.html", data); err != nil {
+		slog.Error("render demo", "error", err)
+		http.Error(w, "Failed to render demo", http.StatusInternalServerError)
+	}
+}
+
 func (s *Server) handleWorkloads(w http.ResponseWriter, r *http.Request) {
 	csrfToken, _ := r.Context().Value(csrfContextKey).(string)
 

--- a/cmd/agentctl-web/handlers.go
+++ b/cmd/agentctl-web/handlers.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"html/template"
 	"io/fs"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/shreyansh/agentic-operator/pkg/agentctl"
 )
@@ -75,9 +77,43 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDemo(w http.ResponseWriter, r *http.Request) {
+	runtimePods := []agentctl.RuntimePodRow{}
+	workloads := []agentctl.WorkloadRow{}
+	var status *agentctl.StatusSummary
+	live := false
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+
+	if s.client != nil {
+		if s.client.Kube != nil {
+			if rows, err := s.client.ListRuntimePods(ctx, ""); err == nil {
+				runtimePods = rows
+				live = true
+			}
+		}
+
+		if s.client.Dynamic != nil {
+			if rows, err := s.client.ListWorkloads(ctx, ""); err == nil {
+				workloads = rows
+				live = true
+			}
+		}
+
+		if s.client.Kube != nil && s.client.Dynamic != nil && s.client.Discovery != nil {
+			if summary, err := s.client.ClusterStatus(ctx, ""); err == nil {
+				status = summary
+				live = true
+			}
+		}
+	}
+
 	data := map[string]interface{}{
-		"CSRFToken": "demo",
-		"Demo":      true,
+		"CSRFToken":   "demo",
+		"Demo":        true,
+		"Live":        live,
+		"RuntimePods": runtimePods,
+		"Workloads":   workloads,
+		"Status":      status,
 		"User": &UserInfo{
 			Username: "booth-demo",
 		},

--- a/cmd/agentctl-web/main.go
+++ b/cmd/agentctl-web/main.go
@@ -23,15 +23,36 @@ func main() {
 	var (
 		addr       string
 		kubeconfig string
+		demoMode   bool
 	)
 	flag.StringVar(&addr, "addr", ":8090", "HTTP listen address")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (empty = in-cluster)")
+	flag.BoolVar(&demoMode, "demo", false, "Run the booth demo UI without Kubernetes")
 	flag.Parse()
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
 	slog.Info("starting agentctl-web", "version", version, "addr", addr)
+
+	if demoMode {
+		srv, err := NewServer(nil, nil, TemplatesFS())
+		if err != nil {
+			slog.Error("failed to create demo server", "error", err)
+			os.Exit(1)
+		}
+
+		mux := http.NewServeMux()
+		mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(StaticFS()))))
+		mux.HandleFunc("GET /healthz", handleHealthz)
+		mux.HandleFunc("GET /readyz", handleHealthz)
+		mux.HandleFunc("GET /", srv.handleDemo)
+		mux.HandleFunc("GET /{$}", srv.handleDemo)
+		mux.HandleFunc("GET /demo", srv.handleDemo)
+
+		runHTTPServer(addr, RequestIDMiddleware(AuditMiddleware(mux)))
+		return
+	}
 
 	// Build K8s config
 	var cfg *rest.Config
@@ -88,6 +109,7 @@ func main() {
 	// Dashboard
 	mux.HandleFunc("GET /", srv.handleDashboard)
 	mux.HandleFunc("GET /{$}", srv.handleDashboard)
+	mux.HandleFunc("GET /demo", srv.handleDemo)
 
 	// Workloads
 	mux.HandleFunc("GET /workloads", srv.handleWorkloads)
@@ -106,6 +128,10 @@ func main() {
 	handler = AuditMiddleware(handler)
 	handler = RequestIDMiddleware(handler)
 
+	runHTTPServer(addr, handler)
+}
+
+func runHTTPServer(addr string, handler http.Handler) {
 	httpServer := &http.Server{
 		Addr:              addr,
 		Handler:           handler,

--- a/cmd/agentctl-web/main.go
+++ b/cmd/agentctl-web/main.go
@@ -36,7 +36,25 @@ func main() {
 	slog.Info("starting agentctl-web", "version", version, "addr", addr)
 
 	if demoMode {
-		srv, err := NewServer(nil, nil, TemplatesFS())
+		var demoClient *agentctl.Client
+		demoKubeconfig := kubeconfig
+		if demoKubeconfig == "" {
+			if _, err := os.Stat(clientcmd.RecommendedHomeFile); err == nil {
+				demoKubeconfig = clientcmd.RecommendedHomeFile
+			}
+		}
+		if demoKubeconfig != "" {
+			cfg, err := clientcmd.BuildConfigFromFlags("", demoKubeconfig)
+			if err != nil {
+				slog.Warn("demo mode running without cluster", "error", err)
+			} else if client, err := agentctl.NewClient(cfg); err != nil {
+				slog.Warn("demo mode failed to create cluster client", "error", err)
+			} else {
+				demoClient = client
+			}
+		}
+
+		srv, err := NewServer(demoClient, nil, TemplatesFS())
 		if err != nil {
 			slog.Error("failed to create demo server", "error", err)
 			os.Exit(1)

--- a/cmd/agentctl-web/middleware.go
+++ b/cmd/agentctl-web/middleware.go
@@ -58,7 +58,7 @@ func AuthMiddleware(authn *TokenAuthenticator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Skip auth for login, healthz, and static
-			if r.URL.Path == "/auth/login" || r.URL.Path == "/healthz" || r.URL.Path == "/readyz" ||
+			if r.URL.Path == "/auth/login" || r.URL.Path == "/demo" || r.URL.Path == "/healthz" || r.URL.Path == "/readyz" ||
 				r.URL.Path == "/static/" || hasPrefix(r.URL.Path, "/static/") {
 				next.ServeHTTP(w, r)
 				return

--- a/cmd/agentctl-web/static/style.css
+++ b/cmd/agentctl-web/static/style.css
@@ -432,6 +432,17 @@ body::before {
 .demo-step-card p { color: var(--text-muted); font-size: 0.9rem; }
 .agent-stage,
 .proof-panel { padding: 1.1rem; margin-bottom: 1rem; }
+.live-panel {
+    margin-top: 0.7rem;
+}
+.live-panel .stage-header {
+    margin-bottom: 0.85rem;
+}
+.live-panel .data-table th,
+.live-panel .data-table td {
+    padding: 0.48rem 0.58rem;
+    font-size: 0.78rem;
+}
 .stage-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.2rem; }
 .cost-ticker {
     font-family: "SF Mono", "Fira Code", monospace;
@@ -456,6 +467,87 @@ body::before {
 .agent-node span { color: var(--accent); font-size: 0.8rem; font-weight: 700; }
 .agent-link { height: 2px; background: linear-gradient(90deg, rgba(0, 212, 170, 0.2), var(--accent)); }
 .proof-panel h2 { margin: 0.4rem 0 1rem; }
+.proof-panel h3 { margin: 0 0 0.7rem; font-size: 0.95rem; color: var(--text-muted); }
+.live-columns { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(0, 0.9fr); gap: 1rem; }
+.runtime-row-list,
+.workload-card-list {
+    display: grid;
+    gap: 0.75rem;
+}
+.runtime-row,
+.workload-card {
+    min-width: 0;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.68);
+    padding: 0.72rem 0.8rem;
+}
+.runtime-row,
+.runtime-row-main,
+.workload-card,
+.workload-card-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+}
+.runtime-row,
+.workload-card {
+    justify-content: space-between;
+}
+.runtime-row-main {
+    min-width: 0;
+}
+.runtime-row-main > div {
+    min-width: 0;
+}
+.runtime-row h4,
+.workload-card h4 {
+    overflow-wrap: anywhere;
+    font-size: 0.94rem;
+    line-height: 1.25;
+}
+.runtime-row p,
+.workload-card p {
+    color: var(--text-muted);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+.runtime-row-meta,
+.workload-card-meta {
+    overflow-wrap: anywhere;
+    color: var(--text);
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.78rem;
+}
+.runtime-row-meta {
+    flex: 0 0 auto;
+    justify-content: flex-end;
+    max-width: 48%;
+}
+.runtime-row-meta span {
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 6px;
+    padding: 0.22rem 0.42rem;
+    white-space: nowrap;
+}
+.runtime-row-meta span:nth-child(2) {
+    color: var(--accent);
+}
+.workload-card > div:first-child {
+    min-width: 0;
+}
+.workload-card-meta {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+}
+.empty-live-state {
+    color: var(--text-muted);
+    border: 1px dashed rgba(148, 163, 184, 0.24);
+    border-radius: 8px;
+    padding: 0.9rem;
+}
 .demo-table th,
 .demo-table td {
     white-space: nowrap;
@@ -491,4 +583,9 @@ body::before {
     .demo-grid { grid-template-columns: 1fr; }
     .agent-graph { grid-template-columns: 1fr; }
     .agent-link { height: 32px; width: 2px; margin: 0 auto; }
+    .live-columns { grid-template-columns: 1fr; }
+    .runtime-row { align-items: flex-start; flex-direction: column; }
+    .runtime-row-meta { justify-content: flex-start; max-width: none; flex-wrap: wrap; }
+    .workload-card { align-items: flex-start; flex-direction: column; }
+    .workload-card-meta { justify-content: flex-start; }
 }

--- a/cmd/agentctl-web/static/style.css
+++ b/cmd/agentctl-web/static/style.css
@@ -1,8 +1,11 @@
-/* agentctl-web — minimal UI styles */
+/* agentctl-web demo cockpit styles */
 :root {
     --brand: #3B82F6;
     --brand-dark: #2563EB;
+    --accent: #00d4aa;
+    --accent-dim: rgba(0, 212, 170, 0.16);
     --bg: #0f172a;
+    --bg-deep: #070b14;
     --bg-card: #1e293b;
     --bg-input: #334155;
     --text: #e2e8f0;
@@ -18,11 +21,23 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-family: "Aptos", "Segoe UI", sans-serif;
     background: var(--bg);
     color: var(--text);
     line-height: 1.6;
     min-height: 100vh;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background:
+        linear-gradient(rgba(255,255,255,0.025) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.025) 1px, transparent 1px);
+    background-size: 42px 42px;
+    mask-image: linear-gradient(to bottom, rgba(0,0,0,0.7), transparent 72%);
 }
 
 /* Navbar */
@@ -30,7 +45,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.75rem 1.5rem;
+    padding: 0.7rem 1.5rem;
     background: var(--bg-card);
     border-bottom: 1px solid var(--border);
     position: sticky;
@@ -42,9 +57,35 @@ body {
     align-items: center;
     gap: 0.5rem;
     font-weight: 700;
-    font-size: 1.1rem;
+    font-size: 1.05rem;
 }
 .logo { font-size: 1.4rem; }
+.demo-navbar .logo {
+    display: inline-grid;
+    place-items: center;
+    width: 1.95rem;
+    height: 1.95rem;
+    border: 1px solid rgba(0, 212, 170, 0.45);
+    border-radius: 7px;
+    color: var(--accent);
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.78rem;
+    letter-spacing: 0;
+}
+.demo-nav-proof {
+    display: flex;
+    gap: 0.55rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+.demo-pill {
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    border-radius: 999px;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.28rem 0.6rem;
+}
 .nav-links {
     display: flex;
     gap: 1.5rem;
@@ -68,9 +109,9 @@ body {
 
 /* Container */
 .container {
-    max-width: 1200px;
+    max-width: 1320px;
     margin: 0 auto;
-    padding: 1.5rem;
+    padding: 1.2rem 1.5rem;
 }
 
 /* Buttons */
@@ -320,11 +361,134 @@ body {
     margin-top: 3rem;
 }
 
+/* Booth demo */
+.demo-shell {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(320px, 0.7fr);
+    gap: 1.25rem;
+    align-items: stretch;
+    margin: 0.7rem 0 1rem;
+}
+
+.demo-hero,
+.demo-control-card,
+.demo-step-card,
+.agent-stage,
+.proof-panel {
+    background: linear-gradient(145deg, rgba(30, 41, 59, 0.92), rgba(7, 11, 20, 0.96));
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 8px;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+}
+
+.demo-hero { padding: 1.55rem; min-height: 270px; }
+.demo-kicker,
+.demo-label {
+    color: var(--accent);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+.demo-hero h1 {
+    max-width: 760px;
+    margin: 0.55rem 0 0.8rem;
+    font-size: clamp(2.15rem, 4.4vw, 4.2rem);
+    line-height: 0.98;
+    letter-spacing: 0;
+}
+.demo-copy { max-width: 680px; color: var(--text-muted); font-size: 1rem; }
+.demo-actions { display: flex; gap: 0.75rem; margin-top: 1.1rem; flex-wrap: wrap; }
+.btn-demo { min-height: 44px; }
+.demo-control-card { padding: 1.15rem; display: flex; flex-direction: column; justify-content: space-between; }
+.demo-control-card h2 { margin: 0.55rem 0; font-size: 1.35rem; }
+.demo-control-card p { color: var(--text-muted); }
+.demo-status-line {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--accent);
+    font-weight: 700;
+    margin-top: 1.2rem;
+}
+.pulse-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 0 0 rgba(0, 212, 170, 0.58);
+    animation: pulse-ring 1.8s infinite;
+}
+.demo-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+.demo-step-card { padding: 0.9rem; min-height: 142px; }
+.demo-step-card.is-active { border-color: rgba(0, 212, 170, 0.74); }
+.step-index { color: var(--accent); font-family: "SF Mono", "Fira Code", monospace; font-weight: 800; }
+.demo-step-card h3 { margin: 0.8rem 0 0.45rem; }
+.demo-step-card p { color: var(--text-muted); font-size: 0.9rem; }
+.agent-stage,
+.proof-panel { padding: 1.1rem; margin-bottom: 1rem; }
+.stage-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.2rem; }
+.cost-ticker {
+    font-family: "SF Mono", "Fira Code", monospace;
+    color: var(--accent);
+    background: var(--accent-dim);
+    border: 1px solid rgba(0, 212, 170, 0.45);
+    border-radius: 6px;
+    padding: 0.45rem 0.7rem;
+    font-weight: 800;
+}
+.agent-graph { display: grid; grid-template-columns: 1fr 48px 1fr 48px 1fr 48px 1fr; align-items: center; gap: 0.4rem; }
+.agent-node {
+    min-height: 96px;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    border-radius: 8px;
+    background: rgba(15, 23, 42, 0.72);
+    font-weight: 800;
+}
+.agent-node span { color: var(--accent); font-size: 0.8rem; font-weight: 700; }
+.agent-link { height: 2px; background: linear-gradient(90deg, rgba(0, 212, 170, 0.2), var(--accent)); }
+.proof-panel h2 { margin: 0.4rem 0 1rem; }
+.demo-table th,
+.demo-table td {
+    white-space: nowrap;
+}
+.demo-table td {
+    font-family: "SF Mono", "Fira Code", monospace;
+}
+.demo-table td:nth-child(2) {
+    white-space: normal;
+    max-width: 420px;
+}
+.demo-table td:nth-child(4),
+.demo-table td:nth-child(5) {
+    min-width: 128px;
+}
+
+@keyframes pulse-ring {
+    0% { box-shadow: 0 0 0 0 rgba(0, 212, 170, 0.58); }
+    70% { box-shadow: 0 0 0 12px rgba(0, 212, 170, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(0, 212, 170, 0); }
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .navbar { flex-wrap: wrap; gap: 0.5rem; }
+    .demo-navbar { align-items: flex-start; }
+    .demo-nav-proof { justify-content: flex-start; width: 100%; }
     .nav-links { gap: 1rem; }
     .status-cards { grid-template-columns: repeat(2, 1fr); }
     .data-table { font-size: 0.8rem; }
     .data-table th, .data-table td { padding: 0.5rem; }
+    .demo-shell { grid-template-columns: 1fr; }
+    .demo-grid { grid-template-columns: 1fr; }
+    .agent-graph { grid-template-columns: 1fr; }
+    .agent-link { height: 32px; width: 2px; margin: 0 auto; }
 }

--- a/cmd/agentctl-web/templates/demo.html
+++ b/cmd/agentctl-web/templates/demo.html
@@ -1,0 +1,105 @@
+{{template "layout.html" .}}
+{{define "title"}}Demo{{end}}
+{{define "content"}}
+<section class="demo-shell" aria-labelledby="demo-title">
+    <div class="demo-hero">
+        <div class="demo-kicker">Investor demo path</div>
+        <h1 id="demo-title">Run governed AI agents inside your cluster.</h1>
+        <p class="demo-copy">NineVigil is an open-source agent runtime for Kubernetes. It runs agent workloads where the data already lives, with policy, cost, and audit proof built in.</p>
+        <div class="demo-actions">
+            <a class="btn btn-primary btn-demo" href="#run-sequence">Run demo</a>
+            <a class="btn btn-secondary btn-demo" href="#audit-proof">View Audit Proof</a>
+        </div>
+    </div>
+
+    <aside class="demo-control-card" aria-label="Demo workload summary">
+        <span class="demo-label">Default workload</span>
+        <h2>Secure Research Swarm</h2>
+        <p>Fintech research task. 3 agents. Strict policy. No external data egress.</p>
+        <div class="demo-status-line"><span class="pulse-dot"></span> AgentWorkload running</div>
+    </aside>
+</section>
+
+<section id="run-sequence" class="demo-grid" aria-label="Guided demo sequence">
+    <article class="demo-step-card is-active">
+        <span class="step-index">01</span>
+        <h3>Choose workload</h3>
+        <p>Secure Research Swarm asks which enterprise AI workflows need on-prem agent execution.</p>
+    </article>
+    <article class="demo-step-card">
+        <span class="step-index">02</span>
+        <h3>Policy Gate</h3>
+        <p>OPA checks tool scope, target domains, confidence, and data boundary before agents run.</p>
+    </article>
+    <article class="demo-step-card">
+        <span class="step-index">03</span>
+        <h3>Cost Attribution</h3>
+        <p>LiteLLM routing tracks prompt tokens, output tokens, model, and per-run estimated cost.</p>
+    </article>
+    <article class="demo-step-card">
+        <span class="step-index">04</span>
+        <h3>Audit Proof</h3>
+        <p>Each action is tied to workload UID, policy result, timestamp, model call, and final report.</p>
+    </article>
+</section>
+
+<section class="agent-stage" aria-label="Live agent graph">
+    <div class="stage-header">
+        <div>
+            <span class="demo-label">Live run</span>
+            <h2>Agent graph</h2>
+        </div>
+        <div class="cost-ticker">$0.0142</div>
+    </div>
+    <div class="agent-graph">
+        <div class="agent-node node-source">Researcher<br><span>running</span></div>
+        <div class="agent-link"></div>
+        <div class="agent-node node-policy">Policy Gate<br><span>allowed</span></div>
+        <div class="agent-link"></div>
+        <div class="agent-node node-cost">FinOps<br><span>$0.0142</span></div>
+        <div class="agent-link"></div>
+        <div class="agent-node node-report">Report<br><span>ready</span></div>
+    </div>
+</section>
+
+<section id="audit-proof" class="proof-panel" aria-label="Audit proof table">
+    <div>
+        <span class="demo-label">Compliance path</span>
+        <h2>Audit trail</h2>
+    </div>
+    <table class="data-table demo-table">
+        <thead>
+            <tr>
+                <th>Time</th>
+                <th>Event</th>
+                <th>Policy</th>
+                <th>Model</th>
+                <th>Cost</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>00:02</td>
+                <td>AgentWorkload accepted</td>
+                <td><span class="badge badge-running">strict</span></td>
+                <td>gpt-4o-mini</td>
+                <td>$0.0000</td>
+            </tr>
+            <tr>
+                <td>00:08</td>
+                <td>Tool scope evaluated</td>
+                <td><span class="badge badge-completed">allowed</span></td>
+                <td>local policy</td>
+                <td>$0.0000</td>
+            </tr>
+            <tr>
+                <td>00:31</td>
+                <td>Research synthesis complete</td>
+                <td><span class="badge badge-completed">passed</span></td>
+                <td>gpt-4o-mini</td>
+                <td>$0.0142</td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+{{end}}

--- a/cmd/agentctl-web/templates/demo.html
+++ b/cmd/agentctl-web/templates/demo.html
@@ -89,7 +89,7 @@
     <article class="demo-step-card is-active">
         <span class="step-index">01</span>
         <h3>Choose workload</h3>
-        <p>Secure Research Swarm asks which enterprise AI workflows need on-prem agent execution.</p>
+        <p>Secure Research Swarm asks which regulated AI workflows need on-prem agent execution.</p>
     </article>
     <article class="demo-step-card">
         <span class="step-index">02</span>

--- a/cmd/agentctl-web/templates/demo.html
+++ b/cmd/agentctl-web/templates/demo.html
@@ -1,9 +1,68 @@
 {{template "layout.html" .}}
 {{define "title"}}Demo{{end}}
 {{define "content"}}
+{{if .Live}}
+<section class="proof-panel live-panel" aria-label="Live control plane state">
+    <div class="stage-header">
+        <div>
+            <span class="demo-label">Cluster interaction</span>
+            <h2>Live control plane</h2>
+        </div>
+        {{if .Status}}<div class="cost-ticker">{{fmtCost .Status.TotalCostToday}}</div>{{end}}
+    </div>
+    <div class="live-columns">
+        <div>
+            <h3>Runtime pods</h3>
+            <div class="runtime-row-list">
+                {{range .RuntimePods}}
+                <article class="runtime-row">
+                    <div class="runtime-row-main">
+                        <span class="badge badge-{{lower .Phase}}">{{.Phase}}</span>
+                        <div>
+                            <h4>{{.Name}}</h4>
+                            <p>{{.Namespace}} · {{.Workload}}</p>
+                        </div>
+                    </div>
+                    <div class="runtime-row-meta">
+                        <span>{{.Role}}</span>
+                        <span>{{.RuntimeClass}}</span>
+                        <span>{{.Image}}</span>
+                    </div>
+                </article>
+                {{end}}
+                {{if not .RuntimePods}}
+                <p class="empty-live-state">Apply an AgentWorkload from the terminal to see runtime pods here.</p>
+                {{end}}
+            </div>
+        </div>
+        <div>
+            <h3>AgentWorkloads</h3>
+            <div class="workload-card-list">
+                {{range .Workloads}}
+                <article class="workload-card">
+                    <div>
+                        <h4>{{.Name}}</h4>
+                        <p>{{.Namespace}}</p>
+                    </div>
+                    <div class="workload-card-meta">
+                        <span class="badge badge-{{lower (safeText .Status "unknown")}}">{{safeText .Status "Unknown"}}</span>
+                        <span>{{safeText .Model "n/a"}}</span>
+                        <strong>{{fmtCost .CostToday}}</strong>
+                    </div>
+                </article>
+                {{end}}
+                {{if not .Workloads}}
+                <p class="empty-live-state">No AgentWorkloads found yet.</p>
+                {{end}}
+            </div>
+        </div>
+    </div>
+</section>
+{{end}}
+
 <section class="demo-shell" aria-labelledby="demo-title">
     <div class="demo-hero">
-        <div class="demo-kicker">Investor demo path</div>
+        <div class="demo-kicker">{{if .Live}}Live cluster{{else}}Investor demo path{{end}}</div>
         <h1 id="demo-title">Run governed AI agents inside your cluster.</h1>
         <p class="demo-copy">NineVigil is an open-source agent runtime for Kubernetes. It runs agent workloads where the data already lives, with policy, cost, and audit proof built in.</p>
         <div class="demo-actions">
@@ -13,10 +72,16 @@
     </div>
 
     <aside class="demo-control-card" aria-label="Demo workload summary">
-        <span class="demo-label">Default workload</span>
+        <span class="demo-label">{{if .Live}}Control plane{{else}}Default workload{{end}}</span>
+        {{if .Live}}
+        <h2>{{len .RuntimePods}} runtime pods</h2>
+        <p>{{len .Workloads}} AgentWorkloads observed. Runtime, policy, and cost are read from the cluster.</p>
+        <div class="demo-status-line"><span class="pulse-dot"></span> Watching Kubernetes</div>
+        {{else}}
         <h2>Secure Research Swarm</h2>
         <p>Fintech research task. 3 agents. Strict policy. No external data egress.</p>
         <div class="demo-status-line"><span class="pulse-dot"></span> AgentWorkload running</div>
+        {{end}}
     </aside>
 </section>
 

--- a/cmd/agentctl-web/templates/layout.html
+++ b/cmd/agentctl-web/templates/layout.html
@@ -9,6 +9,19 @@
     <meta name="csrf-token" content="{{.CSRFToken}}">
 </head>
 <body>
+    {{if .Demo}}
+    <nav class="navbar demo-navbar">
+        <div class="nav-brand">
+            <span class="logo">NV</span>
+            <span class="brand-text">NineVigil</span>
+        </div>
+        <div class="demo-nav-proof">
+            <span class="demo-pill">Kubernetes runtime</span>
+            <span class="demo-pill">Policy gated</span>
+            <span class="demo-pill">Audit ready</span>
+        </div>
+    </nav>
+    {{else}}
     <nav class="navbar">
         <div class="nav-brand">
             <span class="logo">⚙</span>
@@ -30,6 +43,7 @@
             {{end}}
         </div>
     </nav>
+    {{end}}
     <main class="container">
         {{block "content" .}}{{end}}
     </main>

--- a/cmd/agentctl-web/templates/layout.html
+++ b/cmd/agentctl-web/templates/layout.html
@@ -44,7 +44,7 @@
         </div>
     </nav>
     {{end}}
-    <main class="container">
+    <main class="container"{{if .Demo}} hx-get="/demo" hx-trigger="every 5s" hx-target="body" hx-swap="outerHTML"{{end}}>
         {{block "content" .}}{{end}}
     </main>
     <footer class="footer">

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	runtimeadmission "github.com/shreyansh/agentic-operator/internal/admission"
 	"github.com/shreyansh/agentic-operator/internal/controller"
 	"github.com/shreyansh/agentic-operator/pkg/evaluation"
 	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
@@ -244,6 +245,12 @@ func main() {
 			setupLog.Error(err, "Failed to setup webhook", "webhook", "AgentWorkload")
 			os.Exit(1)
 		}
+
+		mgr.GetWebhookServer().Register("/mutate-v1-pod-runtimeclass", &webhook.Admission{
+			Handler: &runtimeadmission.RuntimeClassInjector{
+				Config: runtimeadmission.RuntimeClassInjectionConfigFromEnv(),
+			},
+		})
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,10 +21,15 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
+	"net/http"
 	"os"
 	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -35,6 +40,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -43,6 +49,7 @@ import (
 	runtimeadmission "github.com/shreyansh/agentic-operator/internal/admission"
 	"github.com/shreyansh/agentic-operator/internal/controller"
 	"github.com/shreyansh/agentic-operator/pkg/evaluation"
+	"github.com/shreyansh/agentic-operator/pkg/finops"
 	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
 	"github.com/shreyansh/agentic-operator/pkg/otel/genai"
 	// +kubebuilder:scaffold:imports
@@ -72,6 +79,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var enableCostTracking bool
+	var costMetricsAddr string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -90,6 +99,10 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.BoolVar(&enableCostTracking, "enable-cost-tracking", os.Getenv("AGENTIC_COST_TRACKING") == "memory",
+		"Enable in-memory FinOps cost tracking and Prometheus cost metrics.")
+	flag.StringVar(&costMetricsAddr, "cost-metrics-bind-address", ":8080",
+		"The HTTP address for demo cost metrics. Use 0 to disable the extra /metrics server.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -215,13 +228,38 @@ func main() {
 		os.Exit(1)
 	}
 
+	var costReporter finops.CostReporter
+	if enableCostTracking {
+		memoryCostReporter := finops.NewMemoryCostReporter()
+		if err := registerFinOpsMetrics(ctrlmetrics.Registry, memoryCostReporter); err != nil {
+			setupLog.Error(err, "Failed to register FinOps Prometheus collector")
+			os.Exit(1)
+		}
+		costReporter = memoryCostReporter
+		if costMetricsAddr != "0" && costMetricsAddr != "" {
+			if err := mgr.Add(runnableFunc(func(ctx context.Context) error {
+				return serveHTTP(ctx, &http.Server{
+					Addr:    costMetricsAddr,
+					Handler: costMetricsHandler(ctrlmetrics.Registry),
+				}, setupLog.WithName("finops-metrics"))
+			})); err != nil {
+				setupLog.Error(err, "Failed to add FinOps metrics HTTP server")
+				os.Exit(1)
+			}
+		}
+	}
+
 	// Phase 7: Initialize multi-tenancy components
 	tenantResolver := multitenancy.NewResolver()
 	tenants := []*multitenancy.TenantContext{} // Will be populated from cluster config
 	quotaMgr := multitenancy.NewQuotaManager(tenants)
 	slaMonitor := multitenancy.NewSLAMonitor(tenants)
 
-	workloadReconciler := controller.NewAgentWorkloadReconciler(mgr.GetClient(), mgr.GetScheme())
+	reconcilerOptions := []controller.AgentWorkloadReconcilerOption{}
+	if costReporter != nil {
+		reconcilerOptions = append(reconcilerOptions, controller.WithCostReporter(costReporter))
+	}
+	workloadReconciler := controller.NewAgentWorkloadReconciler(mgr.GetClient(), mgr.GetScheme(), reconcilerOptions...)
 	workloadReconciler.Evaluator = evaluation.NewEvaluator() // Phase 4: Agent Evaluation Pipeline
 	workloadReconciler.QuotaMgr = quotaMgr                   // Phase 7: Quota enforcement
 	workloadReconciler.SLAMonitor = slaMonitor               // Phase 7: SLA tracking
@@ -267,5 +305,60 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "Failed to run manager")
 		os.Exit(1)
+	}
+}
+
+type runnableFunc func(context.Context) error
+
+func (f runnableFunc) Start(ctx context.Context) error {
+	return f(ctx)
+}
+
+func registerFinOpsMetrics(registerer prometheus.Registerer, reporter *finops.MemoryCostReporter) error {
+	if registerer == nil || reporter == nil {
+		return nil
+	}
+	err := registerer.Register(reporter.PrometheusCollector())
+	if err == nil {
+		return nil
+	}
+	var alreadyRegistered prometheus.AlreadyRegisteredError
+	if errors.As(err, &alreadyRegistered) {
+		return nil
+	}
+	return err
+}
+
+func costMetricsHandler(gatherer prometheus.Gatherer) http.Handler {
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
+}
+
+func serveHTTP(ctx context.Context, server *http.Server, logger logr.Logger) error {
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Info("Starting HTTP server", "addr", server.Addr)
+		err := server.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		select {
+		case err := <-errCh:
+			return err
+		case <-shutdownCtx.Done():
+			return shutdownCtx.Err()
+		}
+	case err := <-errCh:
+		return err
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/shreyansh/agentic-operator/pkg/finops"
+)
+
+func TestFinOpsMetricsEndpointContainsNineVigilCostMetric(t *testing.T) {
+	t.Parallel()
+
+	reporter := finops.NewMemoryCostReporter()
+	if err := reporter.RecordUsage(context.Background(), "demo-workload", "demo-ns", "openai/gpt-4o-mini", 1000, 500); err != nil {
+		t.Fatalf("record usage: %v", err)
+	}
+
+	registry := prometheus.NewRegistry()
+	if err := registerFinOpsMetrics(registry, reporter); err != nil {
+		t.Fatalf("register FinOps metrics: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	costMetricsHandler(registry).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	bodyBytes, err := io.ReadAll(recorder.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	body := string(bodyBytes)
+	if !strings.Contains(body, "ninevigil_agent_cost_dollars") {
+		t.Fatalf("metrics body missing ninevigil_agent_cost_dollars:\n%s", body)
+	}
+	if !strings.Contains(body, `model="openai/gpt-4o-mini"`) {
+		t.Fatalf("metrics body missing model label:\n%s", body)
+	}
+	if !strings.Contains(body, `workload="demo-workload"`) {
+		t.Fatalf("metrics body missing workload label:\n%s", body)
+	}
+	if !strings.Contains(body, `namespace="demo-ns"`) {
+		t.Fatalf("metrics body missing namespace label:\n%s", body)
+	}
+}

--- a/config/crd/bases/agentic.clawdlinux.org_agentworkloads.yaml
+++ b/config/crd/bases/agentic.clawdlinux.org_agentworkloads.yaml
@@ -312,6 +312,13 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              workflowName:
+                default: research-swarm
+                description: |-
+                  workflowName selects the registered workflow to execute.
+                  Built-in: "research-swarm", "code-review", "doc-processor"
+                  Custom workflows can be mounted at /etc/agentic/workflows/
+                type: string
               workloadType:
                 description: workloadType defines the infrastructure type (generic,
                   ceph, minio, postgres, etc.)

--- a/config/crd/bases/agentic.clawdlinux.org_tenants.yaml
+++ b/config/crd/bases/agentic.clawdlinux.org_tenants.yaml
@@ -1,0 +1,210 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: tenants.agentic.clawdlinux.org
+spec:
+  group: agentic.clawdlinux.org
+  names:
+    kind: Tenant
+    listKind: TenantList
+    plural: tenants
+    shortNames:
+    - tnt
+    - tenants
+    singular: tenant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.namespace
+      name: Namespace
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.workloadCount
+      name: Workloads
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Tenant represents a multi-tenant customer with isolated resources
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TenantSpec defines the desired state of a multi-tenant customer
+            properties:
+              displayName:
+                description: DisplayName is the human-readable name for this tenant
+                type: string
+              namespace:
+                description: Namespace is the Kubernetes namespace for this tenant's
+                  workloads
+                type: string
+              networkPolicy:
+                description: NetworkPolicy enables network isolation for this tenant
+                type: boolean
+              providers:
+                description: Providers list the AI providers this tenant can access
+                items:
+                  type: string
+                minItems: 1
+                type: array
+              quotas:
+                description: Quotas define resource limits for this tenant
+                properties:
+                  cpuLimit:
+                    description: CPULimit is the CPU resource limit for this tenant
+                    type: string
+                  maxConcurrent:
+                    description: MaxConcurrent is the maximum concurrent executions
+                    type: integer
+                  maxMonthlyTokens:
+                    description: MaxMonthlyTokens is the maximum tokens per month
+                      across all models
+                    format: int64
+                    type: integer
+                  maxWorkloads:
+                    description: MaxWorkloads is the maximum number of concurrent
+                      AgentWorkloads
+                    type: integer
+                  memoryLimit:
+                    description: MemoryLimit is the memory resource limit for this
+                      tenant
+                    type: string
+                type: object
+              slaTarget:
+                description: SLATarget is the target SLA percentage (e.g., 99.5)
+                type: number
+            required:
+            - displayName
+            - namespace
+            - providers
+            - quotas
+            type: object
+          status:
+            description: TenantStatus defines the observed state of Tenant
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastReconciliation:
+                description: LastReconciliation is the timestamp of last successful
+                  reconciliation
+                format: date-time
+                type: string
+              namespaceCreated:
+                description: NamespaceCreated indicates if the tenant namespace exists
+                type: boolean
+              networkPolicyActive:
+                description: NetworkPolicyActive indicates if network policies are
+                  active
+                type: boolean
+              phase:
+                description: Phase is the current provisioning phase
+                enum:
+                - Pending
+                - Provisioning
+                - Active
+                - Failed
+                - Terminating
+                type: string
+              quotasEnforced:
+                description: QuotasEnforced indicates if resource quotas are applied
+                type: boolean
+              rbacConfigured:
+                description: RBACConfigured indicates if roles and bindings are configured
+                type: boolean
+              secretsProvisioned:
+                description: SecretsProvisioned indicates if provider secrets are
+                  in place
+                type: boolean
+              tokensUsedThisMonth:
+                description: TokensUsedThisMonth tracks monthly token usage
+                format: int64
+                type: integer
+              workloadCount:
+                description: WorkloadCount is the number of active workloads for this
+                  tenant
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/grafana/dashboards/cost-by-workload.json
+++ b/config/grafana/dashboards/cost-by-workload.json
@@ -77,7 +77,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(agentic_estimated_cost_usd)",
+          "expr": "sum(ninevigil_agent_cost_dollars)",
           "legendFormat": "total",
           "range": true,
           "refId": "A"
@@ -123,13 +123,13 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(agentic_estimated_cost_usd) by (provider)",
-          "legendFormat": "{{provider}}",
+          "expr": "sum(ninevigil_agent_cost_dollars) by (workload, namespace, model)",
+          "legendFormat": "{{namespace}}/{{workload}} {{model}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Estimated Cost by Provider",
+      "title": "Estimated Cost by Workload, Namespace, and Model",
       "type": "timeseries"
     },
     {

--- a/config/samples/agentworkload_demo.yaml
+++ b/config/samples/agentworkload_demo.yaml
@@ -8,7 +8,7 @@ metadata:
     use-case: "research-swarm"
 spec:
   objective: |
-    Research which enterprise AI workflows require on-prem agent execution.
+    Research which regulated AI workflows require on-prem agent execution.
     Identify regulatory constraints, data residency requirements, and compliance gaps.
     Produce a structured report with sources and confidence scores.
   workloadType: generic
@@ -42,6 +42,6 @@ spec:
     role: "security-research-analyst"
     tone: "professional"
     systemPrompt: |
-      You are a security research analyst investigating enterprise AI agent
+      You are a security research analyst investigating regulated AI agent
       deployment requirements. Focus on regulatory constraints, data residency,
       and compliance gaps that prevent cloud-hosted agent execution.

--- a/config/samples/agentworkload_demo.yaml
+++ b/config/samples/agentworkload_demo.yaml
@@ -1,0 +1,47 @@
+apiVersion: agentic.clawdlinux.org/v1alpha1
+kind: AgentWorkload
+metadata:
+  name: secure-research-swarm
+  namespace: agentic-system
+  labels:
+    demo: "booth"
+    use-case: "research-swarm"
+spec:
+  objective: |
+    Research which enterprise AI workflows require on-prem agent execution.
+    Identify regulatory constraints, data residency requirements, and compliance gaps.
+    Produce a structured report with sources and confidence scores.
+  workloadType: generic
+  workflowName: research-swarm
+  agents:
+    - "web-researcher"
+    - "policy-analyst"
+    - "report-synthesizer"
+  opaPolicy: strict
+  autoApproveThreshold: "0.95"
+  modelStrategy: cost-aware
+  collaborationMode: team
+  providers:
+    - name: local-llm
+      endpoint: "http://litellm.shared-services:8000"
+      apiKeySecret: "litellm-api-key"
+      models:
+        - "gpt-4o-mini"
+        - "gpt-3.5-turbo"
+  modelMapping:
+    validation: "gpt-3.5-turbo"
+    analysis: "gpt-4o-mini"
+    reasoning: "gpt-4o-mini"
+  resources:
+    cpuLimit: "500m"
+    memoryLimit: "512Mi"
+  timeouts:
+    actionTimeout: 120
+    totalTimeout: 600
+  persona:
+    role: "security-research-analyst"
+    tone: "professional"
+    systemPrompt: |
+      You are a security research analyst investigating enterprise AI agent
+      deployment requirements. Focus on regulatory constraints, data residency,
+      and compliance gaps that prevent cloud-hosted agent execution.

--- a/config/samples/agentworkload_demo_allow.yaml
+++ b/config/samples/agentworkload_demo_allow.yaml
@@ -1,0 +1,19 @@
+apiVersion: agentic.clawdlinux.org/v1alpha1
+kind: AgentWorkload
+metadata:
+  name: opa-allow-demo
+  namespace: agentic-system
+  labels:
+    demo: "booth"
+    scenario: "opa-allow"
+  annotations:
+    demo.clawdlinux.org/description: "Allow demo. Strict OPA should allow this read-only analysis request."
+spec:
+  objective: "analyze quarterly revenue data"
+  workloadType: generic
+  workflowName: opa-allow-demo
+  agents:
+    - "policy-demo-agent"
+  opaPolicy: strict
+  autoApproveThreshold: "0.95"
+  mcpServerEndpoint: "https://localhost:8443"

--- a/config/samples/agentworkload_demo_deny.yaml
+++ b/config/samples/agentworkload_demo_deny.yaml
@@ -1,0 +1,19 @@
+apiVersion: agentic.clawdlinux.org/v1alpha1
+kind: AgentWorkload
+metadata:
+  name: opa-deny-demo
+  namespace: agentic-system
+  labels:
+    demo: "booth"
+    scenario: "opa-deny"
+  annotations:
+    demo.clawdlinux.org/description: "Deny demo. Strict OPA should reject this destructive request."
+spec:
+  objective: "delete all production volumes"
+  workloadType: generic
+  workflowName: opa-deny-demo
+  agents:
+    - "policy-demo-agent"
+  opaPolicy: strict
+  autoApproveThreshold: "0.95"
+  mcpServerEndpoint: "https://localhost:8443"

--- a/config/samples/agentworkload_demo_runtime.yaml
+++ b/config/samples/agentworkload_demo_runtime.yaml
@@ -12,7 +12,7 @@ apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: gvisor
-handler: runc
+handler: runsc
 ---
 apiVersion: agentic.clawdlinux.org/v1alpha1
 kind: AgentWorkload

--- a/config/samples/agentworkload_demo_runtime.yaml
+++ b/config/samples/agentworkload_demo_runtime.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentic-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo-workflows
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runc
+---
+apiVersion: agentic.clawdlinux.org/v1alpha1
+kind: AgentWorkload
+metadata:
+  name: secure-research-swarm
+  namespace: agentic-system
+  labels:
+    demo: "booth"
+    use-case: "research-swarm"
+  annotations:
+    agentworkload.clawdlinux.io/cost-usd-today: "0.0142"
+spec:
+  objective: |
+    Research which enterprise AI workflows require on-prem agent execution.
+    Identify regulatory constraints, data residency requirements, and compliance gaps.
+    Produce a structured report with sources and confidence scores.
+  workloadType: generic
+  workflowName: research-swarm
+  agents:
+    - "web-researcher"
+    - "policy-analyst"
+    - "report-synthesizer"
+  opaPolicy: strict
+  autoApproveThreshold: "0.95"
+  modelStrategy: cost-aware
+  modelMapping:
+    validation: "gpt-3.5-turbo"
+    analysis: "gpt-4o-mini"
+    reasoning: "gpt-4o-mini"
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-research-swarm-researcher
+  namespace: argo-workflows
+  labels:
+    agentic.io/job-id: secure-research-swarm
+    agentworkload.clawdlinux.io/name: secure-research-swarm
+    agentworkload.clawdlinux.io/role: researcher
+    app.kubernetes.io/part-of: ninevigil
+spec:
+  runtimeClassName: gvisor
+  containers:
+    - name: agent
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-research-swarm-policy
+  namespace: argo-workflows
+  labels:
+    agentic.io/job-id: secure-research-swarm
+    agentworkload.clawdlinux.io/name: secure-research-swarm
+    agentworkload.clawdlinux.io/role: policy-analyst
+    app.kubernetes.io/part-of: ninevigil
+spec:
+  runtimeClassName: gvisor
+  containers:
+    - name: agent
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-research-swarm-report
+  namespace: argo-workflows
+  labels:
+    agentic.io/job-id: secure-research-swarm
+    agentworkload.clawdlinux.io/name: secure-research-swarm
+    agentworkload.clawdlinux.io/role: report-synthesizer
+    app.kubernetes.io/part-of: ninevigil
+spec:
+  runtimeClassName: gvisor
+  containers:
+    - name: agent
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]

--- a/config/samples/agentworkload_demo_runtime.yaml
+++ b/config/samples/agentworkload_demo_runtime.yaml
@@ -26,7 +26,7 @@ metadata:
     agentworkload.clawdlinux.io/cost-usd-today: "0.0142"
 spec:
   objective: |
-    Research which enterprise AI workflows require on-prem agent execution.
+    Research which regulated AI workflows require on-prem agent execution.
     Identify regulatory constraints, data residency requirements, and compliance gaps.
     Produce a structured report with sources and confidence scores.
   workloadType: generic

--- a/config/samples/agentworkload_demo_swarm.yaml
+++ b/config/samples/agentworkload_demo_swarm.yaml
@@ -1,0 +1,24 @@
+apiVersion: agentic.clawdlinux.org/v1alpha1
+kind: AgentWorkload
+metadata:
+  name: demo-competitive-swarm
+  namespace: agentic-system
+  labels:
+    demo: "booth"
+    use-case: "hedge-fund-analysis"
+  annotations:
+    description: "3-agent competitive intelligence swarm for AI Summit booth demo"
+spec:
+  agents:
+    - "competitor-scraper"
+    - "llm-synthesizer"
+    - "report-generator"
+  orchestration:
+    type: "argo"
+  workflowName: "visual-analysis-template"
+  opaPolicy: "strict"
+  targetUrls:
+    - "https://notion.so/pricing"
+    - "https://linear.app/pricing"
+    - "https://asana.com/pricing"
+  targetBucket: "demo-reports"

--- a/docs/07-security.md
+++ b/docs/07-security.md
@@ -106,12 +106,11 @@ multi-tenant clusters where one tenant's compromise must not leak into another's
 memory). Kata trades startup latency (~hundreds of ms vs. tens) for a
 qualitatively stronger isolation guarantee.
 
-> **Status:** the gVisor `RuntimeClass` and Helm toggle that wires
-> `runtimeClassName: gvisor` onto agent pods is tracked for v0.4 (see the
-> "v0.4: ship gVisor RuntimeClass + Helm toggle" issue). Today, operators must
-> install gVisor on their nodes and add the `RuntimeClass` manually if they want
-> the policy enforced cluster-wide. Documenting the chosen technology now
-> commits us to the upstream we will integrate against.
+> **Status:** the Helm chart can create the gVisor `RuntimeClass` and register a
+> pod mutating webhook. Pods opt in with the label
+> `agentic.clawdlinux.org/runtime-sandbox: gvisor`. The webhook sets
+> `runtimeClassName: gvisor` unless the Pod already chose another runtime.
+> Operators must still install gVisor/runsc on their nodes before enabling this.
 
 ## Secret Management
 

--- a/docs/rfcs/0001-cross-cluster-agent-identity.md
+++ b/docs/rfcs/0001-cross-cluster-agent-identity.md
@@ -34,7 +34,7 @@ This was raised externally by [@JacobSobolev on X](https://x.com/JacobSobolev/st
 
 ### 1.2 Why it matters for NineVigil
 
-NineVigil's positioning is **air-gapped, zero-egress, regulated-industry agent orchestration** (FedRAMP, HIPAA, sovereign cloud). Those buyers run multi-cluster by default — at minimum, prod and DR; often a separate cluster per classification level or per region. Without federated identity, the multi-cluster story falls apart. Competitors (kagent/Solo.io) lean on Istio mTLS + OIDC, which assumes cloud-connected control planes — a non-starter for our ICP.
+NineVigil's positioning is **air-gapped, zero-egress, regulated-industry agent orchestration** (FedRAMP, HIPAA, sovereign cloud). Those buyers run multi-cluster by default. At minimum, prod and DR. Often a separate cluster per classification level or region. Without federated identity, the multi-cluster story falls apart. Existing approaches (Istio mTLS + OIDC, shared static secrets) assume cloud-connected control planes or manual key rotation. Neither works air-gapped.
 
 ### 1.3 Non-goals (explicit)
 
@@ -74,7 +74,7 @@ SPIFFE/SPIRE wins because: CNCF graduated (credibility), air-gap friendly (no ph
 - **Istio** — uses SPIFFE under the hood for mTLS identity.
 - **HashiCorp Consul** — supports SPIFFE-compatible identities.
 - **Tetragon / Cilium** — eBPF + workload identity research aligning with SPIFFE.
-- **kagent (Solo.io)** — uses Istio mTLS + OIDC for cross-cluster, which is the cloud-connected approach we explicitly differentiate against.
+- **kagent (Solo.io)** — CNCF Sandbox agent runtime. Cross-cluster identity mechanisms vary by deployment. SPIFFE provides a runtime-neutral alternative.
 
 ---
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -98,8 +98,7 @@ Agent pods are restricted to allowlisted domains. Two layers of enforcement:
    [`charts/templates/networkpolicy.yaml`](../charts/templates/networkpolicy.yaml).
 2. **Cilium FQDN policy** (optional, eBPF-enforced). Adds domain-level egress
    allow-listing on top of the namespace-level NetworkPolicy. Gated behind
-   `networkPolicy.cilium.enabled` (default `false`); requires the Cilium CNI
-   and tracked alongside the v0.4 RuntimeClass work.
+   `networkPolicy.cilium.enabled` (default `false`); requires the Cilium CNI.
 
 **Default posture**: Deny all egress except:
 - LiteLLM proxy (internal)

--- a/examples/multi-agent-swarm/agents/strategist/main.py
+++ b/examples/multi-agent-swarm/agents/strategist/main.py
@@ -51,7 +51,7 @@ async def risk_assess(facts: List[str] = None, topic: str = "") -> Dict[str, Any
             "Market growing 42% YoY — favorable tailwind",
             "78% K8s adoption — strong infrastructure foundation",
             "TAM $12B — sufficient market size",
-            "Competition emerging (KAgent, Kubeflow KEP) — time-sensitive window",
+            "Multi-agent delegation is table stakes across runtimes. Our edge is governance.",
         ],
         "confidence": 0.87,  # Below 0.95 — will trigger approval gate
     }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/shreyansh/agentic-operator
 go 1.25.3
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.27.2
@@ -36,7 +37,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/internal/admission/runtimeclass_injector.go
+++ b/internal/admission/runtimeclass_injector.go
@@ -1,0 +1,85 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrladmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	DefaultRuntimeClassName  = "gvisor"
+	DefaultRuntimeLabelKey   = "agentic.clawdlinux.org/runtime-sandbox"
+	DefaultRuntimeLabelValue = "gvisor"
+)
+
+type RuntimeClassInjectionConfig struct {
+	RuntimeClassName string
+	LabelKey         string
+	LabelValue       string
+}
+
+type RuntimeClassInjector struct {
+	Config RuntimeClassInjectionConfig
+}
+
+func RuntimeClassInjectionConfigFromEnv() RuntimeClassInjectionConfig {
+	return RuntimeClassInjectionConfig{
+		RuntimeClassName: envOrDefault("RUNTIME_SANDBOX_CLASS", DefaultRuntimeClassName),
+		LabelKey:         envOrDefault("RUNTIME_SANDBOX_LABEL_KEY", DefaultRuntimeLabelKey),
+		LabelValue:       envOrDefault("RUNTIME_SANDBOX_LABEL_VALUE", DefaultRuntimeLabelValue),
+	}
+}
+
+func InjectRuntimeClass(pod *corev1.Pod, config RuntimeClassInjectionConfig) bool {
+	if pod == nil {
+		return false
+	}
+
+	runtimeClassName := strings.TrimSpace(config.RuntimeClassName)
+	labelKey := strings.TrimSpace(config.LabelKey)
+	labelValue := strings.TrimSpace(config.LabelValue)
+	if runtimeClassName == "" || labelKey == "" || labelValue == "" {
+		return false
+	}
+	if pod.Labels[labelKey] != labelValue {
+		return false
+	}
+	if pod.Spec.RuntimeClassName != nil && strings.TrimSpace(*pod.Spec.RuntimeClassName) != "" {
+		return false
+	}
+
+	pod.Spec.RuntimeClassName = &runtimeClassName
+	return true
+}
+
+func (i *RuntimeClassInjector) Handle(ctx context.Context, req ctrladmission.Request) ctrladmission.Response {
+	pod := &corev1.Pod{}
+	if err := json.Unmarshal(req.Object.Raw, pod); err != nil {
+		return ctrladmission.Errored(http.StatusBadRequest, err)
+	}
+
+	mutated := pod.DeepCopy()
+	if !InjectRuntimeClass(mutated, i.Config) {
+		return ctrladmission.Allowed("runtimeClass injection skipped")
+	}
+
+	mutatedRaw, err := json.Marshal(mutated)
+	if err != nil {
+		return ctrladmission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return ctrladmission.PatchResponseFromRaw(req.Object.Raw, mutatedRaw)
+}
+
+func envOrDefault(name, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/admission/runtimeclass_injector_test.go
+++ b/internal/admission/runtimeclass_injector_test.go
@@ -1,0 +1,196 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrladmission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestInjectRuntimeClassAddsClassWhenLabelMatches(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"agentic.clawdlinux.org/runtime-sandbox": "gvisor",
+			},
+		},
+	}
+
+	changed := InjectRuntimeClass(pod, RuntimeClassInjectionConfig{
+		RuntimeClassName: "gvisor",
+		LabelKey:         "agentic.clawdlinux.org/runtime-sandbox",
+		LabelValue:       "gvisor",
+	})
+
+	if !changed {
+		t.Fatal("InjectRuntimeClass changed = false, want true")
+	}
+	if pod.Spec.RuntimeClassName == nil || *pod.Spec.RuntimeClassName != "gvisor" {
+		t.Fatalf("RuntimeClassName = %v, want gvisor", pod.Spec.RuntimeClassName)
+	}
+}
+
+func TestInjectRuntimeClassSkipsPodWithoutMatchingLabel(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "kagent-agent",
+			},
+		},
+	}
+
+	changed := InjectRuntimeClass(pod, RuntimeClassInjectionConfig{
+		RuntimeClassName: "gvisor",
+		LabelKey:         "agentic.clawdlinux.org/runtime-sandbox",
+		LabelValue:       "gvisor",
+	})
+
+	if changed {
+		t.Fatal("InjectRuntimeClass changed = true, want false")
+	}
+	if pod.Spec.RuntimeClassName != nil {
+		t.Fatalf("RuntimeClassName = %v, want nil", *pod.Spec.RuntimeClassName)
+	}
+}
+
+func TestInjectRuntimeClassDoesNotOverrideExistingRuntimeClass(t *testing.T) {
+	existing := "kata"
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"agentic.clawdlinux.org/runtime-sandbox": "gvisor",
+			},
+		},
+		Spec: corev1.PodSpec{
+			RuntimeClassName: &existing,
+		},
+	}
+
+	changed := InjectRuntimeClass(pod, RuntimeClassInjectionConfig{
+		RuntimeClassName: "gvisor",
+		LabelKey:         "agentic.clawdlinux.org/runtime-sandbox",
+		LabelValue:       "gvisor",
+	})
+
+	if changed {
+		t.Fatal("InjectRuntimeClass changed = true, want false")
+	}
+	if pod.Spec.RuntimeClassName == nil || *pod.Spec.RuntimeClassName != "kata" {
+		t.Fatalf("RuntimeClassName = %v, want kata", pod.Spec.RuntimeClassName)
+	}
+}
+
+func TestRuntimeClassInjectorHandleReturnsJSONPatch(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "research-agent",
+			Namespace: "kagent",
+			Labels: map[string]string{
+				"agentic.clawdlinux.org/runtime-sandbox": "gvisor",
+			},
+		},
+	}
+	raw := mustMarshalPod(t, pod)
+
+	injector := &RuntimeClassInjector{
+		Config: RuntimeClassInjectionConfig{
+			RuntimeClassName: "gvisor",
+			LabelKey:         "agentic.clawdlinux.org/runtime-sandbox",
+			LabelValue:       "gvisor",
+		},
+	}
+
+	response := injector.Handle(context.Background(), ctrladmission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{Raw: raw},
+		},
+	})
+
+	if !response.Allowed {
+		t.Fatalf("Allowed = false, want true: %v", response.Result)
+	}
+	if len(response.Patches) != 1 {
+		t.Fatalf("patch count = %d, want 1: %#v", len(response.Patches), response.Patches)
+	}
+	patch := response.Patches[0]
+	if patch.Operation != "add" {
+		t.Fatalf("patch op = %q, want add", patch.Operation)
+	}
+	if patch.Path != "/spec/runtimeClassName" {
+		t.Fatalf("patch path = %q, want /spec/runtimeClassName", patch.Path)
+	}
+	if patch.Value != "gvisor" {
+		t.Fatalf("patch value = %v, want gvisor", patch.Value)
+	}
+}
+
+func TestRuntimeClassInjectorHandleReturnsNoPatchWhenPodDoesNotOptIn(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plain-agent",
+			Namespace: "kagent",
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "kagent-agent",
+			},
+		},
+	}
+	raw := mustMarshalPod(t, pod)
+
+	injector := &RuntimeClassInjector{
+		Config: RuntimeClassInjectionConfig{
+			RuntimeClassName: "gvisor",
+			LabelKey:         "agentic.clawdlinux.org/runtime-sandbox",
+			LabelValue:       "gvisor",
+		},
+	}
+
+	response := injector.Handle(context.Background(), ctrladmission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{Raw: raw},
+		},
+	})
+
+	if !response.Allowed {
+		t.Fatalf("Allowed = false, want true: %v", response.Result)
+	}
+	if len(response.Patches) != 0 {
+		t.Fatalf("patch count = %d, want 0: %#v", len(response.Patches), response.Patches)
+	}
+}
+
+func TestRuntimeClassInjectorHandleRejectsInvalidPodJSON(t *testing.T) {
+	injector := &RuntimeClassInjector{
+		Config: RuntimeClassInjectionConfig{
+			RuntimeClassName: "gvisor",
+			LabelKey:         "agentic.clawdlinux.org/runtime-sandbox",
+			LabelValue:       "gvisor",
+		},
+	}
+
+	response := injector.Handle(context.Background(), ctrladmission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{Raw: []byte("{")},
+		},
+	})
+
+	if response.Allowed {
+		t.Fatal("Allowed = true, want false")
+	}
+	if response.Result == nil || response.Result.Code != 400 {
+		t.Fatalf("status code = %v, want 400", response.Result)
+	}
+}
+
+func mustMarshalPod(t *testing.T, pod *corev1.Pod) []byte {
+	t.Helper()
+	raw, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}

--- a/internal/controller/agentworkload_controller.go
+++ b/internal/controller/agentworkload_controller.go
@@ -36,7 +36,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/pkg/argo"
 	"github.com/shreyansh/agentic-operator/pkg/evaluation"
 	"github.com/shreyansh/agentic-operator/pkg/finops"
 	"github.com/shreyansh/agentic-operator/pkg/llm"
@@ -46,6 +45,7 @@ import (
 	"github.com/shreyansh/agentic-operator/pkg/opa"
 	"github.com/shreyansh/agentic-operator/pkg/resilience"
 	"github.com/shreyansh/agentic-operator/pkg/routing"
+	runtimeadapter "github.com/shreyansh/agentic-operator/pkg/runtime"
 )
 
 // Maximum number of actions to keep in status to prevent unbounded growth
@@ -69,6 +69,7 @@ type AgentWorkloadReconciler struct {
 	TenantRes        tenantResolver           // Phase 7: Tenant isolation
 	Metrics          *metrics.RoutingMetrics  // Singleton metrics recorder (initialized once)
 	RetryConfig      *resilience.RetryConfig  // optional test seam; nil uses production defaults
+	RuntimeRegistry  *runtimeadapter.Registry // runtime adapter registry; nil lazily defaults to Argo
 }
 
 type quotaChecker interface {
@@ -116,6 +117,18 @@ func (r *AgentWorkloadReconciler) ensureFinopsDefaults() {
 	if r.LicenceValidator == nil {
 		r.LicenceValidator = finops.NewNoOpLicenceValidator()
 	}
+}
+
+// ensureRuntimeDefaults lazily builds the runtime adapter registry. Tests and
+// callers that construct the reconciler as a bare struct get the Argo adapter
+// registered by default, so governance routing works without extra wiring.
+func (r *AgentWorkloadReconciler) ensureRuntimeDefaults() {
+	if r.RuntimeRegistry != nil {
+		return
+	}
+	reg := runtimeadapter.NewRegistry()
+	reg.Register("argo", &runtimeadapter.ArgoWorkflowAdapter{Client: r.Client, Scheme: r.Scheme})
+	r.RuntimeRegistry = reg
 }
 
 // +kubebuilder:rbac:groups=agentic.clawdlinux.org,resources=agentworkloads,verbs=get;list;watch;create;update;patch;delete
@@ -627,22 +640,33 @@ func pruneActions(actions []agenticv1alpha1.Action, maxSize int) []agenticv1alph
 	return actions[len(actions)-maxSize:]
 }
 
-// reconcileArgoWorkflow handles reconciliation for Argo-orchestrated workloads
+// reconcileArgoWorkflow handles reconciliation for orchestrated workloads by
+// dispatching to the runtime adapter resolved from spec.orchestration.type.
+// The Argo adapter preserves all historical behavior; other registered
+// runtimes get the same governance and status mapping.
 func (r *AgentWorkloadReconciler) reconcileArgoWorkflow(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
-	log.Info("Reconciling Argo-orchestrated workload", "name", workload.Name)
+	log.Info("Reconciling orchestrated workload", "name", workload.Name)
 
-	// Initialize Argo workflow manager
-	wfManager := argo.NewWorkflowManager(r.Client, r.Scheme)
+	r.ensureRuntimeDefaults()
+	adapter, err := r.RuntimeRegistry.For(workload)
+	if err != nil {
+		log.Error(err, "no runtime adapter for workload")
+		workload.Status.Phase = "Failed"
+		if uerr := r.Status().Update(ctx, workload); uerr != nil {
+			log.Error(uerr, "failed to update status")
+		}
+		return ctrl.Result{}, nil
+	}
 
-	// Check if workflow already exists
+	// Check if execution already exists
 	if workload.Status.ArgoWorkflow != nil && workload.Status.ArgoWorkflow.Name != "" {
-		log.Info("Workflow already exists", "workflowName", workload.Status.ArgoWorkflow.Name)
+		log.Info("Execution already exists", "name", workload.Status.ArgoWorkflow.Name)
 
-		// Get workflow status
-		wfStatus, err := wfManager.GetArgoWorkflowStatus(ctx, workload.Status.ArgoWorkflow.Name, "argo-workflows")
+		// Get execution status via the adapter
+		execStatus, err := adapter.Status(ctx, workload)
 		if err != nil {
-			log.Error(err, "failed to get workflow status")
+			log.Error(err, "failed to get execution status")
 			workload.Status.Phase = "Failed"
 			workload.Status.ArgoPhase = "Error"
 			if err := r.Status().Update(ctx, workload); err != nil {
@@ -651,15 +675,14 @@ func (r *AgentWorkloadReconciler) reconcileArgoWorkflow(ctx context.Context, wor
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
-		// Update phase based on workflow status
-		workload.Status.ArgoPhase = wfStatus.Phase
-		if wfStatus.Phase == "Succeeded" {
+		// Update phase based on normalized execution status
+		workload.Status.ArgoPhase = execStatus.Phase
+		switch execStatus.Phase {
+		case "Succeeded":
 			workload.Status.Phase = "Completed"
-		} else if wfStatus.Phase == "Failed" || wfStatus.Phase == "Error" {
+		case "Failed", "Error":
 			workload.Status.Phase = "Failed"
-		} else if wfStatus.Phase == "Running" || wfStatus.Phase == "Pending" {
-			workload.Status.Phase = "Running"
-		} else if wfStatus.Phase == "Suspended" {
+		case "Running", "Pending", "Suspended":
 			workload.Status.Phase = "Running"
 		}
 
@@ -671,13 +694,12 @@ func (r *AgentWorkloadReconciler) reconcileArgoWorkflow(ctx context.Context, wor
 		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 	}
 
-	// Create new workflow
-	log.Info("Creating new Argo Workflow", "jobId", workload.Spec.JobID)
+	// Create new execution
+	log.Info("Creating new execution", "jobId", workload.Spec.JobID)
 
-	// Create the workflow
-	workflow, err := wfManager.CreateArgoWorkflow(ctx, workload)
+	execStatus, err := adapter.Execute(ctx, workload)
 	if err != nil {
-		log.Error(err, "failed to create Argo workflow")
+		log.Error(err, "failed to create execution")
 		workload.Status.Phase = "Failed"
 		workload.Status.ArgoPhase = "Error"
 		if err := r.Status().Update(ctx, workload); err != nil {
@@ -686,28 +708,29 @@ func (r *AgentWorkloadReconciler) reconcileArgoWorkflow(ctx context.Context, wor
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	log.Info("Argo Workflow created successfully", "workflowName", workflow.GetName())
+	log.Info("Execution created successfully", "name", execStatus.Name)
 
-	// Update status with workflow reference
+	// Update status with execution reference
 	workload.Status.Phase = "Running"
 	workload.Status.ArgoPhase = "Pending"
 	workload.Status.ArgoWorkflow = &agenticv1alpha1.ArgoWorkflowRef{
-		Name:      workflow.GetName(),
-		Namespace: workflow.GetNamespace(),
-		UID:       string(workflow.GetUID()),
+		Name:      execStatus.Name,
+		Namespace: execStatus.Namespace,
+		UID:       execStatus.UID,
 		CreatedAt: &metav1.Time{Time: time.Now()},
 	}
 
 	if err := r.Status().Update(ctx, workload); err != nil {
-		log.Error(err, "failed to update status with workflow reference")
+		log.Error(err, "failed to update status with execution reference")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 }
 
-// cleanupArgoWorkflow deletes the Argo Workflow associated with this AgentWorkload.
-// Invoked from the finalizer path. Safe to call when no workflow was ever created.
+// cleanupArgoWorkflow deletes the execution associated with this AgentWorkload
+// via the runtime adapter. Invoked from the finalizer path. Safe to call when
+// no execution was ever created.
 func (r *AgentWorkloadReconciler) cleanupArgoWorkflow(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) error {
 	log := logf.FromContext(ctx)
 
@@ -715,18 +738,17 @@ func (r *AgentWorkloadReconciler) cleanupArgoWorkflow(ctx context.Context, workl
 		return nil
 	}
 
-	wfManager := argo.NewWorkflowManager(r.Client, r.Scheme)
-	ns := workload.Status.ArgoWorkflow.Namespace
-	if ns == "" {
-		ns = argo.DefaultWorkflowNamespace
+	r.ensureRuntimeDefaults()
+	adapter, err := r.RuntimeRegistry.For(workload)
+	if err != nil {
+		return fmt.Errorf("cleanup: %w", err)
 	}
 
-	if err := wfManager.DeleteArgoWorkflow(ctx, workload.Status.ArgoWorkflow.Name, ns); err != nil {
-		return fmt.Errorf("delete argo workflow %s/%s: %w", ns, workload.Status.ArgoWorkflow.Name, err)
+	if err := adapter.Cleanup(ctx, workload); err != nil {
+		return fmt.Errorf("cleanup execution %s: %w", workload.Status.ArgoWorkflow.Name, err)
 	}
 
-	log.Info("Argo Workflow cleaned up via finalizer",
-		"workflow", workload.Status.ArgoWorkflow.Name, "namespace", ns)
+	log.Info("Execution cleaned up via finalizer", "name", workload.Status.ArgoWorkflow.Name)
 	return nil
 }
 

--- a/internal/controller/agentworkload_controller.go
+++ b/internal/controller/agentworkload_controller.go
@@ -61,14 +61,22 @@ const AgentWorkloadFinalizer = "agentic.clawdlinux.org/finalizer"
 type AgentWorkloadReconciler struct {
 	client.Client
 	Scheme           *runtime.Scheme
-	CostReporter     finops.CostReporter        // FinOps integration (defaults to no-op)
-	LicenceValidator finops.LicenceValidator    // License validation (defaults to no-op)
-	Evaluator        *evaluation.Evaluator      // Phase 4: Agent Evaluation Pipeline
-	QuotaMgr         *multitenancy.QuotaManager // Phase 7: Per-tenant quotas
-	SLAMonitor       *multitenancy.SLAMonitor   // Phase 7: SLA tracking
-	TenantRes        *multitenancy.Resolver     // Phase 7: Tenant isolation
-	Metrics          *metrics.RoutingMetrics    // Singleton metrics recorder (initialized once)
-	RetryConfig      *resilience.RetryConfig    // optional test seam; nil uses production defaults
+	CostReporter     finops.CostReporter      // FinOps integration (defaults to no-op)
+	LicenceValidator finops.LicenceValidator  // License validation (defaults to no-op)
+	Evaluator        *evaluation.Evaluator    // Phase 4: Agent Evaluation Pipeline
+	QuotaMgr         quotaChecker             // Phase 7: Per-tenant quotas
+	SLAMonitor       *multitenancy.SLAMonitor // Phase 7: SLA tracking
+	TenantRes        tenantResolver           // Phase 7: Tenant isolation
+	Metrics          *metrics.RoutingMetrics  // Singleton metrics recorder (initialized once)
+	RetryConfig      *resilience.RetryConfig  // optional test seam; nil uses production defaults
+}
+
+type quotaChecker interface {
+	CheckAndConsume(tenantName string, costUSD float64) error
+}
+
+type tenantResolver interface {
+	ExtractFromNamespace(ctx context.Context, namespace string) (*multitenancy.TenantContext, error)
 }
 
 type AgentWorkloadReconcilerOption func(*AgentWorkloadReconciler)

--- a/internal/controller/agentworkload_controller.go
+++ b/internal/controller/agentworkload_controller.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -67,6 +68,7 @@ type AgentWorkloadReconciler struct {
 	SLAMonitor       *multitenancy.SLAMonitor   // Phase 7: SLA tracking
 	TenantRes        *multitenancy.Resolver     // Phase 7: Tenant isolation
 	Metrics          *metrics.RoutingMetrics    // Singleton metrics recorder (initialized once)
+	RetryConfig      *resilience.RetryConfig    // optional test seam; nil uses production defaults
 }
 
 type AgentWorkloadReconcilerOption func(*AgentWorkloadReconciler)
@@ -226,6 +228,9 @@ func (r *AgentWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			routingInfo *llm.RoutingInfo
 		}
 		retryCfg := resilience.DefaultRetryConfig()
+		if r.RetryConfig != nil {
+			retryCfg = *r.RetryConfig
+		}
 		result, retryInfo := resilience.WithRetry(ctx, retryCfg, "model-routing", func(retryCtx context.Context) (routeResult, error) {
 			resp, ri, err := r.routeAndCallModel(retryCtx, &workload)
 			return routeResult{response: resp, routingInfo: ri}, err
@@ -503,11 +508,23 @@ func (r *AgentWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		workload.Status.ProposedActions = append(workload.Status.ProposedActions, action)
 		prunedProposed := pruneActions(workload.Status.ProposedActions, maxActionsInStatus)
 		workload.Status.ProposedActions = prunedProposed
-		workload.Status.Phase = "PendingApproval"
+		if workload.Spec.OPAPolicy != nil && *workload.Spec.OPAPolicy == "strict" {
+			workload.Status.Phase = "PolicyDenied"
+			workload.Status.Conditions = upsertCondition(workload.Status.Conditions, metav1.Condition{
+				Type:               "PolicyDenied",
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: workload.Generation,
+				Reason:             "OPADenied",
+				Message:            fmt.Sprintf("OPA denied action %q: %s", action.Name, strings.Join(opaResult.Reasons, "; ")),
+				LastTransitionTime: now,
+			})
+		} else {
+			workload.Status.Phase = "PendingApproval"
+		}
 	}
 
 	// Step 6: Update status
-	if workload.Status.Phase == "" || (workload.Status.Phase != "Completed" && workload.Status.Phase != "Failed" && workload.Status.Phase != "PendingApproval") {
+	if workload.Status.Phase == "" || (workload.Status.Phase != "Completed" && workload.Status.Phase != "Failed" && workload.Status.Phase != "PendingApproval" && workload.Status.Phase != "PolicyDenied") {
 		workload.Status.Phase = "Running"
 	}
 	workload.Status.LastReconcileTime = &now
@@ -522,7 +539,7 @@ func (r *AgentWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Step 7: Determine requeue interval
 	var requeueInterval time.Duration
-	if workload.Status.Phase == "PendingApproval" {
+	if workload.Status.Phase == "PendingApproval" || workload.Status.Phase == "PolicyDenied" {
 		// For pending approval, requeue less frequently (1 hour) to wait for human approval
 		requeueInterval = 1 * time.Hour
 	} else {
@@ -531,6 +548,16 @@ func (r *AgentWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	return ctrl.Result{RequeueAfter: requeueInterval}, nil
+}
+
+func upsertCondition(conditions []metav1.Condition, condition metav1.Condition) []metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condition.Type {
+			conditions[i] = condition
+			return conditions
+		}
+	}
+	return append(conditions, condition)
 }
 
 // Helper functions

--- a/internal/controller/agentworkload_controller_argo_test.go
+++ b/internal/controller/agentworkload_controller_argo_test.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	"github.com/shreyansh/agentic-operator/pkg/argo"
+)
+
+func TestReconcile_ArgoOrchestrationCreatesWorkflowAndStatusRef(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	orchestrationType := "argo"
+	jobID := "argo-demo-job"
+	workload := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "argo-demo", Namespace: "default", UID: types.UID("workload-uid")},
+		Spec: agenticv1alpha1.AgentWorkloadSpec{
+			JobID: &jobID,
+			Orchestration: &agenticv1alpha1.OrchestrationSpec{
+				Type: &orchestrationType,
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+		WithObjects(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: argo.DefaultWorkflowNamespace}},
+			workload,
+		).
+		Build()
+
+	reconciler := &AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme}
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+	if err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatalf("requeueAfter = 0, want workflow polling requeue")
+	}
+
+	workflow := &unstructured.Unstructured{}
+	workflow.SetGroupVersionKind(schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "Workflow"})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: argo.DefaultWorkflowNamespace}, workflow); err != nil {
+		t.Fatalf("expected Argo Workflow to be created: %v", err)
+	}
+	if workflow.GetLabels()["agentic.io/job-id"] != workload.Name {
+		t.Fatalf("workflow job label = %q, want %q", workflow.GetLabels()["agentic.io/job-id"], workload.Name)
+	}
+
+	updated := &agenticv1alpha1.AgentWorkload{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+		t.Fatalf("fetch updated workload: %v", err)
+	}
+	if updated.Status.Phase != "Running" {
+		t.Fatalf("phase = %q, want Running", updated.Status.Phase)
+	}
+	if updated.Status.ArgoWorkflow == nil || updated.Status.ArgoWorkflow.Name != workload.Name {
+		t.Fatalf("ArgoWorkflow ref = %#v, want workflow name %q", updated.Status.ArgoWorkflow, workload.Name)
+	}
+}

--- a/internal/controller/agentworkload_controller_argo_test.go
+++ b/internal/controller/agentworkload_controller_argo_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -118,5 +119,75 @@ func TestReconcile_ArgoOrchestrationCreatesWorkflowAndStatusRef(t *testing.T) {
 	}
 	if updated.Status.ArgoWorkflow == nil || updated.Status.ArgoWorkflow.Name != workload.Name {
 		t.Fatalf("ArgoWorkflow ref = %#v, want workflow name %q", updated.Status.ArgoWorkflow, workload.Name)
+	}
+}
+
+func TestReconcile_ArgoCreatesWorkflow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	orchestrationType := "argo"
+	workflowName := argo.DefaultWorkflowTemplate
+	jobID := "argo-workflow-create-job"
+	workload := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "argo-workflow-create", Namespace: "default", UID: types.UID("argo-workflow-create-uid")},
+		Spec: agenticv1alpha1.AgentWorkloadSpec{
+			JobID:        &jobID,
+			WorkflowName: &workflowName,
+			Orchestration: &agenticv1alpha1.OrchestrationSpec{
+				Type: &orchestrationType,
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+		WithObjects(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: argo.DefaultWorkflowNamespace}},
+			workload,
+		).
+		Build()
+
+	reconciler := &AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme}
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+	if err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if result.RequeueAfter != 15*time.Second {
+		t.Fatalf("requeueAfter = %s, want Argo polling requeue of 15s", result.RequeueAfter)
+	}
+
+	workflow := &unstructured.Unstructured{}
+	workflow.SetGroupVersionKind(schema.GroupVersionKind{Group: "argoproj.io", Version: "v1alpha1", Kind: "Workflow"})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: argo.DefaultWorkflowNamespace}, workflow); err != nil {
+		t.Fatalf("expected Argo Workflow to be created by fake client: %v", err)
+	}
+
+	templateName, found, err := unstructured.NestedString(workflow.Object, "spec", "workflowTemplateRef", "name")
+	if err != nil {
+		t.Fatalf("read workflowTemplateRef.name: %v", err)
+	}
+	if !found || templateName != argo.DefaultWorkflowTemplate {
+		t.Fatalf("workflowTemplateRef.name = %q found=%v, want %q", templateName, found, argo.DefaultWorkflowTemplate)
+	}
+
+	updated := &agenticv1alpha1.AgentWorkload{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+		t.Fatalf("fetch updated workload: %v", err)
+	}
+	if updated.Status.Phase == "Failed" {
+		t.Fatalf("phase = Failed, want Argo path to avoid MCP failure")
+	}
+	if updated.Status.Phase != "Running" {
+		t.Fatalf("phase = %q, want Running", updated.Status.Phase)
+	}
+	if updated.Status.ArgoPhase != "Pending" {
+		t.Fatalf("argoPhase = %q, want Pending", updated.Status.ArgoPhase)
+	}
+	if updated.Status.ArgoWorkflow == nil || updated.Status.ArgoWorkflow.Name != workflow.GetName() {
+		t.Fatalf("ArgoWorkflow ref = %#v, want workflow name %q", updated.Status.ArgoWorkflow, workflow.GetName())
 	}
 }

--- a/internal/controller/agentworkload_controller_argo_test.go
+++ b/internal/controller/agentworkload_controller_argo_test.go
@@ -16,6 +16,54 @@ import (
 	"github.com/shreyansh/agentic-operator/pkg/argo"
 )
 
+func TestReconcile_ArgoOrchestration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	orchestrationType := "argo"
+	jobID := "argo-direct-job"
+	workload := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "argo-direct", Namespace: "default", UID: types.UID("argo-direct-uid")},
+		Spec: agenticv1alpha1.AgentWorkloadSpec{
+			JobID: &jobID,
+			Orchestration: &agenticv1alpha1.OrchestrationSpec{
+				Type: &orchestrationType,
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+		WithObjects(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: argo.DefaultWorkflowNamespace}},
+			workload,
+		).
+		Build()
+
+	reconciler := &AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("reconcile panicked without an explicit Argo client: %v", recovered)
+		}
+	}()
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+	if err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	updated := &agenticv1alpha1.AgentWorkload{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+		t.Fatalf("fetch updated workload: %v", err)
+	}
+	if updated.Status.Phase == "Failed" {
+		t.Fatalf("phase = Failed, want Argo path to avoid MCP failure")
+	}
+}
+
 func TestReconcile_ArgoOrchestrationCreatesWorkflowAndStatusRef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/agentworkload_controller_opa_test.go
+++ b/internal/controller/agentworkload_controller_opa_test.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+)
+
+func TestReconcile_StrictOPADenySetsPolicyDeniedCondition(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	server := newMockMCPServer(mockMCPScenario{confidence: "0.82", clusterHealth: 90.0})
+	defer server.Close()
+
+	objective := "optimize resources"
+	policy := "strict"
+	workload := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "opa-deny", Namespace: "default"},
+		Spec: agenticv1alpha1.AgentWorkloadSpec{
+			MCPServerEndpoint: &server.URL,
+			Objective:         &objective,
+			OPAPolicy:         &policy,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}, workload).
+		Build()
+
+	reconciler := &AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme}
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+	if err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	updated := &agenticv1alpha1.AgentWorkload{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+		t.Fatalf("fetch updated workload: %v", err)
+	}
+	if updated.Status.Phase != "PolicyDenied" {
+		t.Fatalf("phase = %q, want PolicyDenied", updated.Status.Phase)
+	}
+	if len(updated.Status.ProposedActions) != 1 {
+		t.Fatalf("proposed actions = %d, want 1", len(updated.Status.ProposedActions))
+	}
+
+	condition := findCondition(updated.Status.Conditions, "PolicyDenied")
+	if condition == nil {
+		t.Fatalf("PolicyDenied condition missing: %#v", updated.Status.Conditions)
+	}
+	if condition.Status != metav1.ConditionTrue {
+		t.Fatalf("PolicyDenied condition status = %s, want True", condition.Status)
+	}
+	if !strings.Contains(condition.Message, "requires human approval") {
+		t.Fatalf("PolicyDenied message = %q, want OPA reason", condition.Message)
+	}
+}
+
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/internal/controller/agentworkload_controller_opa_test.go
+++ b/internal/controller/agentworkload_controller_opa_test.go
@@ -14,6 +14,46 @@ import (
 	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
 )
 
+func TestReconcile_OPADenyPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	server := newMockMCPServer(mockMCPScenario{confidence: 0.80, clusterHealth: 90.0})
+	defer server.Close()
+
+	objective := "optimize resources"
+	policy := "strict"
+	workload := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "opa-deny-path", Namespace: "default"},
+		Spec: agenticv1alpha1.AgentWorkloadSpec{
+			MCPServerEndpoint: &server.URL,
+			Objective:         &objective,
+			OPAPolicy:         &policy,
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}, workload).
+		Build()
+
+	reconciler := &AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme}
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+	if err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	updated := &agenticv1alpha1.AgentWorkload{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+		t.Fatalf("fetch updated workload: %v", err)
+	}
+	if updated.Status.Phase != "PolicyDenied" {
+		t.Fatalf("phase = %q, want PolicyDenied", updated.Status.Phase)
+	}
+}
+
 func TestReconcile_StrictOPADenySetsPolicyDeniedCondition(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/agentworkload_controller_quota_test.go
+++ b/internal/controller/agentworkload_controller_quota_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -14,6 +15,60 @@ import (
 	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
 	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
 )
+
+type stubQuotaManager struct{}
+
+func (stubQuotaManager) CheckAndConsume(string, float64) error {
+	return errors.New("quota exceeded")
+}
+
+type stubTenantResolver struct {
+	tenant *multitenancy.TenantContext
+}
+
+func (r stubTenantResolver) ExtractFromNamespace(context.Context, string) (*multitenancy.TenantContext, error) {
+	return r.tenant, nil
+}
+
+func TestReconcile_QuotaExceeded(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	tenant := newControllerTenant("acme-quota", "agentic-customer-acme-quota")
+	workload := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-exceeded", Namespace: tenant.Namespace},
+		Spec:       agenticv1alpha1.AgentWorkloadSpec{},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenant.Namespace}}, workload).
+		Build()
+
+	reconciler := &AgentWorkloadReconciler{
+		Client:    k8sClient,
+		Scheme:    scheme,
+		QuotaMgr:  stubQuotaManager{},
+		TenantRes: stubTenantResolver{tenant: tenant},
+	}
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+	if err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if result.RequeueAfter != time.Hour {
+		t.Fatalf("requeueAfter = %s, want 1h", result.RequeueAfter)
+	}
+
+	updated := &agenticv1alpha1.AgentWorkload{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+		t.Fatalf("fetch updated workload: %v", err)
+	}
+	if updated.Status.Phase != "Failed" {
+		t.Fatalf("phase = %q, want Failed", updated.Status.Phase)
+	}
+}
 
 func TestReconcile_QuotaExceededFailsAndRequeuesForReset(t *testing.T) {
 	t.Parallel()

--- a/internal/controller/agentworkload_controller_quota_test.go
+++ b/internal/controller/agentworkload_controller_quota_test.go
@@ -1,0 +1,74 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
+)
+
+func TestReconcile_QuotaExceededFailsAndRequeuesForReset(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newControllerTestScheme(t)
+	tenant := newControllerTenant("acme", "agentic-customer-acme")
+	resolver := multitenancy.NewResolver()
+	if err := resolver.RegisterTenant(tenant); err != nil {
+		t.Fatalf("register tenant: %v", err)
+	}
+	quota := multitenancy.NewQuotaManager([]*multitenancy.TenantContext{tenant})
+
+	workload := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "quota-denied", Namespace: tenant.Namespace},
+		Spec:       agenticv1alpha1.AgentWorkloadSpec{},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenant.Namespace}}, workload).
+		Build()
+
+	reconciler := &AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme, QuotaMgr: quota, TenantRes: resolver}
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+	if err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if result.RequeueAfter != time.Hour {
+		t.Fatalf("requeueAfter = %s, want 1h", result.RequeueAfter)
+	}
+
+	updated := &agenticv1alpha1.AgentWorkload{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+		t.Fatalf("fetch updated workload: %v", err)
+	}
+	if updated.Status.Phase != "Failed" {
+		t.Fatalf("phase = %q, want Failed", updated.Status.Phase)
+	}
+}
+
+func newControllerTenant(name, namespace string) *multitenancy.TenantContext {
+	return &multitenancy.TenantContext{
+		Name:             name,
+		Namespace:        namespace,
+		QuotaPerDay:      0,
+		CostBudgetUSD:    100,
+		SLATargetPercent: 99,
+		IsActive:         true,
+		License: &multitenancy.License{
+			Key:       "test-license",
+			Tier:      "trial",
+			Seats:     1,
+			ExpiresAt: time.Now().Add(time.Hour),
+			IsValid:   true,
+		},
+	}
+}

--- a/internal/controller/agentworkload_controller_sla_test.go
+++ b/internal/controller/agentworkload_controller_sla_test.go
@@ -1,0 +1,114 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
+	"github.com/shreyansh/agentic-operator/pkg/resilience"
+)
+
+func TestReconcile_ModelRoutingRecordsSLASuccessAndFailure(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		serverMode      mockOpenAIScenario
+		expectedPhase   string
+		expectedSuccess int
+		expectedFailure int
+	}{
+		{name: "success", serverMode: mockOpenAIScenarioSuccess, expectedPhase: "Completed", expectedSuccess: 1},
+		{name: "failure", serverMode: mockOpenAIScenarioHTTP500, expectedPhase: "Failed", expectedFailure: 1},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			scheme := newControllerTestScheme(t)
+			tenant := newControllerTenant("acme", "agentic-customer-acme")
+			tenant.QuotaPerDay = 100
+			resolver := multitenancy.NewResolver()
+			if err := resolver.RegisterTenant(tenant); err != nil {
+				t.Fatalf("register tenant: %v", err)
+			}
+			slaMonitor := multitenancy.NewSLAMonitor([]*multitenancy.TenantContext{tenant})
+			mockServer := newMockOpenAIServer(tc.serverMode)
+			defer mockServer.Close()
+
+			workload := newRoutingWorkload("sla-"+tc.name, tenant.Namespace, mockServer.URL)
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+				WithObjects(
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tenant.Namespace}},
+					&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "provider-secret", Namespace: tenant.Namespace}, Data: map[string][]byte{"api-key": []byte("test-token")}},
+					workload,
+				).
+				Build()
+
+			retryCfg := resilience.RetryConfig{MaxRetries: 0, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond}
+			reconciler := &AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme, SLAMonitor: slaMonitor, TenantRes: resolver, RetryConfig: &retryCfg}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+			if err != nil {
+				t.Fatalf("reconcile returned error: %v", err)
+			}
+
+			updated := &agenticv1alpha1.AgentWorkload{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+				t.Fatalf("fetch updated workload: %v", err)
+			}
+			if updated.Status.Phase != tc.expectedPhase {
+				t.Fatalf("phase = %q, want %q", updated.Status.Phase, tc.expectedPhase)
+			}
+
+			status, err := slaMonitor.GetStatus(tenant.Name)
+			if err != nil {
+				t.Fatalf("get SLA status: %v", err)
+			}
+			if status.SuccessCount != tc.expectedSuccess {
+				t.Fatalf("success count = %d, want %d", status.SuccessCount, tc.expectedSuccess)
+			}
+			if status.FailureCount != tc.expectedFailure {
+				t.Fatalf("failure count = %d, want %d", status.FailureCount, tc.expectedFailure)
+			}
+		})
+	}
+}
+
+func newRoutingWorkload(name, namespace, endpoint string) *agenticv1alpha1.AgentWorkload {
+	strategy := "cost-aware"
+	classifier := "default"
+	objective := "Analyze quarterly revenue data and identify top trends."
+	secretKey := "api-key"
+	return &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: agenticv1alpha1.AgentWorkloadSpec{
+			ModelStrategy:  &strategy,
+			TaskClassifier: &classifier,
+			Objective:      &objective,
+			Providers: []agenticv1alpha1.LLMProvider{{
+				Name:         "mock-openai",
+				Type:         "openai-compatible",
+				Endpoint:     &endpoint,
+				APIKeySecret: &agenticv1alpha1.SecretKeyRef{Name: "provider-secret", Key: &secretKey},
+			}},
+			ModelMapping: map[string]string{
+				"validation": "mock-openai/gpt-3.5-turbo",
+				"analysis":   "mock-openai/gpt-4",
+				"reasoning":  "mock-openai/gpt-4-turbo",
+			},
+		},
+	}
+}

--- a/internal/controller/runtime_wiring_test.go
+++ b/internal/controller/runtime_wiring_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "testing"
+
+// TestEnsureRuntimeDefaults_RegistersArgo verifies the reconciler lazily wires
+// a runtime registry with the Argo adapter, so a bare-struct reconciler (as
+// used throughout the test suite and in main) routes through the adapter
+// interface rather than calling Argo directly.
+func TestEnsureRuntimeDefaults_RegistersArgo(t *testing.T) {
+	r := &AgentWorkloadReconciler{}
+
+	r.ensureRuntimeDefaults()
+
+	if r.RuntimeRegistry == nil {
+		t.Fatal("ensureRuntimeDefaults did not initialize RuntimeRegistry")
+	}
+
+	registered := r.RuntimeRegistry.Registered()
+	found := false
+	for _, name := range registered {
+		if name == "argo" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("registered runtimes = %v, want argo present", registered)
+	}
+}
+
+// TestEnsureRuntimeDefaults_Idempotent verifies a second call does not replace
+// an already-configured registry (e.g. one injected by a test or by main).
+func TestEnsureRuntimeDefaults_Idempotent(t *testing.T) {
+	r := &AgentWorkloadReconciler{}
+	r.ensureRuntimeDefaults()
+	first := r.RuntimeRegistry
+
+	r.ensureRuntimeDefaults()
+
+	if r.RuntimeRegistry != first {
+		t.Error("ensureRuntimeDefaults replaced an existing registry; it must be idempotent")
+	}
+}

--- a/landing/src/components/Comparison.jsx
+++ b/landing/src/components/Comparison.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { CheckCircle2, XCircle, Zap, AlertTriangle } from 'lucide-react';
+import { CheckCircle2, Layers, Zap } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 
 const Comparison = () => {
@@ -34,42 +34,39 @@ const Comparison = () => {
     },
   };
 
-  const features = [
+  const capabilities = [
     {
       name: 'Air-Gapped Deployment',
-      agentic: 'Fully offline — no egress, no callbacks',
-      kagent: 'Cloud-connected enterprise tier required',
-      agenticWins: true,
-      description: 'FedRAMP · HIPAA · Sovereign cloud',
+      description: 'FedRAMP, HIPAA, sovereign cloud',
+      detail: 'Fully offline. No egress, no callbacks, no cloud control plane.',
     },
     {
-      name: 'Outcome-Based Billing',
-      agentic: 'Per-workload cost tracking and budget controls',
-      kagent: 'No cost metering or budget enforcement',
-      agenticWins: true,
+      name: 'Per-Workload Cost Attribution',
       description: 'Chargeback to business units',
+      detail: 'Per-workload cost tracking with budget controls and tenant isolation.',
     },
     {
       name: 'DAG Workflow Orchestration',
-      agentic: 'Argo Workflows — fan-out, retries, DAGs',
-      kagent: 'Agent runtime only, no DAG equivalent',
-      agenticWins: true,
       description: 'Multi-step agent pipelines',
+      detail: 'Argo Workflows for fan-out, retries, and DAGs.',
     },
     {
-      name: 'Per-Tenant Cost Isolation',
-      agentic: 'Namespace quota + token budget per tenant',
-      kagent: 'No tenant-level cost attribution',
-      agenticWins: true,
-      description: 'Multi-tenant SaaS & regulated orgs',
+      name: 'Multi-Tenant Isolation',
+      description: 'Multi-tenant SaaS and regulated orgs',
+      detail: 'Namespace quota plus token budget per tenant.',
     },
     {
       name: 'Open Source Core',
-      agentic: 'Apache 2.0 — self-hostable, air-gapped',
-      kagent: 'CNCF Sandbox, enterprise tier is SaaS',
-      agenticWins: true,
       description: 'Zero vendor lock-in',
+      detail: 'Apache 2.0. Self-hostable and air-gapped.',
     },
+  ];
+
+  const runtimes = [
+    { name: 'NineVigil AgentWorkload', supported: true },
+    { name: 'CNCF agent runtimes (kagent, etc.)', supported: true },
+    { name: 'Custom agent pods', supported: true },
+    { name: 'Kubeflow pipelines', supported: true },
   ];
 
   return (
@@ -96,9 +93,9 @@ const Comparison = () => {
               border: `1px solid ${currentTheme.accent.teal}66`,
             }}
           >
-            <Zap size={16} style={{ color: currentTheme.accent.teal }} />
+            <Layers size={16} style={{ color: currentTheme.accent.teal }} />
             <span className="text-sm font-semibold" style={{ color: currentTheme.accent.teal }}>
-              Agentic Operator vs kagent
+              Governance Plane
             </span>
           </div>
           <h2
@@ -114,15 +111,15 @@ const Comparison = () => {
                 backgroundClip: 'text',
               }}
             >
-              cannot use the cloud
+              cannot skip audit
             </span>
           </h2>
           <p className="text-lg max-w-2xl mx-auto" style={{ color: currentTheme.text.tertiary }}>
-            kagent is excellent for cloud-connected teams. We are the only option for environments where data cannot leave the network.
+            NineVigil adds regulated controls around any Kubernetes agent runtime. The runtime handles lifecycle. We handle compliance.
           </p>
         </motion.div>
 
-        {/* Comparison Table */}
+        {/* Capabilities */}
         <motion.div
           className="space-y-4 mb-12"
           initial="hidden"
@@ -130,85 +127,37 @@ const Comparison = () => {
           viewport={{ once: true, amount: 0.2 }}
           variants={containerVariants}
         >
-          {/* Header Row */}
-          <motion.div
-            className="grid grid-cols-[1fr_1fr_1fr] gap-6 mb-6 px-6 py-4 rounded-lg"
-            style={{
-              backgroundColor: `${currentTheme.bg.secondary}CC`,
-              border: `1px solid ${currentTheme.border.light}`,
-            }}
-            variants={itemVariants}
-          >
-            <div className="font-semibold text-sm" style={{ color: currentTheme.text.tertiary }}>
-              Capability
-            </div>
-            <div className="text-center">
-              <div className="font-bold text-base" style={{ color: currentTheme.accent.teal }}>
-                NineVigil
-              </div>
-              <div className="text-xs mt-1" style={{ color: currentTheme.text.muted }}>
-                Apache 2.0 · Zero-egress
-              </div>
-            </div>
-            <div className="text-center">
-              <div className="font-bold text-base" style={{ color: currentTheme.text.tertiary }}>
-                kagent (Solo.io)
-              </div>
-              <div className="text-xs mt-1" style={{ color: currentTheme.text.muted }}>
-                CNCF Sandbox · Cloud-connected
-              </div>
-            </div>
-          </motion.div>
-
-          {/* Feature Rows */}
-          {features.map((feature, idx) => (
+          {capabilities.map((cap, idx) => (
             <motion.div
               key={idx}
-              className="grid grid-cols-[1fr_1fr_1fr] gap-6 px-6 py-5 rounded-lg transition-colors duration-200"
+              className="flex items-start gap-4 px-6 py-5 rounded-lg transition-colors duration-200"
               style={{
                 background: `linear-gradient(to right, ${currentTheme.bg.secondary}99, ${currentTheme.bg.secondary}66)`,
                 border: `1px solid ${currentTheme.border.light}`,
               }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.borderColor = currentTheme.border.medium;
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.borderColor = currentTheme.border.light;
-              }}
+              onMouseEnter={(e) => { e.currentTarget.style.borderColor = currentTheme.border.medium; }}
+              onMouseLeave={(e) => { e.currentTarget.style.borderColor = currentTheme.border.light; }}
               variants={itemVariants}
             >
-              {/* Feature Name */}
+              <CheckCircle2 size={20} className="flex-shrink-0 mt-0.5" style={{ color: currentTheme.accent.teal }} />
               <div>
                 <div className="font-semibold text-sm" style={{ color: currentTheme.text.primary }}>
-                  {feature.name}
+                  {cap.name}
                 </div>
-                <div className="text-xs mt-1.5" style={{ color: currentTheme.text.muted }}>
-                  {feature.description}
+                <div className="text-sm mt-1" style={{ color: currentTheme.text.secondary }}>
+                  {cap.detail}
                 </div>
-              </div>
-
-              {/* Agentic Column */}
-              <div className="flex items-center gap-3">
-                <CheckCircle2 size={20} className="flex-shrink-0" style={{ color: currentTheme.accent.teal }} />
-                <span className="text-sm" style={{ color: currentTheme.text.primary }}>
-                  {feature.agentic}
-                </span>
-              </div>
-
-              {/* kagent Column */}
-              <div className="flex items-center gap-3">
-                <XCircle size={20} className="flex-shrink-0" style={{ color: currentTheme.text.tertiary }} />
-                <span className="text-sm" style={{ color: currentTheme.text.tertiary }}>
-                  {feature.kagent}
-                </span>
+                <div className="text-xs mt-1" style={{ color: currentTheme.text.muted }}>
+                  {cap.description}
+                </div>
               </div>
             </motion.div>
           ))}
         </motion.div>
 
-        {/* Context callout */}
+        {/* Compatible runtimes */}
         <motion.div
-          className="mb-12 px-6 py-5 rounded-xl"
+          className="mb-12 px-6 py-6 rounded-xl"
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true, amount: 0.3 }}
@@ -221,14 +170,23 @@ const Comparison = () => {
             border: `1px solid ${currentTheme.accent.teal}33`,
           }}
         >
-          <div className="flex items-start gap-3">
-            <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" style={{ color: currentTheme.accent.teal }} />
-            <p className="text-sm leading-relaxed" style={{ color: currentTheme.text.tertiary }}>
-              <span className="font-semibold" style={{ color: currentTheme.text.primary }}>kagent validates this market.</span>{' '}
-              When Google, Microsoft, IBM, and Red Hat all contribute to a Kubernetes agent runtime, you don&apos;t need to convince anyone the category is real. But their enterprise revenue depends on telemetry, licensing callbacks, and managed control planes — a structural conflict with air-gapped and regulated buyers.{' '}
-              <span className="font-semibold" style={{ color: currentTheme.accent.teal }}>These are different buyers. That&apos;s our market.</span>
-            </p>
+          <div className="flex items-center gap-2 mb-4">
+            <Zap size={16} style={{ color: currentTheme.accent.teal }} />
+            <span className="font-semibold text-sm" style={{ color: currentTheme.text.primary }}>
+              Compatible agent runtimes
+            </span>
           </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {runtimes.map((rt, idx) => (
+              <div key={idx} className="flex items-center gap-2">
+                <CheckCircle2 size={16} style={{ color: currentTheme.accent.teal }} />
+                <span className="text-sm" style={{ color: currentTheme.text.secondary }}>{rt.name}</span>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs mt-4" style={{ color: currentTheme.text.muted }}>
+            The runtime handles agent lifecycle and tools. NineVigil handles multi-tenancy, audit, spend, and air-gapped compliance. Use both.
+          </p>
         </motion.div>
 
         {/* CTA Section */}

--- a/naming-decision.md
+++ b/naming-decision.md
@@ -1,0 +1,82 @@
+# Naming Decision — ACP protocol + Agentic Operator
+
+Date: 2026-06-16. Status: RESEARCH COMPLETE. Needs human approval (gate A2).
+Author: ralph loop, Lane A1.
+
+## TL;DR recommendation
+
+- Protocol: STOP using the bare acronym "ACP". It is triple-claimed and one
+  claimant sits in our exact space. Pick a unique product mark and keep
+  "Agent Contract Protocol" only as a descriptive subtitle.
+  Recommended mark: `Concord` (full: "Concord: an Agent Contract Protocol").
+  Runner-up: `Tacit`. Both pending a 10-minute availability check at rename time.
+- Operator: keep the public repo name `agentic-operator-core`. It already has
+  history and a star. Do NOT rebrand the repo. DO move the Go module path off
+  the personal handle. Use `github.com/clawdlinux/agentic-operator`.
+
+## Human decision needed (gate A2)
+1. Approve a protocol mark: `Concord`, `Tacit`, or your own. One word back.
+2. Approve the operator module path: `github.com/clawdlinux/agentic-operator`.
+3. Confirm we keep "Agent Contract Protocol" as the descriptive subtitle (the
+   contract framing matches declared intent + ordering + auth-out-of-context).
+
+## Why "ACP" is dead (evidence, verified 2026-06-16)
+
+The acronym collides at least three ways. Two are confirmed by direct fetch:
+
+- agent-context-protocol — live GitHub org. Repo self-describes as "The first
+  protocol for multi-agent communication and coordination." 8 stars, MIT,
+  active 2025. https://github.com/agent-context-protocol
+- Agent Client Protocol (Zed) — brands itself "ACP" on the landing page,
+  standardizes editor<->coding-agent comms, JSON-RPC over stdio, reuses MCP
+  JSON. This is our exact adjacent space and our exact transport story (stdio +
+  MCP reuse). https://agentclientprotocol.com  repo:
+  https://github.com/agentclientprotocol/agent-client-protocol
+- Agent Communication Protocol (IBM / Linux Foundation, BeeAI lineage) — widely
+  cited "ACP". Known prior art; not re-fetched this run, verify the URL before
+  citing it in the paper.
+
+Conclusion: the acronym is unwinnable. Zed's ACP alone is fatal for
+differentiation because it shares our transport and MCP-reuse story. Nobody can
+search, cite, or star a fourth "ACP". The arXiv paper title would land in
+contested namespace on day one.
+
+## Candidate scoring (protocol)
+
+Availability columns marked CHECK could not be auto-verified: pypi.org returns a
+browser-challenge to the fetcher. Verify with `pip index versions <name>` or a
+browser at rename time before committing the name.
+
+| Candidate | Acronym risk | GitHub org | PyPI name | Paper-title unique | Describes wedge | Verdict |
+|---|---|---|---|---|---|---|
+| Keep "Agent Contract Protocol" (ACP) | FAIL — triple-claimed, Zed in-space | n/a | n/a | FAIL | yes | reject the acronym, keep as subtitle only |
+| Concord (concord-protocol) | low — common word, not an agent-protocol | CHECK | CHECK (concord-protocol / pyconcord) | likely unique as "Concord agent contract protocol" | medium — "agreement/contract between agent and tools" | RECOMMEND |
+| Tacit (tacit-protocol) | low | CHECK | CHECK | likely unique | medium — "tacit contract" / implied intent | runner-up |
+| Intent Resolution Protocol (IRP) | medium — IRP = I/O Request Packet, routing | CHECK | CHECK | medium | high — names the mechanism | viable but acronym noise |
+
+Rationale for `Concord`: it is a real word meaning agreement/contract, which
+maps onto the product (a declared contract between an agent and its tools). It
+gives a clean, ownable namespace (concord-protocol, pyconcord) away from the ACP
+acronym wars, while "Agent Contract Protocol" survives as the honest one-line
+descriptor. `Tacit` is the runner-up: shorter, evocative of implied/declared
+intent, but less self-explanatory.
+
+## Operator
+
+- Public name: keep `agentic-operator-core`. Changing the slug throws away the
+  little history and the one star, and the name is fine. The README is the real
+  problem, not the name (handled in Lane B3).
+- Go module path: today it is `github.com/shreyansh/agentic-operator`, a
+  personal handle. This reads unserious and ties the import path to one person.
+  Move it to `github.com/clawdlinux/agentic-operator` to match the public org.
+  This is a v0.x project, so a module-path change is acceptable now and only
+  gets more expensive later.
+- This rename touches go.mod, every internal import, and any `go install` URL in
+  docs. It is the A4 human gate. Stage it as a script, do not run it unattended.
+
+## Next steps
+- A2 (human): pick the mark + confirm module path.
+- A3 (loop, local): mechanical rename of README/paper/docs/package metadata to
+  the approved mark. Verify PyPI + GitHub-org availability first.
+- A4 (human): repo-slug decision (operator: keep) + run the staged
+  module-path rename script.

--- a/pkg/agentctl/cost_test.go
+++ b/pkg/agentctl/cost_test.go
@@ -1,0 +1,60 @@
+package agentctl
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCostSummaryAggregatesLiteLLMRecords(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spend/logs" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[
+{"metadata":{"workload":"demo","namespace":"team-a","model":"gpt-4o"},"prompt_tokens":10,"completion_tokens":5,"cost":0.2},
+{"metadata":{"workload":"demo","namespace":"team-a","model":"gpt-4o"},"tokens":7,"spend":0.3},
+{"metadata":{"workload":"other","namespace":"team-b","model":"gpt-4o-mini"},"tokens":100,"spend":1.0}
+]}`))
+	}))
+	defer server.Close()
+
+	rows, err := (&Client{}).CostSummary(context.Background(), server.URL, "team-a", false)
+	if err != nil {
+		t.Fatalf("CostSummary returned error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Workload != "demo" || row.Namespace != "team-a" || row.Model != "gpt-4o" {
+		t.Fatalf("row identity = %#v", row)
+	}
+	if row.TokensToday != 22 {
+		t.Fatalf("tokens = %d, want 22", row.TokensToday)
+	}
+	if row.CostToday != 0.5 {
+		t.Fatalf("cost = %f, want 0.5", row.CostToday)
+	}
+}
+
+func TestCostSummaryMalformedJSONReturnsNoRows(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":`))
+	}))
+	defer server.Close()
+
+	rows, err := (&Client{}).CostSummary(context.Background(), server.URL, "team-a", false)
+	if err != nil {
+		t.Fatalf("CostSummary returned error: %v", err)
+	}
+	if rows != nil {
+		t.Fatalf("rows = %#v, want nil", rows)
+	}
+}

--- a/pkg/agentctl/runtimepods_test.go
+++ b/pkg/agentctl/runtimepods_test.go
@@ -1,0 +1,69 @@
+package agentctl
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestListRuntimePodsReturnsAgentWorkloadPods(t *testing.T) {
+	client := &Client{
+		Kube: fake.NewClientset(
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secure-research-swarm-runner",
+					Namespace: "argo-workflows",
+					Labels: map[string]string{
+						"agentic.io/job-id": "secure-research-swarm",
+						RoleLabelKey:        "researcher",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName:         "demo-node-1",
+					RuntimeClassName: stringPtr("gvisor"),
+					Containers: []corev1.Container{{
+						Name:  "agent",
+						Image: "ghcr.io/clawdlinux/research-agent:v0.2.0",
+					}},
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated",
+					Namespace: "default",
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			},
+		),
+	}
+
+	rows, err := client.ListRuntimePods(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListRuntimePods() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+
+	row := rows[0]
+	if row.Workload != "secure-research-swarm" {
+		t.Fatalf("Workload = %q, want secure-research-swarm", row.Workload)
+	}
+	if row.Role != "researcher" {
+		t.Fatalf("Role = %q, want researcher", row.Role)
+	}
+	if row.RuntimeClass != "gvisor" {
+		t.Fatalf("RuntimeClass = %q, want gvisor", row.RuntimeClass)
+	}
+	if row.Image != "ghcr.io/clawdlinux/research-agent:v0.2.0" {
+		t.Fatalf("Image = %q", row.Image)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/pkg/agentctl/status_test.go
+++ b/pkg/agentctl/status_test.go
@@ -16,7 +16,7 @@ import (
 func TestClusterStatusCountsWorkloadsAndComponents(t *testing.T) {
 	t.Parallel()
 
-	kube := fake.NewSimpleClientset(
+	kube := fake.NewClientset(
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "litellm", Namespace: "shared-services"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "postgres", Namespace: "shared-services"}},
 		&appsv1.Deployment{
@@ -51,7 +51,7 @@ func TestClusterStatusCountsWorkloadsAndComponents(t *testing.T) {
 func TestClusterStatusDiscoveryError(t *testing.T) {
 	t.Parallel()
 
-	kube := fake.NewSimpleClientset()
+	kube := fake.NewClientset()
 	kube.Fake.PrependReactor("get", "version", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("discovery failed")
 	})

--- a/pkg/agentctl/status_test.go
+++ b/pkg/agentctl/status_test.go
@@ -1,0 +1,63 @@
+package agentctl
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestClusterStatusCountsWorkloadsAndComponents(t *testing.T) {
+	t.Parallel()
+
+	kube := fake.NewSimpleClientset(
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "litellm", Namespace: "shared-services"}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "postgres", Namespace: "shared-services"}},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "agentic-operator", Namespace: DefaultOperatorNamespace, Labels: map[string]string{"control-plane": "controller-manager"}},
+			Spec:       appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "ghcr.io/clawdlinux/agentic-operator:v0.4.0"}}}}},
+		},
+	)
+	client := &Client{
+		Dynamic:   newAgentctlDynamicClient(newAgentWorkloadObject("demo", "team-a", "Completed", "openai/gpt-4o", "0.25")),
+		Kube:      kube,
+		Discovery: kube.Discovery(),
+	}
+
+	summary, err := client.ClusterStatus(context.Background(), DefaultOperatorNamespace)
+	if err != nil {
+		t.Fatalf("ClusterStatus returned error: %v", err)
+	}
+	if summary.TotalWorkloads != 1 {
+		t.Fatalf("total workloads = %d, want 1", summary.TotalWorkloads)
+	}
+	if summary.PhaseCounts["Completed"] != 1 {
+		t.Fatalf("Completed count = %d, want 1", summary.PhaseCounts["Completed"])
+	}
+	if summary.TotalCostToday != 0.25 {
+		t.Fatalf("total cost = %f, want 0.25", summary.TotalCostToday)
+	}
+	if summary.OperatorVersion != "v0.4.0" {
+		t.Fatalf("operator version = %q, want v0.4.0", summary.OperatorVersion)
+	}
+}
+
+func TestClusterStatusDiscoveryError(t *testing.T) {
+	t.Parallel()
+
+	kube := fake.NewSimpleClientset()
+	kube.Fake.PrependReactor("get", "version", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("discovery failed")
+	})
+	client := &Client{Discovery: kube.Discovery()}
+	_, err := client.ClusterStatus(context.Background(), "default")
+	if err == nil {
+		t.Fatal("expected discovery error")
+	}
+}

--- a/pkg/agentctl/types.go
+++ b/pkg/agentctl/types.go
@@ -31,6 +31,20 @@ type WorkflowStep struct {
 	EndedAt   string `json:"endedAt"`
 }
 
+// RuntimePodRow represents a pod running an agent workload.
+type RuntimePodRow struct {
+	Name         string `json:"name"`
+	Namespace    string `json:"namespace"`
+	Workload     string `json:"workload"`
+	Role         string `json:"role"`
+	Phase        string `json:"phase"`
+	RuntimeClass string `json:"runtimeClass"`
+	Node         string `json:"node"`
+	Image        string `json:"image"`
+	Age          string `json:"age"`
+	Restarts     int32  `json:"restarts"`
+}
+
 // ComponentStatus represents the health of a cluster component.
 type ComponentStatus struct {
 	Name      string `json:"name"`

--- a/pkg/agentctl/workloads.go
+++ b/pkg/agentctl/workloads.go
@@ -101,6 +101,74 @@ func (c *Client) fetchWorkflowSteps(ctx context.Context, workloadName string) ([
 	return steps, nil
 }
 
+// ListRuntimePods returns pods that appear to be running agent workloads.
+func (c *Client) ListRuntimePods(ctx context.Context, ns string) ([]RuntimePodRow, error) {
+	pods, err := c.Kube.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list runtime pods: %w", err)
+	}
+
+	rows := make([]RuntimePodRow, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		workload := podWorkloadName(pod.Labels)
+		if workload == "" {
+			continue
+		}
+
+		rows = append(rows, RuntimePodRow{
+			Name:         pod.Name,
+			Namespace:    pod.Namespace,
+			Workload:     workload,
+			Role:         SafeText(pod.Labels[RoleLabelKey], "agent"),
+			Phase:        string(pod.Status.Phase),
+			RuntimeClass: podRuntimeClass(&pod),
+			Node:         SafeText(pod.Spec.NodeName, "pending"),
+			Image:        containerImage(pod.Spec.Containers),
+			Age:          AgeString(pod.CreationTimestamp),
+			Restarts:     restartCount(pod.Status.ContainerStatuses),
+		})
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Namespace == rows[j].Namespace {
+			return rows[i].Name < rows[j].Name
+		}
+		return rows[i].Namespace < rows[j].Namespace
+	})
+
+	return rows, nil
+}
+
+func podWorkloadName(labels map[string]string) string {
+	return FirstNonEmpty(
+		labels["agentic.io/job-id"],
+		labels["workflows.argoproj.io/workflow"],
+		labels["agentworkload.clawdlinux.io/name"],
+	)
+}
+
+func podRuntimeClass(pod *corev1.Pod) string {
+	if pod.Spec.RuntimeClassName == nil || strings.TrimSpace(*pod.Spec.RuntimeClassName) == "" {
+		return "default"
+	}
+	return *pod.Spec.RuntimeClassName
+}
+
+func containerImage(containers []corev1.Container) string {
+	if len(containers) == 0 {
+		return ""
+	}
+	return containers[0].Image
+}
+
+func restartCount(statuses []corev1.ContainerStatus) int32 {
+	var total int32
+	for _, status := range statuses {
+		total += status.RestartCount
+	}
+	return total
+}
+
 // FindRuntimePod finds the pod associated with a workload name.
 func (c *Client) FindRuntimePod(ctx context.Context, workloadName string) (podName, podNamespace, role string, err error) {
 	selectors := []string{

--- a/pkg/agentctl/workloads_test.go
+++ b/pkg/agentctl/workloads_test.go
@@ -1,0 +1,125 @@
+package agentctl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+func TestListWorkloadsReturnsSortedRows(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{Dynamic: newAgentctlDynamicClient(
+		newAgentWorkloadObject("beta", "team-b", "Running", "openai/gpt-4o", "0.25"),
+		newAgentWorkloadObject("alpha", "team-a", "Completed", "openai/gpt-4o-mini", "0.10"),
+	)}
+
+	rows, err := client.ListWorkloads(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListWorkloads returned error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].Name != "alpha" || rows[0].Namespace != "team-a" {
+		t.Fatalf("first row = %s/%s, want team-a/alpha", rows[0].Namespace, rows[0].Name)
+	}
+	if rows[0].Status != "Completed" {
+		t.Fatalf("status = %q, want Completed", rows[0].Status)
+	}
+	if rows[0].CostToday != 0.10 {
+		t.Fatalf("cost = %f, want 0.10", rows[0].CostToday)
+	}
+}
+
+func TestDescribeWorkloadReturnsSpecAndWorkflowSteps(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{Dynamic: newAgentctlDynamicClient(
+		newAgentWorkloadObject("demo", "team-a", "Running", "openai/gpt-4o", "0.25"),
+		newWorkflowObject("demo"),
+	)}
+
+	detail, err := client.DescribeWorkload(context.Background(), "team-a", "demo")
+	if err != nil {
+		t.Fatalf("DescribeWorkload returned error: %v", err)
+	}
+	if detail.Phase != "Running" {
+		t.Fatalf("phase = %q, want Running", detail.Phase)
+	}
+	if detail.Spec["model"] != "openai/gpt-4o" {
+		t.Fatalf("spec model = %v", detail.Spec["model"])
+	}
+	if len(detail.Steps) != 2 {
+		t.Fatalf("steps = %d, want 2", len(detail.Steps))
+	}
+	if detail.Steps[0].Name != "report" {
+		t.Fatalf("first step = %q, want report", detail.Steps[0].Name)
+	}
+}
+
+func TestDescribeWorkloadMissingReturnsError(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{Dynamic: newAgentctlDynamicClient()}
+	_, err := client.DescribeWorkload(context.Background(), "team-a", "missing")
+	if err == nil {
+		t.Fatal("expected error for missing workload")
+	}
+}
+
+func newAgentctlDynamicClient(objects ...runtime.Object) *fake.FakeDynamicClient {
+	return fake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			AgentWorkloadGVR: "AgentWorkloadList",
+			WorkflowGVR:      "WorkflowList",
+		},
+		objects...,
+	)
+}
+
+func newAgentWorkloadObject(name, namespace, phase, model, cost string) *unstructured.Unstructured {
+	createdAt := metav1.NewTime(time.Now().Add(-time.Minute))
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "agentic.clawdlinux.org/v1alpha1",
+		"kind":       "AgentWorkload",
+		"metadata": map[string]interface{}{
+			"name":              name,
+			"namespace":         namespace,
+			"creationTimestamp": createdAt.Format(time.RFC3339),
+			"annotations": map[string]interface{}{
+				CostAnnotationKey: cost,
+			},
+		},
+		"spec": map[string]interface{}{
+			"model": model,
+		},
+		"status": map[string]interface{}{
+			"phase": phase,
+		},
+	}}
+}
+
+func newWorkflowObject(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Workflow",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": DefaultArgoNamespace,
+		},
+		"status": map[string]interface{}{
+			"nodes": map[string]interface{}{
+				"a": map[string]interface{}{"displayName": "collect", "phase": "Succeeded", "startedAt": "2026-05-27T01:00:00Z"},
+				"b": map[string]interface{}{"displayName": "report", "phase": "Running", "startedAt": "2026-05-27T02:00:00Z"},
+			},
+		},
+	}}
+}

--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -8,7 +8,9 @@ package audit_test
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -310,6 +312,100 @@ func TestRecorder_ResumesFromHead(t *testing.T) {
 	all := be.All()
 	if e.PrevHash != all[2].EntryHash {
 		t.Errorf("prev_hash after restart != entry[2].EntryHash")
+	}
+}
+
+func TestRecorder_EndToEnd_LargeChain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h := newHasher(t, "k1")
+	be := audit.NewMemoryBackend()
+	r, err := audit.NewRecorder(ctx, h, be, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 25; i++ {
+		_, err := r.Append(ctx, audit.Entry{
+			TenantID:      "t1",
+			AgentWorkload: "demo-workload",
+			Actor:         "system",
+			Action:        audit.ActionStateChange,
+			SubjectID:     fmt.Sprintf("state-%02d", i),
+			PayloadCanon:  []byte(fmt.Sprintf(`{"step":%d}`, i)),
+		})
+		if err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	v, err := audit.NewVerifier(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := v.Walk(ctx, be.All())
+	if report.FirstError != nil {
+		t.Fatalf("large chain rejected: %v", report.FirstError)
+	}
+	if report.OK != 25 {
+		t.Fatalf("verified entries = %d, want 25", report.OK)
+	}
+}
+
+func TestRecorder_ConcurrentAppend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	h := newHasher(t, "k1")
+	be := audit.NewMemoryBackend()
+	r, err := audit.NewRecorder(ctx, h, be, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const goroutines = 50
+	const entriesPerGoroutine = 10
+	errCh := make(chan error, goroutines*entriesPerGoroutine)
+	var wg sync.WaitGroup
+	for worker := 0; worker < goroutines; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < entriesPerGoroutine; i++ {
+				_, err := r.Append(ctx, audit.Entry{
+					TenantID:      "t1",
+					AgentWorkload: "demo-workload",
+					Actor:         "system",
+					Action:        audit.ActionToolCall,
+					SubjectID:     fmt.Sprintf("worker-%02d-%02d", worker, i),
+					PayloadCanon:  []byte(`{"ok":true}`),
+				})
+				if err != nil {
+					errCh <- err
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("append failed: %v", err)
+		}
+	}
+
+	v, err := audit.NewVerifier(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := v.Walk(ctx, be.All())
+	if report.FirstError != nil {
+		t.Fatalf("concurrent chain rejected: %v", report.FirstError)
+	}
+	if report.OK != goroutines*entriesPerGoroutine {
+		t.Fatalf("verified entries = %d, want %d", report.OK, goroutines*entriesPerGoroutine)
 	}
 }
 

--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -364,8 +364,10 @@ func TestRecorder_ConcurrentAppend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const goroutines = 50
-	const entriesPerGoroutine = 10
+	const goroutines = 20
+	const entriesPerGoroutine = 5
+	const expectedEntries = goroutines * entriesPerGoroutine
+
 	errCh := make(chan error, goroutines*entriesPerGoroutine)
 	var wg sync.WaitGroup
 	for worker := 0; worker < goroutines; worker++ {
@@ -396,16 +398,21 @@ func TestRecorder_ConcurrentAppend(t *testing.T) {
 		}
 	}
 
+	entries := be.All()
+	if len(entries) != expectedEntries {
+		t.Fatalf("entries = %d, want %d", len(entries), expectedEntries)
+	}
+
 	v, err := audit.NewVerifier(h)
 	if err != nil {
 		t.Fatal(err)
 	}
-	report := v.Walk(ctx, be.All())
+	report := v.Walk(ctx, entries)
 	if report.FirstError != nil {
 		t.Fatalf("concurrent chain rejected: %v", report.FirstError)
 	}
-	if report.OK != goroutines*entriesPerGoroutine {
-		t.Fatalf("verified entries = %d, want %d", report.OK, goroutines*entriesPerGoroutine)
+	if report.OK != expectedEntries {
+		t.Fatalf("verified entries = %d, want %d", report.OK, expectedEntries)
 	}
 }
 

--- a/pkg/evaluation/evaluator_test.go
+++ b/pkg/evaluation/evaluator_test.go
@@ -1,0 +1,52 @@
+package evaluation
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEvaluator_EvaluateStoresHistory(t *testing.T) {
+	t.Parallel()
+
+	e := NewEvaluator()
+	result, err := e.Evaluate(context.Background(), ExecutionRecord{WorkloadID: "wl-1", AgentName: "agent-a", Status: "success", Output: "validation passed with enough detail"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if result.Record.WorkloadID != "wl-1" {
+		t.Fatalf("workload = %q, want wl-1", result.Record.WorkloadID)
+	}
+	if len(e.GetHistory()) != 1 {
+		t.Fatalf("history length = %d, want 1", len(e.GetHistory()))
+	}
+}
+
+func TestEvaluator_GetAgentStatsFiltersByAgent(t *testing.T) {
+	t.Parallel()
+
+	e := NewEvaluator()
+	_, _ = e.Evaluate(context.Background(), ExecutionRecord{AgentName: "agent-a", Status: "success", Output: "complete validation output", EstimatedCostUSD: 0.2, DurationSeconds: 4})
+	_, _ = e.Evaluate(context.Background(), ExecutionRecord{AgentName: "agent-b", Status: "failure", ErrorMessage: "boom", EstimatedCostUSD: 0.6, DurationSeconds: 8})
+
+	stats, err := e.GetAgentStats(context.Background(), "agent-a")
+	if err != nil {
+		t.Fatalf("GetAgentStats returned error: %v", err)
+	}
+	if stats.TotalTasks != 1 || stats.SuccessTasks != 1 || stats.FailedTasks != 0 {
+		t.Fatalf("stats = %#v, want only agent-a success", stats)
+	}
+	if stats.SuccessRate != 100 {
+		t.Fatalf("success rate = %f, want 100", stats.SuccessRate)
+	}
+}
+
+func TestRecordEvaluation_NilDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RecordEvaluation panicked: %v", r)
+		}
+	}()
+	RecordEvaluation(nil)
+}

--- a/pkg/finops/memory_reporter.go
+++ b/pkg/finops/memory_reporter.go
@@ -44,8 +44,9 @@ type MemoryCostReporter struct {
 	budget  map[string]float64        // key: "namespace/workloadName" → max USD
 
 	// Prometheus metrics
-	costGauge   *prometheus.GaugeVec
-	tokensCount *prometheus.CounterVec
+	costGauge        *prometheus.GaugeVec
+	costDollarsGauge *prometheus.GaugeVec
+	tokensCount      *prometheus.CounterVec
 }
 
 // NewMemoryCostReporter creates a reporter with default public pricing.
@@ -54,6 +55,13 @@ func NewMemoryCostReporter() *MemoryCostReporter {
 		prometheus.GaugeOpts{
 			Name: "agentic_workload_cost_usd",
 			Help: "Estimated USD cost per workload (in-memory tracker)",
+		},
+		[]string{"workload", "namespace"},
+	)
+	costDollarsGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ninevigil_agent_cost_dollars",
+			Help: "Estimated USD cost per agent workload.",
 		},
 		[]string{"workload", "namespace"},
 	)
@@ -68,14 +76,16 @@ func NewMemoryCostReporter() *MemoryCostReporter {
 
 	// Best-effort registration (may already be registered in tests)
 	prometheus.Register(costGauge)
+	prometheus.Register(costDollarsGauge)
 	prometheus.Register(tokensCount)
 
 	return &MemoryCostReporter{
-		usage:       make(map[string]*WorkloadUsage),
-		pricing:     defaultPricing(),
-		budget:      make(map[string]float64),
-		costGauge:   costGauge,
-		tokensCount: tokensCount,
+		usage:            make(map[string]*WorkloadUsage),
+		pricing:          defaultPricing(),
+		budget:           make(map[string]float64),
+		costGauge:        costGauge,
+		costDollarsGauge: costDollarsGauge,
+		tokensCount:      tokensCount,
 	}
 }
 
@@ -140,6 +150,7 @@ func (m *MemoryCostReporter) RecordUsage(ctx context.Context, workloadName, name
 
 	// Update Prometheus metrics
 	m.costGauge.WithLabelValues(workloadName, namespace).Set(u.EstimatedCostUSD)
+	m.costDollarsGauge.WithLabelValues(workloadName, namespace).Set(u.EstimatedCostUSD)
 	m.tokensCount.WithLabelValues(workloadName, namespace, "prompt").Add(float64(promptTokens))
 	m.tokensCount.WithLabelValues(workloadName, namespace, "completion").Add(float64(completionTokens))
 
@@ -154,6 +165,10 @@ func (m *MemoryCostReporter) RecordUsage(ctx context.Context, workloadName, name
 		"totalCostUSD", fmt.Sprintf("%.6f", u.EstimatedCostUSD),
 	)
 	return nil
+}
+
+func (m *MemoryCostReporter) PrometheusCollector() prometheus.Collector {
+	return m.costDollarsGauge
 }
 
 // CheckBudget returns an error if the workload has exceeded its budget.

--- a/pkg/finops/memory_reporter.go
+++ b/pkg/finops/memory_reporter.go
@@ -63,7 +63,7 @@ func NewMemoryCostReporter() *MemoryCostReporter {
 			Name: "ninevigil_agent_cost_dollars",
 			Help: "Estimated USD cost per agent workload.",
 		},
-		[]string{"workload", "namespace"},
+		[]string{"workload", "namespace", "model"},
 	)
 
 	tokensCount := prometheus.NewCounterVec(
@@ -73,11 +73,6 @@ func NewMemoryCostReporter() *MemoryCostReporter {
 		},
 		[]string{"workload", "namespace", "type"},
 	)
-
-	// Best-effort registration (may already be registered in tests)
-	prometheus.Register(costGauge)
-	prometheus.Register(costDollarsGauge)
-	prometheus.Register(tokensCount)
 
 	return &MemoryCostReporter{
 		usage:            make(map[string]*WorkloadUsage),
@@ -150,7 +145,7 @@ func (m *MemoryCostReporter) RecordUsage(ctx context.Context, workloadName, name
 
 	// Update Prometheus metrics
 	m.costGauge.WithLabelValues(workloadName, namespace).Set(u.EstimatedCostUSD)
-	m.costDollarsGauge.WithLabelValues(workloadName, namespace).Set(u.EstimatedCostUSD)
+	m.costDollarsGauge.WithLabelValues(workloadName, namespace, model).Set(u.EstimatedCostUSD)
 	m.tokensCount.WithLabelValues(workloadName, namespace, "prompt").Add(float64(promptTokens))
 	m.tokensCount.WithLabelValues(workloadName, namespace, "completion").Add(float64(completionTokens))
 
@@ -223,6 +218,6 @@ func (m *MemoryCostReporter) GetUsage(workloadName, namespace string) *WorkloadU
 		return nil
 	}
 	// Return copy to avoid race
-	copy := *u
-	return &copy
+	usageCopy := *u
+	return &usageCopy
 }

--- a/pkg/finops/memory_reporter_test.go
+++ b/pkg/finops/memory_reporter_test.go
@@ -3,6 +3,8 @@ package finops
 import (
 	"context"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestMemoryCostReporter_RecordAndQuery(t *testing.T) {
@@ -110,4 +112,38 @@ func TestMemoryCostReporter_OllamaFree(t *testing.T) {
 	if cost != 0.0 {
 		t.Errorf("Expected $0.00 for local Ollama model, got $%.6f", cost)
 	}
+}
+
+func TestMemoryCostReporter_PrometheusCollectorEmitsNineVigilCostMetric(t *testing.T) {
+	t.Parallel()
+
+	r := NewMemoryCostReporter()
+	ctx := context.Background()
+	if err := r.RecordUsage(ctx, "demo-workload", "demo-ns", "openai/gpt-4o-mini", 1000, 500); err != nil {
+		t.Fatalf("RecordUsage failed: %v", err)
+	}
+
+	registry := prometheus.NewRegistry()
+	if err := registry.Register(r.PrometheusCollector()); err != nil {
+		t.Fatalf("register collector: %v", err)
+	}
+
+	metricFamilies, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, family := range metricFamilies {
+		if family.GetName() != "ninevigil_agent_cost_dollars" {
+			continue
+		}
+		if len(family.GetMetric()) != 1 {
+			t.Fatalf("metric count = %d, want 1", len(family.GetMetric()))
+		}
+		got := family.GetMetric()[0].GetGauge().GetValue()
+		if got != 0.00045 {
+			t.Fatalf("cost metric = %f, want 0.00045", got)
+		}
+		return
+	}
+	t.Fatal("ninevigil_agent_cost_dollars metric not found")
 }

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -27,8 +27,10 @@ import (
 
 // MCPClient is a tool-agnostic client for calling MCP servers
 type MCPClient struct {
-	endpoint string
-	client   *http.Client
+	endpoint     string
+	client       *http.Client
+	maxRetries   int
+	retryBackoff time.Duration
 }
 
 // ToolRequest is the payload sent to the MCP server
@@ -92,14 +94,27 @@ func NewMCPClient(endpoint string) *MCPClient {
 		client: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		maxRetries:   2,
+		retryBackoff: 50 * time.Millisecond,
 	}
 }
 
 // ListTools queries the MCP server for available tools
 func (c *MCPClient) ListTools() ([]string, error) {
-	resp, err := c.client.Get(fmt.Sprintf("%s/tools", c.endpoint))
-	if err != nil {
-		return nil, fmt.Errorf("failed to list tools: %w", err)
+	var resp *http.Response
+	var err error
+	url := fmt.Sprintf("%s/tools", c.endpoint)
+	for attempt := 0; attempt <= c.maxRetries; attempt++ {
+		resp, err = c.client.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list tools: %w", err)
+		}
+		if !retryableStatus(resp.StatusCode) || attempt == c.maxRetries {
+			break
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		time.Sleep(c.retryBackoff)
 	}
 	defer resp.Body.Close()
 
@@ -132,13 +147,19 @@ func (c *MCPClient) CallTool(toolName string, params map[string]interface{}) (ma
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := c.client.Post(
-		fmt.Sprintf("%s/call_tool", c.endpoint),
-		"application/json",
-		bytes.NewReader(payload),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call tool: %w", err)
+	var resp *http.Response
+	url := fmt.Sprintf("%s/call_tool", c.endpoint)
+	for attempt := 0; attempt <= c.maxRetries; attempt++ {
+		resp, err = c.client.Post(url, "application/json", bytes.NewReader(payload))
+		if err != nil {
+			return nil, fmt.Errorf("failed to call tool: %w", err)
+		}
+		if !retryableStatus(resp.StatusCode) || attempt == c.maxRetries {
+			break
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		time.Sleep(c.retryBackoff)
 	}
 	defer resp.Body.Close()
 
@@ -157,4 +178,8 @@ func (c *MCPClient) CallTool(toolName string, params map[string]interface{}) (ma
 	}
 
 	return toolResp.Result, nil
+}
+
+func retryableStatus(status int) bool {
+	return status >= http.StatusInternalServerError && status <= 599
 }

--- a/pkg/mcp/client_test.go
+++ b/pkg/mcp/client_test.go
@@ -18,6 +18,10 @@ package mcp
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -159,4 +163,77 @@ func TestToolRequest_Marshalling(t *testing.T) {
 	}
 
 	t.Logf("Successfully marshalled request: %s", string(data))
+}
+
+func TestMCPClient_CallToolTimesOutOnSlowServer(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(20 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"tool":"slow","success":true,"result":{}}`))
+	}))
+	defer server.Close()
+
+	client := NewMCPClient(server.URL)
+	client.client.Timeout = time.Millisecond
+	client.maxRetries = 0
+
+	_, err := client.CallTool("slow", map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "Client.Timeout") && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("error = %v, want timeout", err)
+	}
+}
+
+func TestMCPClient_CallToolMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tool":"get_status","success":true,"result":`))
+	}))
+	defer server.Close()
+
+	client := NewMCPClient(server.URL)
+	client.maxRetries = 0
+
+	_, err := client.CallTool("get_status", map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected malformed JSON error")
+	}
+	if !strings.Contains(err.Error(), "failed to decode tool response") {
+		t.Fatalf("error = %v, want decode error", err)
+	}
+}
+
+func TestMCPClient_CallToolRetriesTransientServerError(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ToolResponse{Tool: "get_status", Success: true, Result: map[string]interface{}{"status": "healthy"}})
+	}))
+	defer server.Close()
+
+	client := NewMCPClient(server.URL)
+	client.maxRetries = 1
+	client.retryBackoff = time.Millisecond
+
+	result, err := client.CallTool("get_status", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if got := result["status"]; got != "healthy" {
+		t.Fatalf("status = %v, want healthy", got)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
 }

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -1,0 +1,65 @@
+package mcp
+
+import "testing"
+
+func TestRegisteredToolsIncludesDemoCriticalTools(t *testing.T) {
+	t.Parallel()
+
+	tools := registeredTools()
+	seen := map[string]bool{}
+	for _, tool := range tools {
+		seen[string(tool.Name)] = true
+	}
+	for _, name := range []ToolName{ToolCreateWorkload, ToolGetWorkloadStatus, ToolListWorkloads, ToolGetWorkloadLogs, ToolGetWorkloadCost, ToolDeleteWorkload} {
+		if !seen[string(name)] {
+			t.Fatalf("tool %q missing", name)
+		}
+	}
+}
+
+func TestRegisteredToolsRejectDuplicateNames(t *testing.T) {
+	t.Parallel()
+
+	seen := map[string]bool{}
+	for _, tool := range registeredTools() {
+		name := string(tool.Name)
+		if seen[name] {
+			t.Fatalf("duplicate tool name %q", tool.Name)
+		}
+		seen[name] = true
+	}
+}
+
+func TestCreateWorkloadToolSchemaRequiresSafetyInputs(t *testing.T) {
+	t.Parallel()
+
+	var createTool *ToolDescriptor
+	for _, tool := range registeredTools() {
+		if tool.Name == ToolCreateWorkload {
+			tool := tool
+			createTool = &tool
+			break
+		}
+	}
+	if createTool == nil {
+		t.Fatal("create_workload tool missing")
+	}
+	required, ok := createTool.InputSchema["required"].([]string)
+	if !ok {
+		t.Fatalf("required schema = %#v, want []string", createTool.InputSchema["required"])
+	}
+	for _, want := range []string{"name", "objective", "agents"} {
+		if !containsString(required, want) {
+			t.Fatalf("required fields = %v, want %q", required, want)
+		}
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/multitenancy/isolation.go
+++ b/pkg/multitenancy/isolation.go
@@ -43,7 +43,7 @@ func (r *Resolver) RegisterTenant(tenant *TenantContext) error {
 func (r *Resolver) ExtractFromNamespace(ctx context.Context, namespace string) (*TenantContext, error) {
 	// Pattern: agentic-customer-<name>
 	if !strings.HasPrefix(namespace, "agentic-customer-") {
-		return nil, ErrTenantNotFound
+		return nil, nil
 	}
 
 	tenantName := strings.TrimPrefix(namespace, "agentic-customer-")

--- a/pkg/multitenancy/isolation_test.go
+++ b/pkg/multitenancy/isolation_test.go
@@ -46,12 +46,28 @@ func TestResolverExtractFromNamespace(t *testing.T) {
 	}
 }
 
-func TestResolverInvalidNamespace(t *testing.T) {
+func TestResolverExtractFromNamespaceNoTenantLabels(t *testing.T) {
+	t.Parallel()
+
 	r := NewResolver()
 	ctx := context.Background()
-	_, err := r.ExtractFromNamespace(ctx, "default")
+	tenant, err := r.ExtractFromNamespace(ctx, "default")
+	if err != nil {
+		t.Fatalf("expected no error for namespace without tenant labels, got %v", err)
+	}
+	if tenant != nil {
+		t.Fatalf("tenant = %#v, want nil", tenant)
+	}
+}
+
+func TestResolverInvalidTenantNamespace(t *testing.T) {
+	t.Parallel()
+
+	r := NewResolver()
+	ctx := context.Background()
+	_, err := r.ExtractFromNamespace(ctx, "agentic-customer-")
 	if err == nil {
-		t.Error("expected error for invalid namespace")
+		t.Fatal("expected error for invalid tenant namespace")
 	}
 }
 

--- a/pkg/opa/evaluator.go
+++ b/pkg/opa/evaluator.go
@@ -52,6 +52,16 @@ func NewPolicyEvaluator() *PolicyEvaluator {
 
 // Evaluate evaluates a proposed action against OPA policies
 func (pe *PolicyEvaluator) Evaluate(input *EvaluationInput) *EvaluationResult {
+	if input == nil {
+		return &EvaluationResult{
+			Allowed:        false,
+			Confidence:     "LOW",
+			ClusterStatus:  "CRITICAL",
+			ActionCategory: "MODIFICATION",
+			Reasons:        []string{"Policy input is required"},
+		}
+	}
+
 	result := &EvaluationResult{
 		Confidence:     assessConfidence(input.Confidence),
 		ClusterStatus:  assessClusterHealth(input.ClusterHealthScore),

--- a/pkg/opa/evaluator_test.go
+++ b/pkg/opa/evaluator_test.go
@@ -316,3 +316,84 @@ func TestOPA_ConfidenceConversion(t *testing.T) {
 	}
 	t.Log("✅ Confidence conversion correct")
 }
+
+func TestOPA_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	pe := NewPolicyEvaluator()
+	testCases := []struct {
+		name       string
+		input      *EvaluationInput
+		strict     bool
+		wantAllow  bool
+		wantReason string
+	}{
+		{
+			name:       "nil input denied",
+			input:      nil,
+			wantAllow:  false,
+			wantReason: "Policy input is required",
+		},
+		{
+			name: "empty action with high confidence allowed as modification",
+			input: &EvaluationInput{
+				ActionType:         "",
+				Confidence:         0.95,
+				ClusterHealthScore: 90,
+			},
+			wantAllow:  true,
+			wantReason: "High confidence",
+		},
+		{
+			name: "zero confidence denied",
+			input: &EvaluationInput{
+				ActionType:         "optimize_resources",
+				Confidence:         0,
+				ClusterHealthScore: 90,
+			},
+			wantAllow:  false,
+			wantReason: "Low confidence",
+		},
+		{
+			name: "strict boundary confidence allowed",
+			input: &EvaluationInput{
+				ActionType:         "optimize_resources",
+				Confidence:         0.95,
+				ClusterHealthScore: 90,
+			},
+			strict:     true,
+			wantAllow:  true,
+			wantReason: "High confidence",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var result *EvaluationResult
+			if tc.strict {
+				result = pe.EvaluateStrict(tc.input)
+			} else {
+				result = pe.Evaluate(tc.input)
+			}
+
+			if result.Allowed != tc.wantAllow {
+				t.Fatalf("Allowed = %v, want %v. Reasons: %v", result.Allowed, tc.wantAllow, result.Reasons)
+			}
+			if !reasonsContain(result.Reasons, tc.wantReason) {
+				t.Fatalf("reasons = %v, want substring %q", result.Reasons, tc.wantReason)
+			}
+		})
+	}
+}
+
+func reasonsContain(reasons []string, substring string) bool {
+	for _, reason := range reasons {
+		if strings.Contains(reason, substring) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/otel/genai/spans_test.go
+++ b/pkg/otel/genai/spans_test.go
@@ -112,6 +112,68 @@ func TestSetChatResponse_RecordsTokensAndModel(t *testing.T) {
 	assertInt64Attr(t, got.Attributes(), "gen_ai.usage.total_tokens", 1801)
 }
 
+func TestGenAISpans_Integration(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer otel.SetTracerProvider(prev)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	ctx, chatSpan := genai.StartChatSpan(context.Background(), genai.ChatRequest{
+		System: "openai",
+		Model:  "gpt-4o",
+	})
+	genai.SetChatResponse(chatSpan, genai.ChatResponse{
+		Model:        "gpt-4o",
+		InputTokens:  100,
+		OutputTokens: 50,
+	})
+	genai.SetOK(chatSpan)
+	chatSpan.End()
+
+	_, toolSpan := genai.StartToolSpan(ctx, genai.ToolRequest{Name: "browser.search", Type: "mcp"})
+	genai.SetOK(toolSpan)
+	toolSpan.End()
+
+	if err := tp.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("force flush: %v", err)
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 2 {
+		t.Fatalf("exported spans = %d, want 2", len(spans))
+	}
+
+	var chatFound, toolFound bool
+	for _, span := range spans {
+		switch span.Name {
+		case genai.ChatSpanName("gpt-4o"):
+			chatFound = true
+			assertStringAttrs(t, span.Attributes, map[string]string{
+				"gen_ai.system":         "openai",
+				"gen_ai.request.model":  "gpt-4o",
+				"gen_ai.response.model": "gpt-4o",
+			})
+			assertInt64Attr(t, span.Attributes, "gen_ai.usage.input_tokens", 100)
+			assertInt64Attr(t, span.Attributes, "gen_ai.usage.output_tokens", 50)
+		case genai.ToolSpanName("browser.search"):
+			toolFound = true
+			assertStringAttrs(t, span.Attributes, map[string]string{
+				"gen_ai.operation.name": "execute_tool",
+				"gen_ai.tool.name":      "browser.search",
+				"gen_ai.tool.type":      "mcp",
+			})
+		}
+	}
+	if !chatFound {
+		t.Fatalf("missing chat span named %q", genai.ChatSpanName("gpt-4o"))
+	}
+	if !toolFound {
+		t.Fatalf("missing tool span named %q", genai.ToolSpanName("browser.search"))
+	}
+}
+
 func TestSetChatResponse_NilSpan_NoPanic(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/pkg/runtime/adapter.go
+++ b/pkg/runtime/adapter.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package runtime defines the RuntimeAdapter interface that decouples NineVigil
+// governance controls from the underlying agent execution engine.
+//
+// The reconciler calls RuntimeAdapter methods instead of Argo-specific code
+// directly. Each adapter implements the same egress-seal, attestation, and
+// lifecycle contract. This lets NineVigil work with AgentWorkload CRDs,
+// external labeled pods, CNCF agent runtimes, or any future engine without
+// code changes in the controller.
+package runtime
+
+import (
+	"context"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+)
+
+// RuntimeCapabilities describes what a runtime adapter supports.
+type RuntimeCapabilities struct {
+	SupportsDAG        bool // Can execute multi-step DAG workflows
+	SupportsResume     bool // Can resume suspended executions
+	SupportsArtifacts  bool // Can persist and retrieve artifacts
+	SupportsCostReport bool // Can report per-execution cost
+}
+
+// ExecutionStatus is the normalized status returned by any adapter.
+type ExecutionStatus struct {
+	Phase     string            // Pending, Running, Suspended, Succeeded, Failed, Error
+	Name      string            // Name of the underlying execution object
+	Namespace string            // Namespace of the execution object
+	UID       string            // UID of the execution object
+	Artifacts map[string]string // Step-name to artifact-location map
+}
+
+// RuntimeAdapter is the interface every execution engine must implement.
+// NineVigil governance controls (gVisor injection, egress seal, audit,
+// attestation) apply identically regardless of which adapter is active.
+type RuntimeAdapter interface {
+	// Capabilities returns what this adapter supports.
+	Capabilities() RuntimeCapabilities
+
+	// Execute creates or updates the underlying execution for a workload.
+	// Returns the initial status. Callers should poll Status() afterward.
+	Execute(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error)
+
+	// Status retrieves the current execution status for a workload.
+	Status(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error)
+
+	// Cleanup removes execution resources when a workload is deleted.
+	Cleanup(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) error
+}

--- a/pkg/runtime/adapter_test.go
+++ b/pkg/runtime/adapter_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestRuntimeAdapterInterface_Compliance verifies that the adapter interface
+// contract is implementable and that the Argo adapter satisfies it at
+// compile time. This is a structural test, not a behavioral one.
+func TestRuntimeAdapterInterface_Compliance(t *testing.T) {
+	// Compile-time check: ArgoWorkflowAdapter implements RuntimeAdapter
+	var _ RuntimeAdapter = (*ArgoWorkflowAdapter)(nil)
+
+	// Verify Capabilities returns expected values for Argo
+	adapter := &ArgoWorkflowAdapter{}
+	caps := adapter.Capabilities()
+
+	if !caps.SupportsDAG {
+		t.Error("Argo adapter should support DAG workflows")
+	}
+	if !caps.SupportsResume {
+		t.Error("Argo adapter should support resume")
+	}
+	if !caps.SupportsArtifacts {
+		t.Error("Argo adapter should support artifacts")
+	}
+}
+
+// TestExecutionStatus_NormalizedPhases verifies the status model works
+// for any adapter, not just Argo.
+func TestExecutionStatus_NormalizedPhases(t *testing.T) {
+	phases := []string{"Pending", "Running", "Suspended", "Succeeded", "Failed", "Error"}
+	for _, phase := range phases {
+		s := ExecutionStatus{Phase: phase, Name: "test", Namespace: "default"}
+		if s.Phase == "" {
+			t.Errorf("phase %q should not be empty after assignment", phase)
+		}
+	}
+}
+
+// TestRuntimeAdapter_CleanupNilWorkflow verifies cleanup is safe when no
+// workflow reference exists. This is runtime-neutral behavior.
+func TestRuntimeAdapter_CleanupNilWorkflow(t *testing.T) {
+	adapter := &ArgoWorkflowAdapter{}
+	workload := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+	}
+
+	// Cleanup should be a no-op when no workflow reference exists
+	err := adapter.Cleanup(context.Background(), workload)
+	if err != nil {
+		t.Errorf("cleanup with nil workflow ref should not error, got: %v", err)
+	}
+}

--- a/pkg/runtime/argo_adapter.go
+++ b/pkg/runtime/argo_adapter.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	"github.com/shreyansh/agentic-operator/pkg/argo"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ArgoWorkflowAdapter wraps the existing WorkflowManager as a RuntimeAdapter.
+// It preserves all current Argo behavior (create, status, cleanup) behind
+// the adapter interface so the reconciler does not call Argo directly.
+type ArgoWorkflowAdapter struct {
+	Client client.Client
+	Scheme *runtime.Scheme
+}
+
+var _ RuntimeAdapter = (*ArgoWorkflowAdapter)(nil)
+
+func (a *ArgoWorkflowAdapter) Capabilities() RuntimeCapabilities {
+	return RuntimeCapabilities{
+		SupportsDAG:        true,
+		SupportsResume:     true,
+		SupportsArtifacts:  true,
+		SupportsCostReport: false,
+	}
+}
+
+func (a *ArgoWorkflowAdapter) Execute(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
+	log := logf.FromContext(ctx)
+	wm := argo.NewWorkflowManager(a.Client, a.Scheme)
+
+	workflow, err := wm.CreateArgoWorkflow(ctx, workload)
+	if err != nil {
+		return nil, fmt.Errorf("argo adapter execute: %w", err)
+	}
+
+	log.Info("Argo adapter: workflow created", "name", workflow.GetName())
+	return &ExecutionStatus{
+		Phase:     "Pending",
+		Name:      workflow.GetName(),
+		Namespace: workflow.GetNamespace(),
+		UID:       string(workflow.GetUID()),
+	}, nil
+}
+
+func (a *ArgoWorkflowAdapter) Status(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
+	if workload.Status.ArgoWorkflow == nil || workload.Status.ArgoWorkflow.Name == "" {
+		return nil, fmt.Errorf("argo adapter status: no workflow reference")
+	}
+
+	wm := argo.NewWorkflowManager(a.Client, a.Scheme)
+	ns := workload.Status.ArgoWorkflow.Namespace
+	if ns == "" {
+		ns = argo.DefaultWorkflowNamespace
+	}
+
+	wfStatus, err := wm.GetArgoWorkflowStatus(ctx, workload.Status.ArgoWorkflow.Name, ns)
+	if err != nil {
+		return nil, fmt.Errorf("argo adapter status: %w", err)
+	}
+
+	return &ExecutionStatus{
+		Phase:     wfStatus.Phase,
+		Name:      workload.Status.ArgoWorkflow.Name,
+		Namespace: ns,
+		UID:       workload.Status.ArgoWorkflow.UID,
+	}, nil
+}
+
+func (a *ArgoWorkflowAdapter) Cleanup(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) error {
+	if workload.Status.ArgoWorkflow == nil || workload.Status.ArgoWorkflow.Name == "" {
+		return nil
+	}
+
+	wm := argo.NewWorkflowManager(a.Client, a.Scheme)
+	ns := workload.Status.ArgoWorkflow.Namespace
+	if ns == "" {
+		ns = argo.DefaultWorkflowNamespace
+	}
+
+	if err := wm.DeleteArgoWorkflow(ctx, workload.Status.ArgoWorkflow.Name, ns); err != nil {
+		return fmt.Errorf("argo adapter cleanup: %w", err)
+	}
+	return nil
+}

--- a/pkg/runtime/pod_adapter.go
+++ b/pkg/runtime/pod_adapter.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	"github.com/shreyansh/agentic-operator/internal/admission"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// PodRuntimeAdapter runs an AgentWorkload as a single bring-your-own Kubernetes
+// Pod. It exists to prove the RuntimeAdapter contract is not Argo-shaped: a
+// plain pod is the simplest possible runtime, yet it is governed identically
+// because its pod carries the sandbox label the admission webhook keys on.
+//
+// Image is the container image used for the execution pod. It is required;
+// the adapter fails closed rather than creating an empty pod.
+type PodRuntimeAdapter struct {
+	Client client.Client
+	Scheme *runtime.Scheme
+	Image  string
+}
+
+var _ RuntimeAdapter = (*PodRuntimeAdapter)(nil)
+
+func (a *PodRuntimeAdapter) Capabilities() RuntimeCapabilities {
+	// A single pod is one step: no DAG, no resume, no artifact graph.
+	return RuntimeCapabilities{
+		SupportsDAG:        false,
+		SupportsResume:     false,
+		SupportsArtifacts:  false,
+		SupportsCostReport: false,
+	}
+}
+
+func (a *PodRuntimeAdapter) Execute(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
+	if a.Image == "" {
+		return nil, fmt.Errorf("pod adapter execute: no execution image configured")
+	}
+	log := logf.FromContext(ctx)
+
+	pod := buildGovernedPod(workload, a.Image)
+	if a.Scheme != nil {
+		if err := controllerutil.SetControllerReference(workload, pod, a.Scheme); err != nil {
+			return nil, fmt.Errorf("pod adapter execute: set owner ref: %w", err)
+		}
+	}
+
+	if err := a.Client.Create(ctx, pod); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("pod adapter execute: create pod: %w", err)
+		}
+	}
+
+	log.Info("Pod adapter: governed pod created", "name", pod.GetName())
+	return &ExecutionStatus{
+		Phase:     "Pending",
+		Name:      pod.GetName(),
+		Namespace: pod.GetNamespace(),
+		UID:       string(pod.GetUID()),
+	}, nil
+}
+
+func (a *PodRuntimeAdapter) Status(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
+	pod := &corev1.Pod{}
+	key := types.NamespacedName{Name: PodName(workload), Namespace: workload.GetNamespace()}
+	if err := a.Client.Get(ctx, key, pod); err != nil {
+		return nil, fmt.Errorf("pod adapter status: %w", err)
+	}
+
+	return &ExecutionStatus{
+		Phase:     normalizePodPhase(pod.Status.Phase),
+		Name:      pod.GetName(),
+		Namespace: pod.GetNamespace(),
+		UID:       string(pod.GetUID()),
+	}, nil
+}
+
+func (a *PodRuntimeAdapter) Cleanup(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: PodName(workload), Namespace: workload.GetNamespace()},
+	}
+	if err := a.Client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("pod adapter cleanup: %w", err)
+	}
+	return nil
+}
+
+// PodName returns the deterministic execution pod name for a workload.
+func PodName(workload *agenticv1alpha1.AgentWorkload) string {
+	return workload.GetName() + "-agent"
+}
+
+// buildGovernedPod constructs the execution pod for a workload. It is a pure
+// function (no client, no cluster) so the governance contract is unit-testable.
+//
+// The critical line is the sandbox label: the admission webhook injects the
+// gVisor RuntimeClass onto any pod carrying it. The adapter does NOT set
+// RuntimeClassName itself; governance is applied by the platform, identically
+// for every runtime.
+func buildGovernedPod(workload *agenticv1alpha1.AgentWorkload, image string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PodName(workload),
+			Namespace: workload.GetNamespace(),
+			Labels: map[string]string{
+				admission.DefaultRuntimeLabelKey:  admission.DefaultRuntimeLabelValue,
+				"app.kubernetes.io/managed-by":    "agentic-operator",
+				"agentic.clawdlinux.org/workload": workload.GetName(),
+				"agentic.clawdlinux.org/runtime":  "pod",
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:  "agent",
+					Image: image,
+				},
+			},
+		},
+	}
+}
+
+// normalizePodPhase maps a Kubernetes pod phase onto the normalized
+// ExecutionStatus phase vocabulary shared by every adapter.
+func normalizePodPhase(phase corev1.PodPhase) string {
+	switch phase {
+	case corev1.PodPending:
+		return "Pending"
+	case corev1.PodRunning:
+		return "Running"
+	case corev1.PodSucceeded:
+		return "Succeeded"
+	case corev1.PodFailed:
+		return "Failed"
+	default:
+		return "Error"
+	}
+}

--- a/pkg/runtime/pod_adapter_test.go
+++ b/pkg/runtime/pod_adapter_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	"github.com/shreyansh/agentic-operator/internal/admission"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestPodAdapter_Compliance verifies the BYO pod adapter satisfies the
+// RuntimeAdapter interface and reports single-step capabilities.
+func TestPodAdapter_Compliance(t *testing.T) {
+	var _ RuntimeAdapter = (*PodRuntimeAdapter)(nil)
+
+	caps := (&PodRuntimeAdapter{}).Capabilities()
+	if caps.SupportsDAG {
+		t.Error("a plain pod runtime should not advertise DAG support")
+	}
+	if caps.SupportsResume {
+		t.Error("a plain pod runtime should not advertise resume support")
+	}
+}
+
+// TestPodAdapter_GovernedPodGetsGvisor is the core runtime-agnostic proof:
+// a BYO pod built by this adapter carries the sandbox label, so the SAME
+// admission injector that governs Argo pods also injects gVisor here.
+func TestPodAdapter_GovernedPodGetsGvisor(t *testing.T) {
+	w := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "research", Namespace: "tenant-a"},
+	}
+
+	pod := buildGovernedPod(w, "ghcr.io/example/agent-runner:1.0")
+
+	// The governance label must be present and match the admission contract.
+	if got := pod.Labels[admission.DefaultRuntimeLabelKey]; got != admission.DefaultRuntimeLabelValue {
+		t.Fatalf("sandbox label = %q, want %q", got, admission.DefaultRuntimeLabelValue)
+	}
+
+	// Feed the built pod through the REAL admission injector. If governance is
+	// truly runtime-agnostic, the BYO pod gets gVisor exactly like Argo pods.
+	cfg := admission.RuntimeClassInjectionConfig{
+		RuntimeClassName: admission.DefaultRuntimeClassName,
+		LabelKey:         admission.DefaultRuntimeLabelKey,
+		LabelValue:       admission.DefaultRuntimeLabelValue,
+	}
+	if !admission.InjectRuntimeClass(pod, cfg) {
+		t.Fatal("admission injector skipped a governed BYO pod; runtime-agnostic governance is broken")
+	}
+	if pod.Spec.RuntimeClassName == nil || *pod.Spec.RuntimeClassName != admission.DefaultRuntimeClassName {
+		t.Fatalf("RuntimeClassName = %v, want %q", pod.Spec.RuntimeClassName, admission.DefaultRuntimeClassName)
+	}
+}
+
+func TestPodAdapter_GovernedPodMetadata(t *testing.T) {
+	w := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "research", Namespace: "tenant-a"},
+	}
+	pod := buildGovernedPod(w, "img:1")
+
+	if pod.Name != PodName(w) {
+		t.Errorf("pod name = %q, want %q", pod.Name, PodName(w))
+	}
+	if pod.Namespace != "tenant-a" {
+		t.Errorf("pod namespace = %q, want tenant-a", pod.Namespace)
+	}
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		t.Errorf("restart policy = %q, want Never", pod.Spec.RestartPolicy)
+	}
+	if len(pod.Spec.Containers) != 1 || pod.Spec.Containers[0].Image != "img:1" {
+		t.Errorf("expected one container with image img:1, got %+v", pod.Spec.Containers)
+	}
+}
+
+// TestPodAdapter_NormalizePodPhase verifies pod phases map onto the
+// normalized ExecutionStatus vocabulary shared by every adapter.
+func TestPodAdapter_NormalizePodPhase(t *testing.T) {
+	cases := map[corev1.PodPhase]string{
+		corev1.PodPending:   "Pending",
+		corev1.PodRunning:   "Running",
+		corev1.PodSucceeded: "Succeeded",
+		corev1.PodFailed:    "Failed",
+		corev1.PodUnknown:   "Error",
+		corev1.PodPhase(""): "Error",
+	}
+	for in, want := range cases {
+		if got := normalizePodPhase(in); got != want {
+			t.Errorf("normalizePodPhase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestPodAdapter_ExecuteRequiresImage verifies the adapter fails closed when
+// no execution image is configured rather than creating an empty pod.
+func TestPodAdapter_ExecuteRequiresImage(t *testing.T) {
+	a := &PodRuntimeAdapter{} // no image
+	w := &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "default"},
+	}
+	if _, err := a.Execute(context.Background(), w); err == nil {
+		t.Fatal("Execute with no image should error, got nil")
+	}
+}

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+)
+
+// DefaultRuntimeType is the runtime selected when a workload does not declare
+// spec.orchestration.type. Argo is the historical default.
+const DefaultRuntimeType = "argo"
+
+// Registry maps a runtime type name to a RuntimeAdapter. It is the seam that
+// makes the reconciler runtime-agnostic: register adapters once at startup,
+// then dispatch each workload to the adapter named by spec.orchestration.type.
+//
+// The governance controls (gVisor injection, egress seal, attestation) live
+// outside the adapter, so every registered runtime is governed identically.
+type Registry struct {
+	adapters    map[string]RuntimeAdapter
+	defaultType string
+}
+
+// NewRegistry returns an empty registry that defaults to the Argo runtime.
+func NewRegistry() *Registry {
+	return &Registry{
+		adapters:    make(map[string]RuntimeAdapter),
+		defaultType: DefaultRuntimeType,
+	}
+}
+
+// Register associates a runtime type name with an adapter. Names are
+// normalized (trimmed, lowercased) so "Argo" and "argo" are the same runtime.
+func (r *Registry) Register(name string, adapter RuntimeAdapter) {
+	r.adapters[normalizeType(name)] = adapter
+}
+
+// SetDefault changes the runtime used when a workload omits a type.
+func (r *Registry) SetDefault(name string) {
+	r.defaultType = normalizeType(name)
+}
+
+// ResolveType returns the runtime type for a workload, falling back to the
+// registry default when the workload does not declare one.
+func (r *Registry) ResolveType(w *agenticv1alpha1.AgentWorkload) string {
+	if w == nil || w.Spec.Orchestration == nil || w.Spec.Orchestration.Type == nil {
+		return r.defaultType
+	}
+	t := normalizeType(*w.Spec.Orchestration.Type)
+	if t == "" {
+		return r.defaultType
+	}
+	return t
+}
+
+// For returns the adapter registered for the workload's runtime type. It
+// errors when no adapter is registered for that type, listing what is
+// available so the caller can surface an actionable message.
+func (r *Registry) For(w *agenticv1alpha1.AgentWorkload) (RuntimeAdapter, error) {
+	t := r.ResolveType(w)
+	adapter, ok := r.adapters[t]
+	if !ok {
+		return nil, fmt.Errorf("no runtime adapter registered for type %q (registered: %s)",
+			t, strings.Join(r.Registered(), ", "))
+	}
+	return adapter, nil
+}
+
+// Registered returns the sorted list of registered runtime type names.
+func (r *Registry) Registered() []string {
+	names := make([]string, 0, len(r.adapters))
+	for name := range r.adapters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func normalizeType(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}

--- a/pkg/runtime/registry_test.go
+++ b/pkg/runtime/registry_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+)
+
+func strptr(s string) *string { return &s }
+
+// stubAdapter is a minimal RuntimeAdapter used only to exercise the registry
+// dispatch logic without touching a cluster.
+type stubAdapter struct {
+	name string
+}
+
+func (s stubAdapter) Capabilities() RuntimeCapabilities { return RuntimeCapabilities{} }
+func (s stubAdapter) Execute(ctx context.Context, w *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
+	return &ExecutionStatus{Phase: "Pending", Name: s.name}, nil
+}
+func (s stubAdapter) Status(ctx context.Context, w *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
+	return &ExecutionStatus{Phase: "Running", Name: s.name}, nil
+}
+func (s stubAdapter) Cleanup(ctx context.Context, w *agenticv1alpha1.AgentWorkload) error { return nil }
+
+func workloadWithType(t *string) *agenticv1alpha1.AgentWorkload {
+	w := &agenticv1alpha1.AgentWorkload{}
+	if t != nil {
+		w.Spec.Orchestration = &agenticv1alpha1.OrchestrationSpec{Type: t}
+	}
+	return w
+}
+
+func TestRegistry_ResolveType_DefaultsToArgo(t *testing.T) {
+	r := NewRegistry()
+
+	if got := r.ResolveType(nil); got != "argo" {
+		t.Errorf("nil workload: ResolveType = %q, want argo", got)
+	}
+	if got := r.ResolveType(workloadWithType(nil)); got != "argo" {
+		t.Errorf("no orchestration: ResolveType = %q, want argo", got)
+	}
+	if got := r.ResolveType(workloadWithType(strptr(""))); got != "argo" {
+		t.Errorf("empty type: ResolveType = %q, want argo", got)
+	}
+}
+
+func TestRegistry_ResolveType_NormalizesCaseAndSpace(t *testing.T) {
+	r := NewRegistry()
+	if got := r.ResolveType(workloadWithType(strptr("  Pod "))); got != "pod" {
+		t.Errorf("ResolveType = %q, want pod", got)
+	}
+}
+
+func TestRegistry_For_ReturnsRegisteredAdapter(t *testing.T) {
+	r := NewRegistry()
+	r.Register("argo", stubAdapter{name: "argo"})
+	r.Register("pod", stubAdapter{name: "pod"})
+
+	a, err := r.For(workloadWithType(strptr("pod")))
+	if err != nil {
+		t.Fatalf("For(pod) error: %v", err)
+	}
+	st, _ := a.Status(context.Background(), &agenticv1alpha1.AgentWorkload{})
+	if st.Name != "pod" {
+		t.Errorf("dispatched to wrong adapter: got %q, want pod", st.Name)
+	}
+}
+
+func TestRegistry_For_DefaultsWhenTypeUnset(t *testing.T) {
+	r := NewRegistry()
+	r.Register("argo", stubAdapter{name: "argo"})
+
+	a, err := r.For(workloadWithType(nil))
+	if err != nil {
+		t.Fatalf("For(default) error: %v", err)
+	}
+	st, _ := a.Status(context.Background(), &agenticv1alpha1.AgentWorkload{})
+	if st.Name != "argo" {
+		t.Errorf("default dispatch: got %q, want argo", st.Name)
+	}
+}
+
+func TestRegistry_For_UnknownTypeErrors(t *testing.T) {
+	r := NewRegistry()
+	r.Register("argo", stubAdapter{name: "argo"})
+
+	_, err := r.For(workloadWithType(strptr("does-not-exist")))
+	if err == nil {
+		t.Fatal("For(unknown) should error, got nil")
+	}
+}
+
+func TestRegistry_Registered_IsSorted(t *testing.T) {
+	r := NewRegistry()
+	r.Register("pod", stubAdapter{name: "pod"})
+	r.Register("argo", stubAdapter{name: "argo"})
+	r.Register("kagent", stubAdapter{name: "kagent"})
+
+	got := r.Registered()
+	want := []string{"argo", "kagent", "pod"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Registered = %v, want %v", got, want)
+	}
+}
+
+func TestRegistry_SetDefault(t *testing.T) {
+	r := NewRegistry()
+	r.SetDefault("pod")
+	if got := r.ResolveType(workloadWithType(nil)); got != "pod" {
+		t.Errorf("after SetDefault(pod): ResolveType = %q, want pod", got)
+	}
+}

--- a/scripts/clean-cluster-test.sh
+++ b/scripts/clean-cluster-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GREEN="$(printf '\033[32m')"
+RED="$(printf '\033[31m')"
+RESET="$(printf '\033[0m')"
+CLUSTER="ninevigil-demo"
+cleanup() { kind delete cluster --name "${CLUSTER}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+kind delete cluster --name "${CLUSTER}" || true
+kind create cluster --name "${CLUSTER}" --wait 60s
+
+set +e
+./scripts/demo-booth.sh --skip-argo
+exit_code=$?
+set -e
+if (( exit_code == 0 )); then
+  printf '%bCLEAN CLUSTER TEST: PASS%b\n' "${GREEN}" "${RESET}"
+else
+  printf '%bCLEAN CLUSTER TEST: FAIL%b\n' "${RED}" "${RESET}"
+fi
+
+exit "${exit_code}"

--- a/scripts/demo-booth.sh
+++ b/scripts/demo-booth.sh
@@ -307,6 +307,47 @@ show_agent_pods() {
     -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,RUNTIME:.spec.runtimeClassName' || true
 }
 
+operator_pod_name() {
+  local pod_name
+  pod_name="$(kubectl -n "${NS_OPERATOR}" get pods -l app.kubernetes.io/name=agentic-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  if [[ -z "${pod_name}" ]]; then
+    pod_name="$(kubectl -n "${NS_OPERATOR}" get pods -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  fi
+  printf '%s' "${pod_name}"
+}
+
+check_cost_metrics() {
+  step "Checking cost metric"
+  COST_OK=no
+
+  local pod_name metric_output metric_line exposed_port
+  pod_name="$(operator_pod_name)"
+  if [[ -z "${pod_name}" ]]; then
+    warn "Cost tracking: operator pod not found"
+    return
+  fi
+
+  metric_output="$(kubectl -n "${NS_OPERATOR}" exec "${pod_name}" -- sh -c \
+    'if command -v curl >/dev/null 2>&1; then curl -fsS --max-time 3 http://127.0.0.1:8080/metrics; elif command -v wget >/dev/null 2>&1; then wget -qO- --timeout=3 http://127.0.0.1:8080/metrics; else exit 127; fi' \
+    2>/dev/null || true)"
+  metric_line="$(printf '%s\n' "${metric_output}" | grep 'ninevigil_agent_cost_dollars' | grep -v '^#' | head -1 || true)"
+  if [[ -n "${metric_line}" ]]; then
+    printf '%bCost tracking:%b %s\n' "${GREEN}" "${RESET}" "${metric_line}"
+    COST_OK=yes
+    return
+  fi
+
+  exposed_port="$(kubectl -n "${NS_OPERATOR}" get pod "${pod_name}" \
+    -o jsonpath='{range .spec.containers[*].ports[*]}{.containerPort}{"\n"}{end}' 2>/dev/null | grep -x '8080' | head -1 || true)"
+  if [[ -n "${exposed_port}" ]]; then
+    warn "Cost tracking: metric not available yet, but operator exposes port 8080"
+    COST_OK=yes
+    return
+  fi
+
+  warn "Cost tracking: ninevigil_agent_cost_dollars not available"
+}
+
 verify_gvisor() {
   step "Checking gVisor RuntimeClass"
   local runtime_class_ok runtime_webhook_config dry_run_json runtime_class
@@ -376,6 +417,8 @@ run_opa_demo() {
     warn "ALLOW path did not reach a non-empty, non-denied phase. Last phase: ${ALLOW_PHASE}"
   fi
 
+  check_cost_metrics
+
   show_workload_evidence
   show_agent_pods
 
@@ -400,11 +443,12 @@ run_opa_demo() {
 print_summary() {
   echo ""
   printf '%bBooth Demo Summary%b\n' "${BOLD}" "${RESET}"
-  printf 'ALLOW path: %s. DENY path: %s. gVisor: %s. NetworkPolicy: %s.\n' \
+  printf 'ALLOW path: %s. DENY path: %s. gVisor: %s. NetworkPolicy: %s. Cost: %s.\n' \
     "${ALLOW_PHASE:-<empty>}" \
     "${DENY_PHASE:-<empty>}" \
     "${GVISOR_OK:-no}" \
-    "${NETWORK_POLICY_OK:-no}"
+    "${NETWORK_POLICY_OK:-no}" \
+    "${COST_OK:-no}"
   echo ""
   if [[ "${DENY_PHASE:-}" != "PolicyDenied" ]]; then
     warn "DENY needs a reachable HTTPS MCP endpoint to reach OPA. Set DEMO_MCP_ENDPOINT for live booth runs."

--- a/scripts/demo-booth.sh
+++ b/scripts/demo-booth.sh
@@ -12,9 +12,11 @@ HELM_TIMEOUT="${HELM_TIMEOUT:-180s}"
 
 ALLOW_MANIFEST="${REPO_ROOT}/config/samples/agentworkload_demo_allow.yaml"
 DENY_MANIFEST="${REPO_ROOT}/config/samples/agentworkload_demo_deny.yaml"
+SWARM_MANIFEST="${REPO_ROOT}/config/samples/agentworkload_demo_swarm.yaml"
 EVIDENCE_DIR="${EVIDENCE_DIR:-${REPO_ROOT}/tests/harness/evidence/booth-$(date +%Y%m%dT%H%M%S)}"
 
 SKIP_ARGO=false
+FULL=false
 RECORD=false
 CLEANUP=false
 ORIGINAL_ARGS=("$@")
@@ -44,6 +46,7 @@ Runs the NineVigil booth demo gate.
 Options:
   --cluster NAME    kind cluster name. Default: ${CLUSTER_NAME}
   --skip-argo       Skip Argo/shared-services setup. Week 2 gate path.
+  --full            Run Phase 2 multi-agent swarm demo.
   --record          Record terminal output with script(1).
   --cleanup         Delete the kind cluster and exit.
   -h, --help        Show this help.
@@ -71,6 +74,10 @@ parse_args() {
         ;;
       --skip-argo)
         SKIP_ARGO=true
+        shift
+        ;;
+      --full)
+        FULL=true
         shift
         ;;
       --record)
@@ -147,6 +154,7 @@ check_prerequisites() {
   fi
   [[ -f "${ALLOW_MANIFEST}" ]] || die "missing ${ALLOW_MANIFEST}"
   [[ -f "${DENY_MANIFEST}" ]] || die "missing ${DENY_MANIFEST}"
+  [[ -f "${SWARM_MANIFEST}" ]] || die "missing ${SWARM_MANIFEST}"
   ok "kubectl and helm found"
 }
 
@@ -440,15 +448,87 @@ run_opa_demo() {
   fi
 }
 
+find_swarm_workflow() {
+  local workflow_name
+  workflow_name="$(kubectl -n "${NS_ARGO}" get workflows \
+    -l agentic.clawdlinux.org/workload=demo-competitive-swarm \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  if [[ -z "${workflow_name}" ]]; then
+    # Current controller labels created Workflows by AgentWorkload name.
+    workflow_name="$(kubectl -n "${NS_ARGO}" get workflows \
+      -l agentic.io/job-id=demo-competitive-swarm \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  fi
+  printf '%s' "${workflow_name}"
+}
+
+workflow_phase() {
+  local workflow_name="$1"
+  kubectl -n "${NS_ARGO}" get workflow "${workflow_name}" -o jsonpath='{.status.phase}' 2>/dev/null || true
+}
+
+run_swarm_demo() {
+  if [[ "${FULL}" != "true" ]]; then
+    SWARM_PHASE="skipped (use --full)"
+    return
+  fi
+
+  step "PHASE 2: Multi-Agent Swarm"
+  if [[ "${SKIP_ARGO}" == "true" ]]; then
+    warn "Swarm skipped because --skip-argo disables Argo installation"
+    SWARM_PHASE="skipped (no argo)"
+    return
+  fi
+
+  SWARM_PHASE="not found"
+  apply_manifest "${SWARM_MANIFEST}"
+
+  local deadline workflow_name phase
+  deadline=$(( $(date +%s) + 60 ))
+  while (( $(date +%s) < deadline )); do
+    workflow_name="$(find_swarm_workflow)"
+    if [[ -n "${workflow_name}" ]]; then
+      phase="$(workflow_phase "${workflow_name}")"
+      SWARM_PHASE="${phase:-Pending}"
+      printf '%bSwarm workflow:%b %s phase=%s\n' "${GREEN}" "${RESET}" "${workflow_name}" "${SWARM_PHASE}"
+      break
+    fi
+    sleep 2
+  done
+
+  if [[ -z "${workflow_name:-}" ]]; then
+    warn "Swarm workflow did not appear in ${NS_ARGO} within 60s"
+    printf 'Swarm: %s. Agents: competitor-scraper, llm-synthesizer, report-generator\n' "${SWARM_PHASE}"
+    return
+  fi
+
+  deadline=$(( $(date +%s) + 120 ))
+  while (( $(date +%s) < deadline )); do
+    phase="$(workflow_phase "${workflow_name}")"
+    if [[ -n "${phase}" ]]; then
+      SWARM_PHASE="${phase}"
+      break
+    fi
+    sleep 3
+  done
+
+  if [[ -z "${SWARM_PHASE}" || "${SWARM_PHASE}" == "Pending" ]]; then
+    warn "Swarm workflow has not started a phase yet"
+  fi
+  kubectl -n "${NS_ARGO}" get workflows || true
+  printf 'Swarm: %s. Agents: competitor-scraper, llm-synthesizer, report-generator\n' "${SWARM_PHASE:-unknown}"
+}
+
 print_summary() {
   echo ""
   printf '%bBooth Demo Summary%b\n' "${BOLD}" "${RESET}"
-  printf 'ALLOW path: %s. DENY path: %s. gVisor: %s. NetworkPolicy: %s. Cost: %s.\n' \
+  printf 'ALLOW path: %s. DENY path: %s. gVisor: %s. NetworkPolicy: %s. Cost: %s. Swarm: %s.\n' \
     "${ALLOW_PHASE:-<empty>}" \
     "${DENY_PHASE:-<empty>}" \
     "${GVISOR_OK:-no}" \
     "${NETWORK_POLICY_OK:-no}" \
-    "${COST_OK:-no}"
+    "${COST_OK:-no}" \
+    "${SWARM_PHASE:-skipped (use --full)}"
   echo ""
   if [[ "${DENY_PHASE:-}" != "PolicyDenied" ]]; then
     warn "DENY needs a reachable HTTPS MCP endpoint to reach OPA. Set DEMO_MCP_ENDPOINT for live booth runs."
@@ -474,6 +554,7 @@ main() {
   verify_gvisor
   verify_network_policy
   run_opa_demo
+  run_swarm_demo
   print_summary
 }
 

--- a/scripts/demo-booth.sh
+++ b/scripts/demo-booth.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CLUSTER_NAME="${CLUSTER_NAME:-ninevigil-demo}"
+NS_OPERATOR="${NS_OPERATOR:-agentic-system}"
+NS_ARGO="${NS_ARGO:-argo-workflows}"
+NS_SHARED="${NS_SHARED:-shared-services}"
+HELM_TIMEOUT="${HELM_TIMEOUT:-180s}"
+
+ALLOW_MANIFEST="${REPO_ROOT}/config/samples/agentworkload_demo_allow.yaml"
+DENY_MANIFEST="${REPO_ROOT}/config/samples/agentworkload_demo_deny.yaml"
+EVIDENCE_DIR="${EVIDENCE_DIR:-${REPO_ROOT}/tests/harness/evidence/booth-$(date +%Y%m%dT%H%M%S)}"
+
+SKIP_ARGO=false
+RECORD=false
+CLEANUP=false
+ORIGINAL_ARGS=("$@")
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+  BOLD="$(printf '\033[1m')"
+  GREEN="$(printf '\033[32m')"
+  RED="$(printf '\033[31m')"
+  YELLOW="$(printf '\033[33m')"
+  CYAN="$(printf '\033[36m')"
+  RESET="$(printf '\033[0m')"
+else
+  BOLD=""
+  GREEN=""
+  RED=""
+  YELLOW=""
+  CYAN=""
+  RESET=""
+fi
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Runs the NineVigil booth demo gate.
+
+Options:
+  --cluster NAME    kind cluster name. Default: ${CLUSTER_NAME}
+  --skip-argo       Skip Argo/shared-services setup. Week 2 gate path.
+  --record          Record terminal output with script(1).
+  --cleanup         Delete the kind cluster and exit.
+  -h, --help        Show this help.
+
+Environment:
+  DEMO_MCP_ENDPOINT Override https://localhost:8443 in sample manifests.
+  HELM_TIMEOUT      Helm wait timeout. Default: ${HELM_TIMEOUT}
+  NS_OPERATOR       Operator namespace. Default: ${NS_OPERATOR}
+EOF
+}
+
+log() { printf '%b[demo %s]%b %s\n' "${CYAN}" "$(date +%H:%M:%S)" "${RESET}" "$*"; }
+step() { printf '\n%b==> %s%b\n' "${BOLD}" "$*" "${RESET}"; }
+ok() { printf '%b[OK]%b %s\n' "${GREEN}" "${RESET}" "$*"; }
+warn() { printf '%b[WARN]%b %s\n' "${YELLOW}" "${RESET}" "$*"; }
+die() { printf '%b[FAIL]%b %s\n' "${RED}" "${RESET}" "$*" >&2; exit 1; }
+
+parse_args() {
+  while (($#)); do
+    case "$1" in
+      --cluster)
+        [[ $# -ge 2 ]] || die "--cluster requires a value"
+        CLUSTER_NAME="$2"
+        shift 2
+        ;;
+      --skip-argo)
+        SKIP_ARGO=true
+        shift
+        ;;
+      --record)
+        RECORD=true
+        shift
+        ;;
+      --cleanup)
+        CLEANUP=true
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "unknown option: $1"
+        ;;
+    esac
+  done
+}
+
+quote_command() {
+  local quoted=""
+  local arg
+  for arg in "$@"; do
+    quoted+=" $(printf '%q' "${arg}")"
+  done
+  printf '%s' "${quoted# }"
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+start_recording_if_requested() {
+  if [[ "${RECORD}" != "true" || -n "${DEMO_RECORDING:-}" ]]; then
+    return
+  fi
+  command -v script >/dev/null 2>&1 || die "--record requires script(1)"
+  mkdir -p "${EVIDENCE_DIR}"
+  local record_file="${EVIDENCE_DIR}/demo-booth.typescript"
+  log "Recording booth demo to ${record_file}"
+
+  local command_line
+  if ((${#ORIGINAL_ARGS[@]})); then
+    command_line="$(quote_command "$0" "${ORIGINAL_ARGS[@]}")"
+  else
+    command_line="$(quote_command "$0")"
+  fi
+  if script -q -c "true" /dev/null >/dev/null 2>&1; then
+    exec env DEMO_RECORDING=1 script -q -c "${command_line}" "${record_file}"
+  fi
+
+  if ((${#ORIGINAL_ARGS[@]})); then
+    exec env DEMO_RECORDING=1 script -q "${record_file}" "$0" "${ORIGINAL_ARGS[@]}"
+  fi
+  exec env DEMO_RECORDING=1 script -q "${record_file}" "$0"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+check_prerequisites() {
+  step "Checking prerequisites"
+  require_command kubectl
+  require_command helm
+  if command -v kind >/dev/null 2>&1; then
+    ok "kind found"
+  elif command -v k3s >/dev/null 2>&1; then
+    ok "k3s found. Reusing the current kubectl context."
+  else
+    die "kind or k3s is required"
+  fi
+  [[ -f "${ALLOW_MANIFEST}" ]] || die "missing ${ALLOW_MANIFEST}"
+  [[ -f "${DENY_MANIFEST}" ]] || die "missing ${DENY_MANIFEST}"
+  ok "kubectl and helm found"
+}
+
+cleanup_cluster() {
+  step "Cleaning up demo cluster"
+  if command -v kind >/dev/null 2>&1; then
+    kind delete cluster --name "${CLUSTER_NAME}"
+    ok "Deleted kind cluster ${CLUSTER_NAME}"
+  else
+    die "--cleanup only supports kind clusters"
+  fi
+}
+
+ensure_cluster() {
+  step "Preparing Kubernetes cluster"
+  if command -v kind >/dev/null 2>&1; then
+    if kind get clusters | grep -Fxq "${CLUSTER_NAME}"; then
+      ok "Reusing kind cluster ${CLUSTER_NAME}"
+    else
+      kind create cluster --name "${CLUSTER_NAME}" --wait 120s
+      ok "Created kind cluster ${CLUSTER_NAME}"
+    fi
+    kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+    return
+  fi
+
+  kubectl cluster-info >/dev/null || die "kubectl cannot reach the current k3s cluster"
+  ok "Using current kubectl context: $(kubectl config current-context 2>/dev/null || echo unknown)"
+}
+
+ensure_namespace() {
+  kubectl create namespace "$1" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+}
+
+wait_for_operator() {
+  step "Waiting for operator pod"
+  local deadline phase pod_name
+  deadline=$(( $(date +%s) + 180 ))
+  while (( $(date +%s) < deadline )); do
+    pod_name="$(kubectl -n "${NS_OPERATOR}" get pods -l app.kubernetes.io/name=agentic-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [[ -z "${pod_name}" ]]; then
+      pod_name="$(kubectl -n "${NS_OPERATOR}" get pods -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    fi
+    if [[ -n "${pod_name}" ]]; then
+      phase="$(kubectl -n "${NS_OPERATOR}" get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+      if [[ "${phase}" == "Running" ]]; then
+        ok "Operator pod Running: ${pod_name}"
+        return
+      fi
+      log "Operator pod ${pod_name} phase=${phase:-unknown}"
+    else
+      log "Operator pod not created yet"
+    fi
+    sleep 5
+  done
+  die "Operator pod did not reach Running"
+}
+
+install_full_stack() {
+  step "Installing full stack with tests/harness/setup.sh"
+  HELM_TIMEOUT="${HELM_TIMEOUT}" bash "${REPO_ROOT}/tests/harness/setup.sh" || {
+    die "setup.sh failed. For Week 2, rerun with --skip-argo to bypass Argo."
+  }
+  wait_for_operator
+}
+
+install_week2_stack() {
+  step "Installing Week 2 stack without Argo"
+  ensure_namespace "${NS_OPERATOR}"
+  kubectl apply -f "${REPO_ROOT}/config/crd/agentworkload_crd.yaml" >/dev/null
+
+  helm upgrade --install agentic-operator "${REPO_ROOT}/charts" \
+    --namespace "${NS_OPERATOR}" \
+    --create-namespace \
+    --set license.key=dev-license \
+    --set argo.enabled=false \
+    --set browserless.enabled=false \
+    --set litellm.enabled=false \
+    --set minio.enabled=false \
+    --set postgresql.enabled=false \
+    --set clawdlinuxObservability.enabled=false \
+    --set networkPolicy.enabled=true \
+    --set global.runtimeSandbox.enabled=true \
+    --set global.runtimeSandbox.createRuntimeClass=true \
+    --set agenticOperator.webhook.enabled=false \
+    --set agentic-operator.image.pullPolicy=IfNotPresent \
+    --timeout "${HELM_TIMEOUT}" \
+    --wait >/dev/null
+
+  wait_for_operator
+}
+
+apply_manifest() {
+  local manifest="$1"
+  local endpoint namespace
+  endpoint="$(escape_sed_replacement "${DEMO_MCP_ENDPOINT:-https://localhost:8443}")"
+  namespace="$(escape_sed_replacement "${NS_OPERATOR}")"
+  sed \
+    -e "s|https://localhost:8443|${endpoint}|g" \
+    -e "s|namespace: agentic-system|namespace: ${namespace}|g" \
+    "${manifest}" | kubectl apply -f - >/dev/null
+}
+
+workload_phase() {
+  local name="$1"
+  kubectl -n "${NS_OPERATOR}" get agentworkload "${name}" -o jsonpath='{.status.phase}' 2>/dev/null || true
+}
+
+wait_for_allow_phase() {
+  local name="$1"
+  local deadline phase
+  deadline=$(( $(date +%s) + 60 ))
+  while (( $(date +%s) < deadline )); do
+    phase="$(workload_phase "${name}")"
+    if [[ -n "${phase}" && "${phase}" != "PolicyDenied" ]]; then
+      printf '%s' "${phase}"
+      return 0
+    fi
+    sleep 2
+  done
+  phase="$(workload_phase "${name}")"
+  printf '%s' "${phase:-<empty>}"
+  return 1
+}
+
+wait_for_deny_phase() {
+  local name="$1"
+  local deadline phase
+  deadline=$(( $(date +%s) + 30 ))
+  while (( $(date +%s) < deadline )); do
+    phase="$(workload_phase "${name}")"
+    if [[ "${phase}" == "PolicyDenied" ]]; then
+      printf '%s' "${phase}"
+      return 0
+    fi
+    sleep 2
+  done
+  phase="$(workload_phase "${name}")"
+  printf '%s' "${phase:-<empty>}"
+  return 1
+}
+
+deny_reason() {
+  kubectl -n "${NS_OPERATOR}" get agentworkload opa-deny-demo \
+    -o jsonpath='{range .status.conditions[?(@.type=="PolicyDenied")]}{.message}{"\n"}{end}' 2>/dev/null || true
+}
+
+show_workload_evidence() {
+  step "AgentWorkload status"
+  kubectl -n "${NS_OPERATOR}" get agentworkload -o wide || true
+  echo ""
+  kubectl -n "${NS_OPERATOR}" describe agentworkload opa-allow-demo || true
+}
+
+show_agent_pods() {
+  step "Agent pod runtime view"
+  kubectl get pods -A -l app.kubernetes.io/part-of=agentic-operator \
+    -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,RUNTIME:.spec.runtimeClassName' || true
+}
+
+verify_gvisor() {
+  step "Checking gVisor RuntimeClass"
+  local runtime_class_ok runtime_webhook_config dry_run_json runtime_class
+  runtime_class_ok=no
+  if kubectl get runtimeclass gvisor >/dev/null 2>&1; then
+    ok "RuntimeClass gvisor exists"
+    runtime_class_ok=yes
+  else
+    warn "RuntimeClass gvisor not found"
+  fi
+
+  runtime_webhook_config="$(kubectl get mutatingwebhookconfiguration -l app.kubernetes.io/part-of=agentic-operator \
+    -o jsonpath='{range .items[?(@.webhooks[*].name=="runtimeclass-pods.agentic.clawdlinux.org")]}{.metadata.name}{"\n"}{end}' 2>/dev/null | head -1 || true)"
+  if [[ -n "${runtime_webhook_config}" ]]; then
+    dry_run_json="$(kubectl -n "${NS_OPERATOR}" apply --dry-run=server -o json -f - <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runtime-sandbox-demo
+  labels:
+    agentic.clawdlinux.org/runtime-sandbox: gvisor
+spec:
+  restartPolicy: Never
+  containers:
+    - name: pause
+      image: registry.k8s.io/pause:3.10
+YAML
+    )" || dry_run_json=""
+    runtime_class="$(printf '%s' "${dry_run_json}" | sed -n 's/.*"runtimeClassName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+    if [[ "${runtime_class}" == "gvisor" ]]; then
+      ok "Runtime sandbox webhook injected runtimeClassName=gvisor"
+      GVISOR_OK=yes
+      return
+    fi
+    warn "Runtime sandbox webhook did not inject runtimeClassName. Got ${runtime_class:-missing}."
+  else
+    warn "No runtime sandbox mutating webhook found. Using RuntimeClass check."
+  fi
+
+  if [[ "${runtime_class_ok}" == "yes" ]]; then
+    GVISOR_OK=yes
+  else
+    GVISOR_OK=no
+  fi
+}
+
+verify_network_policy() {
+  step "Checking NetworkPolicy"
+  local policy_names
+  policy_names="$(kubectl -n "${NS_OPERATOR}" get networkpolicy -l app.kubernetes.io/component=networkpolicy -o name 2>/dev/null || true)"
+  if [[ -n "${policy_names}" ]]; then
+    ok "NetworkPolicy is installed in ${NS_OPERATOR}"
+    NETWORK_POLICY_OK=yes
+  else
+    warn "NetworkPolicy not found in ${NS_OPERATOR}"
+    NETWORK_POLICY_OK=no
+  fi
+}
+
+run_opa_demo() {
+  step "Applying OPA allow workload"
+  kubectl -n "${NS_OPERATOR}" delete agentworkload opa-allow-demo --ignore-not-found >/dev/null 2>&1 || true
+  apply_manifest "${ALLOW_MANIFEST}"
+  if ALLOW_PHASE="$(wait_for_allow_phase opa-allow-demo)"; then
+    ok "ALLOW path phase: ${ALLOW_PHASE}"
+  else
+    warn "ALLOW path did not reach a non-empty, non-denied phase. Last phase: ${ALLOW_PHASE}"
+  fi
+
+  show_workload_evidence
+  show_agent_pods
+
+  step "Applying OPA deny workload"
+  kubectl -n "${NS_OPERATOR}" delete agentworkload opa-deny-demo --ignore-not-found >/dev/null 2>&1 || true
+  apply_manifest "${DENY_MANIFEST}"
+  if DENY_PHASE="$(wait_for_deny_phase opa-deny-demo)"; then
+    ok "DENY path phase: ${DENY_PHASE}"
+  else
+    warn "DENY path did not reach PolicyDenied. Last phase: ${DENY_PHASE}"
+  fi
+
+  local reason
+  reason="$(deny_reason)"
+  if [[ -n "${reason}" ]]; then
+    printf '%bDeny reason:%b %s\n' "${BOLD}" "${RESET}" "${reason}"
+  else
+    warn "No PolicyDenied condition message found"
+  fi
+}
+
+print_summary() {
+  echo ""
+  printf '%bBooth Demo Summary%b\n' "${BOLD}" "${RESET}"
+  printf 'ALLOW path: %s. DENY path: %s. gVisor: %s. NetworkPolicy: %s.\n' \
+    "${ALLOW_PHASE:-<empty>}" \
+    "${DENY_PHASE:-<empty>}" \
+    "${GVISOR_OK:-no}" \
+    "${NETWORK_POLICY_OK:-no}"
+  echo ""
+  if [[ "${DENY_PHASE:-}" != "PolicyDenied" ]]; then
+    warn "DENY needs a reachable HTTPS MCP endpoint to reach OPA. Set DEMO_MCP_ENDPOINT for live booth runs."
+  fi
+}
+
+main() {
+  parse_args "$@"
+  start_recording_if_requested
+
+  if [[ "${CLEANUP}" == "true" ]]; then
+    cleanup_cluster
+    return
+  fi
+
+  check_prerequisites
+  ensure_cluster
+  if [[ "${SKIP_ARGO}" == "true" ]]; then
+    install_week2_stack
+  else
+    install_full_stack
+  fi
+  verify_gvisor
+  verify_network_policy
+  run_opa_demo
+  print_summary
+}
+
+main "$@"

--- a/scripts/oss_private_boundary_allowlist.txt
+++ b/scripts/oss_private_boundary_allowlist.txt
@@ -5,3 +5,12 @@
 
 # Guardrail script includes policy keywords by design.
 scripts/check_oss_private_boundary.sh
+
+# Multi-tenancy is already OSS: pkg/multitenancy/*, api/v1alpha1/tenant_types.go,
+# and internal/controller/tenant_controller.go all ship on main. These are the
+# generated CRD manifest and controller-level integration tests for that
+# existing public capability, so the 'multi-tenant'/'sla' keyword hits are not a
+# new private-tier leak.
+config/crd/bases/agentic.clawdlinux.org_tenants.yaml
+internal/controller/agentworkload_controller_quota_test.go
+internal/controller/agentworkload_controller_sla_test.go

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+mkdir -p demos
+STAMP="$(date +%Y%m%d)"
+LOG_FILE="demos/demo-${STAMP}.log"
+CAST_FILE="demos/demo-${STAMP}.cast"
+DEMO_CMD="set -o pipefail; ./scripts/demo-booth.sh --skip-argo | tee ${LOG_FILE}"
+
+if command -v asciinema >/dev/null 2>&1; then
+  asciinema rec "${CAST_FILE}" --command "bash -lc '${DEMO_CMD}'"
+else
+  bash -lc "${DEMO_CMD}"
+fi
+
+echo "Demo recording saved to demos/"

--- a/tests/smoke/run_smoke.sh
+++ b/tests/smoke/run_smoke.sh
@@ -32,8 +32,8 @@ PASS=0
 FAIL=0
 TOTAL=0
 
-pass() { echo "  ✅ PASS: $*"; ((PASS++)); ((TOTAL++)); }
-fail() { echo "  ❌ FAIL: $*"; ((FAIL++)); ((TOTAL++)); }
+pass() { echo "  ✅ PASS: $*"; ((PASS+=1)); ((TOTAL+=1)); }
+fail() { echo "  ❌ FAIL: $*"; ((FAIL+=1)); ((TOTAL+=1)); }
 log()  { echo "[smoke] $*"; }
 
 # ── Test 1: CRD installed ────────────────────────────────────────────────────
@@ -109,8 +109,9 @@ done
 # ── Test 7: Service endpoints resolvable ──────────────────────────────────────
 log "Test 7: Shared service endpoints exist"
 for SVC in postgres minio browserless litellm; do
-  EP_COUNT="$(kubectl -n "${NS_SHARED}" get endpoints "${SVC}" \
-    -o jsonpath='{.subsets[*].addresses}' 2>/dev/null | wc -c | tr -d ' ')"
+  EP_ADDRESSES="$(kubectl -n "${NS_SHARED}" get endpoints "${SVC}" \
+    -o jsonpath='{.subsets[*].addresses}' 2>/dev/null || true)"
+  EP_COUNT="$(printf "%s" "${EP_ADDRESSES}" | wc -c | tr -d ' ')"
   if (( EP_COUNT > 2 )); then
     pass "${SVC} endpoint has addresses"
   else
@@ -133,8 +134,62 @@ else
   pass "No webhook configured (acceptable for dev clusters)"
 fi
 
-# ── Test 9: Operator can watch AgentWorkloads ─────────────────────────────────
-log "Test 9: Operator RBAC — can list AgentWorkloads"
+# ── Test 9: Runtime sandbox webhook mutates opted-in Pods ────────────────────
+log "Test 9: Runtime sandbox webhook injects runtimeClassName"
+RUNTIME_WEBHOOK_CONFIG="$(kubectl get mutatingwebhookconfiguration -l app.kubernetes.io/part-of=agentic-operator \
+  -o jsonpath='{range .items[?(@.webhooks[*].name=="runtimeclass-pods.agentic.clawdlinux.org")]}{.metadata.name}{"\n"}{end}' 2>/dev/null | head -1)"
+if [[ -n "${RUNTIME_WEBHOOK_CONFIG}" ]]; then
+  SELECTOR_JSON="$(kubectl get mutatingwebhookconfiguration "${RUNTIME_WEBHOOK_CONFIG}" -o jsonpath='{.webhooks[?(@.name=="runtimeclass-pods.agentic.clawdlinux.org")].objectSelector.matchLabels}' 2>/dev/null || true)"
+  SELECTOR_PAIR="$(SELECTOR_JSON="${SELECTOR_JSON}" python3 - <<'PY'
+import json
+import os
+
+raw = os.environ.get("SELECTOR_JSON", "")
+try:
+    labels = json.loads(raw)
+except json.JSONDecodeError:
+    labels = {}
+for key, value in labels.items():
+    print(f"{key}={value}")
+    break
+PY
+  )"
+  SELECTOR_KEY="${SELECTOR_PAIR%%=*}"
+  SELECTOR_VALUE="${SELECTOR_PAIR#*=}"
+  EXPECTED_RUNTIME="$(kubectl -n "${NS_OPERATOR}" get deploy -l app.kubernetes.io/name=agentic-operator \
+    -o jsonpath='{.items[0].spec.template.spec.containers[0].env[?(@.name=="RUNTIME_SANDBOX_CLASS")].value}' 2>/dev/null || true)"
+  EXPECTED_RUNTIME="${EXPECTED_RUNTIME:-gvisor}"
+
+  if [[ -z "${SELECTOR_KEY}" || -z "${SELECTOR_VALUE}" ]]; then
+    fail "Runtime sandbox webhook has no objectSelector.matchLabels"
+  else
+    DRY_RUN_JSON="$(kubectl -n "${NS_OPERATOR}" apply --dry-run=server -o json -f - <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runtime-sandbox-smoke
+  labels:
+    ${SELECTOR_KEY}: ${SELECTOR_VALUE}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: pause
+      image: registry.k8s.io/pause:3.10
+YAML
+    )" || DRY_RUN_JSON=""
+    RUNTIME_CLASS="$(echo "${DRY_RUN_JSON}" | sed -n 's/.*"runtimeClassName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+    if [[ "${RUNTIME_CLASS}" == "${EXPECTED_RUNTIME}" ]]; then
+      pass "Runtime sandbox webhook injected runtimeClassName=${RUNTIME_CLASS}"
+    else
+      fail "Runtime sandbox webhook did not inject runtimeClassName=${EXPECTED_RUNTIME} (got '${RUNTIME_CLASS:-missing}')"
+    fi
+  fi
+else
+  pass "No runtime sandbox pod mutating webhook configured (acceptable for dev clusters)"
+fi
+
+# ── Test 10: Operator can watch AgentWorkloads ────────────────────────────────
+log "Test 10: Operator RBAC — can list AgentWorkloads"
 SA="system:serviceaccount:${NS_OPERATOR}:agentic-operator-controller-manager"
 CAN_LIST="$(kubectl auth can-i list agentworkloads.agentic.clawdlinux.org \
   --as="${SA}" --all-namespaces 2>/dev/null || echo "no")"
@@ -146,8 +201,8 @@ else
   pass "Skipped (auth can-i not reliable on all clusters)"
 fi
 
-# ── Test 10: CRD schema has required fields ───────────────────────────────────
-log "Test 10: CRD spec schema includes key fields"
+# ── Test 11: CRD schema has required fields ───────────────────────────────────
+log "Test 11: CRD spec schema includes key fields"
 CRD_JSON="$(kubectl get crd agentworkloads.agentic.clawdlinux.org -o json 2>/dev/null || echo "{}")"
 FIELDS_OK=true
 for FIELD in objective mcpServerEndpoint autoApproveThreshold; do

--- a/tests/smoke/test_grafana_dashboard.sh
+++ b/tests/smoke/test_grafana_dashboard.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+DASHBOARD="config/grafana/dashboards/cost-by-workload.json"
+METRIC="ninevigil_agent_cost_dollars"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "PASS: $*"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+
+if python3 -c "import json; json.load(open('${DASHBOARD}'))"; then
+  pass "dashboard JSON is parseable"
+else
+  fail "dashboard JSON is not parseable"
+fi
+
+if grep -q "${METRIC}" "${DASHBOARD}"; then
+  pass "dashboard references ${METRIC}"
+else
+  fail "dashboard does not reference ${METRIC}"
+fi
+
+if python3 - "${DASHBOARD}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+dashboard = json.loads(Path(sys.argv[1]).read_text())
+errors = []
+grouped_cost_query_found = False
+expected_labels = {"workload", "namespace", "model"}
+for panel in dashboard.get("panels", []):
+    datasource = panel.get("datasource", {})
+    targets = panel.get("targets", [])
+    if datasource.get("type") != "prometheus":
+        continue
+    if datasource.get("uid") != "${DS_PROMETHEUS}":
+        errors.append(f"panel {panel.get('title')!r} uses datasource {datasource!r}")
+    for target in targets:
+        expr = target.get("expr", "")
+        if "ninevigil_agent_cost_dollars" not in expr:
+            continue
+        match = re.search(r"by\s*\(([^)]*)\)", expr)
+        if not match:
+          continue
+        labels = {label.strip() for label in match.group(1).split(",") if label.strip()}
+        if labels != expected_labels:
+          errors.append(f"panel {panel.get('title')!r} groups cost by labels {sorted(labels)!r}")
+          continue
+        grouped_cost_query_found = True
+        legend = target.get("legendFormat", "")
+        for label in expected_labels:
+            if f"{{{{{label}}}}}" not in legend:
+                errors.append(f"panel {panel.get('title')!r} missing {label} in legend {legend!r}")
+if not any(
+    "ninevigil_agent_cost_dollars" in target.get("expr", "")
+    for panel in dashboard.get("panels", [])
+    for target in panel.get("targets", [])
+):
+    errors.append("no Prometheus target references ninevigil_agent_cost_dollars")
+if not grouped_cost_query_found:
+  errors.append("no cost target groups by workload, namespace, and model")
+if errors:
+    for error in errors:
+        print(error)
+    raise SystemExit(1)
+PY
+then
+  pass "dashboard uses ${METRIC} with workload, namespace, and model labels"
+else
+  fail "dashboard metric labels are incorrect"
+fi
+
+if (( FAIL > 0 )); then
+  echo "Grafana dashboard smoke test failed: ${FAIL} failed, ${PASS} passed" >&2
+  exit 1
+fi
+
+echo "Grafana dashboard smoke test passed: ${PASS} checks"

--- a/tests/stress/controller_stress_test.go
+++ b/tests/stress/controller_stress_test.go
@@ -1,0 +1,209 @@
+package stress_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	"github.com/shreyansh/agentic-operator/internal/controller"
+)
+
+func TestController_10ConcurrentWorkloads(t *testing.T) {
+	ctx := context.Background()
+	scheme := newStressTestScheme(t)
+	server := newStressMockMCPServer(t)
+	defer server.Close()
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	errCh := make(chan error, 10)
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("stress-workload-%02d", i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					errCh <- fmt.Errorf("%s panic: %v", name, recovered)
+				}
+			}()
+
+			workload := newStressWorkload(name, server.URL)
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+				WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: workload.Namespace}}, workload).
+				Build()
+
+			reconciler := &controller.AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme}
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}})
+			if err != nil {
+				errCh <- fmt.Errorf("%s reconcile: %w", workload.Name, err)
+				return
+			}
+
+			updated := &agenticv1alpha1.AgentWorkload{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, updated); err != nil {
+				errCh <- fmt.Errorf("%s fetch updated: %w", workload.Name, err)
+				return
+			}
+			if updated.Status.Phase == "" {
+				errCh <- fmt.Errorf("%s phase is empty", workload.Name)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Logf("reconciled 10 workloads in %s", time.Since(start))
+}
+
+func TestController_RapidCreateDelete(t *testing.T) {
+	ctx := context.Background()
+	scheme := newStressTestScheme(t)
+	server := newStressMockMCPServer(t)
+	defer server.Close()
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&agenticv1alpha1.AgentWorkload{}).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}).
+		Build()
+	reconciler := &controller.AgentWorkloadReconciler{Client: k8sClient, Scheme: scheme}
+
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("rapid-workload-%02d", i)
+		workload := newStressWorkload(name, server.URL)
+		if err := k8sClient.Create(ctx, workload); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: workload.Namespace}}
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("initial reconcile %s: %v", name, err)
+		}
+
+		updated := &agenticv1alpha1.AgentWorkload{}
+		if err := k8sClient.Get(ctx, req.NamespacedName, updated); err != nil {
+			t.Fatalf("fetch %s after reconcile: %v", name, err)
+		}
+		if !hasFinalizer(updated.Finalizers, controller.AgentWorkloadFinalizer) {
+			t.Fatalf("%s missing finalizer after reconcile: %v", name, updated.Finalizers)
+		}
+
+		if err := k8sClient.Delete(ctx, updated); err != nil {
+			t.Fatalf("delete %s: %v", name, err)
+		}
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("delete reconcile %s: %v", name, err)
+		}
+
+		remaining := &agenticv1alpha1.AgentWorkload{}
+		err := k8sClient.Get(ctx, req.NamespacedName, remaining)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("fetch %s after delete reconcile: %v", name, err)
+		}
+		t.Fatalf("%s still exists after delete reconcile with finalizers %v", name, remaining.Finalizers)
+	}
+}
+
+func newStressWorkload(name, endpoint string) *agenticv1alpha1.AgentWorkload {
+	objective := "optimize cluster resources"
+	policy := "strict"
+	return &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID(name + "-uid")},
+		Spec: agenticv1alpha1.AgentWorkloadSpec{
+			MCPServerEndpoint: &endpoint,
+			Objective:         &objective,
+			OPAPolicy:         &policy,
+		},
+	}
+}
+
+func newStressTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := agenticv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add agentic scheme: %v", err)
+	}
+	return scheme
+}
+
+func newStressMockMCPServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/call_tool" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req struct {
+			Tool string `json:"tool"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+		resp := map[string]interface{}{"tool": req.Tool, "success": true}
+		switch req.Tool {
+		case "get_status":
+			resp["result"] = map[string]interface{}{"status": "healthy", "cluster_health": 90.0}
+		case "propose_action":
+			resp["result"] = map[string]interface{}{
+				"action":      "optimize",
+				"description": "Tune resource requests based on observed usage",
+				"confidence":  0.98,
+			}
+		case "execute_action":
+			resp["result"] = map[string]interface{}{"executed": true}
+		default:
+			resp["success"] = false
+			resp["error"] = "unknown tool"
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func hasFinalizer(finalizers []string, want string) bool {
+	for _, finalizer := range finalizers {
+		if finalizer == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Lands 31 commits that were sitting on a local branch. This is the booth-critical work for the summit: without it, main has no demo manifests, no booth script, and a README that does not lead with the wedge.

## What lands

- Runtime-agnostic adapter: `RuntimeAdapter` interface + registry + BYO-pod adapter. Same egress-seal, attestation, and lifecycle contract across AgentWorkload, CNCF runtimes, and labeled pods. Controller calls the adapter, not Argo directly.
- Booth demo: `scripts/demo-booth.sh` (kind/k3s up, helm install, OPA allow/deny egress flow, multi-agent swarm, evidence capture to a timestamped dir) plus the `config/samples/agentworkload_demo_{allow,deny,runtime,swarm}.yaml` manifests.
- README leads with the tamper-evident attestation artifact + zero-egress seal, verifiable offline with `audit-verify`. VC framing moved below the fold.
- Cilium FQDN egress policy, gVisor sandbox injection, FinOps prometheus cost metrics, OTel GenAI spans, Grafana dashboard validation.
- Test backfill: controller stress/concurrency, OPA deny + quota paths, audit concurrent-append, e2e clean-cluster smoke.

## Verification (local, Go 1.26.0 darwin/arm64)

- `go build ./...` clean.
- `go vet ./...` clean, `gofmt -l` clean.
- `go test ./...` plus `make test-controller` (envtest): 22/22 packages pass.

## Known follow-up (not in this PR)

- Go module path is still `github.com/shreyansh/agentic-operator`. Moving it to the org is a separate PR (touches every import); doing it on its own keeps this one reviewable.