### PR TITLE
chore(module): move Go module path to Clawdlinux/agentic-operator-core

### DIFF
--- a/RALPH_BACKLOG.md
+++ b/RALPH_BACKLOG.md
@@ -21,8 +21,8 @@ Pre-flight gates before any new branch or issue (do not skip):
 - [x] A1 Acronym-collision matrix + one recommendation -> naming-decision.md (shared with ACP). Recommend: drop ACP acronym, mark `Concord`, operator module path github.com/clawdlinux/agentic-operator.
 - [HUMAN] A2 Approve the name.
 - [ ] A3 Mechanical local rename: README, docs, badges, chart metadata. LOCAL only.
-- [HUMAN] A4 Irreversible: GitHub repo slug + Go module path (github.com/shreyansh/agentic-operator). Staged as rename-module.sh.
+- [HUMAN] A4 Irreversible: GitHub repo slug + Go module path (github.com/Clawdlinux/agentic-operator-core). Staged as rename-module.sh.
 
 ## Notes
-- Go module today: github.com/shreyansh/agentic-operator (not under Clawdlinux org — naming debt).
+- Go module today: github.com/Clawdlinux/agentic-operator-core (not under Clawdlinux org — naming debt).
 - Strategy of record: STRATEGY_positioning_runtime_agnostic.md. Runtime-agnostic, kagent is one adapter.

--- a/cmd/agentctl-web/demo_test.go
+++ b/cmd/agentctl-web/demo_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shreyansh/agentic-operator/pkg/agentctl"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/agentctl"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"

--- a/cmd/agentctl-web/handlers.go
+++ b/cmd/agentctl-web/handlers.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shreyansh/agentic-operator/pkg/agentctl"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/agentctl"
 )
 
 // Server holds the web server dependencies.

--- a/cmd/agentctl-web/main.go
+++ b/cmd/agentctl-web/main.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/shreyansh/agentic-operator/pkg/agentctl"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/agentctl"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"

--- a/cmd/agentctl/commands.go
+++ b/cmd/agentctl/commands.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
+	agentctl "github.com/Clawdlinux/agentic-operator-core/pkg/agentctl"
 	"github.com/olekukonko/tablewriter"
-	agentctl "github.com/shreyansh/agentic-operator/pkg/agentctl"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/cmd/agentctl/mcp_serve.go
+++ b/cmd/agentctl/mcp_serve.go
@@ -28,7 +28,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/shreyansh/agentic-operator/pkg/mcp"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/mcp"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/agentctl/root.go
+++ b/cmd/agentctl/root.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	agentctl "github.com/Clawdlinux/agentic-operator-core/pkg/agentctl"
 	"github.com/olekukonko/tablewriter"
-	agentctl "github.com/shreyansh/agentic-operator/pkg/agentctl"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/cmd/agentctl/root_test.go
+++ b/cmd/agentctl/root_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	agentctl "github.com/shreyansh/agentic-operator/pkg/agentctl"
+	agentctl "github.com/Clawdlinux/agentic-operator-core/pkg/agentctl"
 )
 
 func TestNewRootCommand_ContainsRequiredSubcommands(t *testing.T) {

--- a/cmd/audit-verify/main.go
+++ b/cmd/audit-verify/main.go
@@ -36,7 +36,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/shreyansh/agentic-operator/pkg/audit"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/audit"
 )
 
 func main() {

--- a/cmd/audit-verify/main_test.go
+++ b/cmd/audit-verify/main_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shreyansh/agentic-operator/pkg/audit"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/audit"
 )
 
 func TestEndToEnd_CleanLedgerPasses(t *testing.T) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,13 +45,13 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	runtimeadmission "github.com/shreyansh/agentic-operator/internal/admission"
-	"github.com/shreyansh/agentic-operator/internal/controller"
-	"github.com/shreyansh/agentic-operator/pkg/evaluation"
-	"github.com/shreyansh/agentic-operator/pkg/finops"
-	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
-	"github.com/shreyansh/agentic-operator/pkg/otel/genai"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	runtimeadmission "github.com/Clawdlinux/agentic-operator-core/internal/admission"
+	"github.com/Clawdlinux/agentic-operator-core/internal/controller"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/evaluation"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/finops"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/multitenancy"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/otel/genai"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/shreyansh/agentic-operator/pkg/finops"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/finops"
 )
 
 func TestFinOpsMetricsEndpointContainsNineVigilCostMetric(t *testing.T) {

--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -9,7 +9,7 @@ Configure the NineVigil for your environment.
 operator:
   replicas: 1
   image:
-    repository: ghcr.io/shreyansh/agentic-operator
+    repository: ghcr.io/Clawdlinux/agentic-operator-core
     tag: latest
   resources:
     requests:

--- a/docs/12-contributing.md
+++ b/docs/12-contributing.md
@@ -6,7 +6,7 @@ Help improve NineVigil!
 
 ```bash
 # Clone repository
-git clone https://github.com/shreyansh/agentic-operator
+git clone https://github.com/Clawdlinux/agentic-operator-core
 cd agentic-operator
 
 # Install tools

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shreyansh/agentic-operator
+module github.com/Clawdlinux/agentic-operator-core
 
 go 1.25.3
 

--- a/internal/controller/agentcard_controller.go
+++ b/internal/controller/agentcard_controller.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 // AgentCardReconciler reconciles an AgentCard object

--- a/internal/controller/agentworkload_controller.go
+++ b/internal/controller/agentworkload_controller.go
@@ -35,17 +35,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/pkg/evaluation"
-	"github.com/shreyansh/agentic-operator/pkg/finops"
-	"github.com/shreyansh/agentic-operator/pkg/llm"
-	"github.com/shreyansh/agentic-operator/pkg/mcp"
-	"github.com/shreyansh/agentic-operator/pkg/metrics"
-	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
-	"github.com/shreyansh/agentic-operator/pkg/opa"
-	"github.com/shreyansh/agentic-operator/pkg/resilience"
-	"github.com/shreyansh/agentic-operator/pkg/routing"
-	runtimeadapter "github.com/shreyansh/agentic-operator/pkg/runtime"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/evaluation"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/finops"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/llm"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/mcp"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/metrics"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/multitenancy"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/opa"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/resilience"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/routing"
+	runtimeadapter "github.com/Clawdlinux/agentic-operator-core/pkg/runtime"
 )
 
 // Maximum number of actions to keep in status to prevent unbounded growth

--- a/internal/controller/agentworkload_controller_argo_test.go
+++ b/internal/controller/agentworkload_controller_argo_test.go
@@ -13,8 +13,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/pkg/argo"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/argo"
 )
 
 func TestReconcile_ArgoOrchestration(t *testing.T) {

--- a/internal/controller/agentworkload_controller_finops_test.go
+++ b/internal/controller/agentworkload_controller_finops_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 type listErrorClient struct {

--- a/internal/controller/agentworkload_controller_model_routing_test.go
+++ b/internal/controller/agentworkload_controller_model_routing_test.go
@@ -14,7 +14,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 type mockOpenAIScenario string

--- a/internal/controller/agentworkload_controller_opa_test.go
+++ b/internal/controller/agentworkload_controller_opa_test.go
@@ -11,7 +11,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 func TestReconcile_OPADenyPath(t *testing.T) {

--- a/internal/controller/agentworkload_controller_quota_test.go
+++ b/internal/controller/agentworkload_controller_quota_test.go
@@ -12,8 +12,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/multitenancy"
 )
 
 type stubQuotaManager struct{}

--- a/internal/controller/agentworkload_controller_reconcile_integration_test.go
+++ b/internal/controller/agentworkload_controller_reconcile_integration_test.go
@@ -14,7 +14,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 type mockMCPScenario struct {

--- a/internal/controller/agentworkload_controller_sla_test.go
+++ b/internal/controller/agentworkload_controller_sla_test.go
@@ -11,9 +11,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
-	"github.com/shreyansh/agentic-operator/pkg/resilience"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/multitenancy"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/resilience"
 )
 
 func TestReconcile_ModelRoutingRecordsSLASuccessAndFailure(t *testing.T) {

--- a/internal/controller/agentworkload_controller_test.go
+++ b/internal/controller/agentworkload_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 var _ = Describe("AgentWorkloadReconciler", func() {

--- a/internal/controller/agentworkload_finalizer_test.go
+++ b/internal/controller/agentworkload_finalizer_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 // Regression coverage for P0 launch fix:

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -32,7 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/tenant_controller.go
+++ b/internal/controller/tenant_controller.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 // TenantReconciler reconciles a Tenant object

--- a/naming-decision.md
+++ b/naming-decision.md
@@ -66,7 +66,7 @@ intent, but less self-explanatory.
 - Public name: keep `agentic-operator-core`. Changing the slug throws away the
   little history and the one star, and the name is fine. The README is the real
   problem, not the name (handled in Lane B3).
-- Go module path: today it is `github.com/shreyansh/agentic-operator`, a
+- Go module path: today it is `github.com/Clawdlinux/agentic-operator-core`, a
   personal handle. This reads unserious and ties the import path to one person.
   Move it to `github.com/clawdlinux/agentic-operator` to match the public org.
   This is a v0.x project, so a module-path change is acceptable now and only

--- a/pkg/argo/workflow.go
+++ b/pkg/argo/workflow.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 // WorkflowManager encapsulates Argo Workflows interaction logic

--- a/pkg/argo/workflow_test.go
+++ b/pkg/argo/workflow_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 // TestWorkflowManager_CreateArgoWorkflow verifies that a valid Workflow CR is created

--- a/pkg/audit/audit_test.go
+++ b/pkg/audit/audit_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shreyansh/agentic-operator/pkg/audit"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/audit"
 )
 
 func newHasher(t *testing.T, kid string) *audit.ChainHasher {

--- a/pkg/autoscaling/integration_test.go
+++ b/pkg/autoscaling/integration_test.go
@@ -3,7 +3,7 @@ package autoscaling
 import (
 	"testing"
 
-	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/multitenancy"
 )
 
 // TestAutoScaler_IntegrationWithSLAMonitor tests end-to-end scaling decisions

--- a/pkg/autoscaling/scaler.go
+++ b/pkg/autoscaling/scaler.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/multitenancy"
 )
 
 // AutoScaler evaluates SLA metrics and makes scaling decisions.

--- a/pkg/autoscaling/scaler_test.go
+++ b/pkg/autoscaling/scaler_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shreyansh/agentic-operator/pkg/multitenancy"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/multitenancy"
 )
 
 func TestAutoScaler_CriticalThreshold(t *testing.T) {

--- a/pkg/llm/provider.go
+++ b/pkg/llm/provider.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	agentv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agentv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 // Provider defines the interface for LLM providers

--- a/pkg/llm/routing.go
+++ b/pkg/llm/routing.go
@@ -7,8 +7,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/pkg/routing"
+	"github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/routing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/llm/routing_test.go
+++ b/pkg/llm/routing_test.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/pkg/routing"
+	"github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/routing"
 )
 
 // TestModelRouterWithMockProvider tests the full routing flow with a mock provider

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -42,7 +42,7 @@ import (
 	"strings"
 	"time"
 
-	agentctl "github.com/shreyansh/agentic-operator/pkg/agentctl"
+	agentctl "github.com/Clawdlinux/agentic-operator-core/pkg/agentctl"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	agentctl "github.com/shreyansh/agentic-operator/pkg/agentctl"
+	agentctl "github.com/Clawdlinux/agentic-operator-core/pkg/agentctl"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/otel/genai/semconv.go
+++ b/pkg/otel/genai/semconv.go
@@ -9,10 +9,10 @@ import "go.opentelemetry.io/otel/attribute"
 
 // TracerName is the canonical tracer/instrumentation-library name for all
 // agentic-operator GenAI spans.
-const TracerName = "github.com/shreyansh/agentic-operator/pkg/otel/genai"
+const TracerName = "github.com/Clawdlinux/agentic-operator-core/pkg/otel/genai"
 
 // MeterName is the canonical meter name for GenAI metrics.
-const MeterName = "github.com/shreyansh/agentic-operator/pkg/otel/genai"
+const MeterName = "github.com/Clawdlinux/agentic-operator-core/pkg/otel/genai"
 
 // SchemaURL points at the stable OTel GenAI semconv schema. We pin a
 // concrete version so downstream tooling can detect breaking renames.

--- a/pkg/otel/genai/spans_test.go
+++ b/pkg/otel/genai/spans_test.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/shreyansh/agentic-operator/pkg/otel/genai"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/otel/genai"
 )
 
 func newTestRecorder(t *testing.T) (*tracetest.SpanRecorder, func()) {

--- a/pkg/runtime/adapter.go
+++ b/pkg/runtime/adapter.go
@@ -27,7 +27,7 @@ package runtime
 import (
 	"context"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 // RuntimeCapabilities describes what a runtime adapter supports.

--- a/pkg/runtime/adapter_test.go
+++ b/pkg/runtime/adapter_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/runtime/argo_adapter.go
+++ b/pkg/runtime/argo_adapter.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/pkg/argo"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/pkg/argo"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"

--- a/pkg/runtime/pod_adapter.go
+++ b/pkg/runtime/pod_adapter.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/internal/admission"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/internal/admission"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/runtime/pod_adapter_test.go
+++ b/pkg/runtime/pod_adapter_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/internal/admission"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/internal/admission"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 // DefaultRuntimeType is the runtime selected when a workload does not declare

--- a/pkg/runtime/registry_test.go
+++ b/pkg/runtime/registry_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
 )
 
 func strptr(s string) *string { return &s }

--- a/tests/stress/controller_stress_test.go
+++ b/tests/stress/controller_stress_test.go
@@ -19,8 +19,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agenticv1alpha1 "github.com/shreyansh/agentic-operator/api/v1alpha1"
-	"github.com/shreyansh/agentic-operator/internal/controller"
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/internal/controller"
 )
 
 func TestController_10ConcurrentWorkloads(t *testing.T) {


### PR DESCRIPTION
The A4 gate from the plan. Moves the Go module path off the personal handle.

`github.com/shreyansh/agentic-operator` -> `github.com/Clawdlinux/agentic-operator-core`

## Why

- `go install` of the canonical path now resolves (path matches the repo slug).
- Built binaries and `audit-verify` imports no longer carry a side-project path. Matters for an enterprise booth handout.
- Matches the ACP repo convention (`github.com/Clawdlinux/...`).

## What changed

Mechanical rename across 45 Go files + `go.mod`. `gofmt` re-sorted import blocks where the new path changed alphabetical order (`Clawdlinux` sorts before deps that the old `shreyansh` path sorted after). Updated `go install` URLs in docs.

## Verification (local, Go 1.26.0 darwin/arm64)

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./...` + `make test-controller` (envtest): 22/22 packages pass.
- OSS/private boundary check passes.

No external users are on the old path (repo has 0 forks), so no install breakage.