### PR TITLE
fix: chart bugs blocking the demo, plus README/contact cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The wedge: NineVigil emits a signed, tamper-evident attestation artifact for eac
 | Runtime isolation | gVisor `RuntimeClass` injection for labeled pods |
 | Audit | Tamper-evident audit chain |
 | Cost | Per-workload budget and chargeback hooks |
-| Context | ACP for MCP tool discovery compression |
+| Context | ACP: governed execution contracts on top of MCP tool calls |
 | Delivery | Air-gapped install path and offline licensing |
 | Orchestration | Argo Workflows DAG orchestration |
 

--- a/charts/charts/agentic-operator/templates/_helpers.tpl
+++ b/charts/charts/agentic-operator/templates/_helpers.tpl
@@ -1,5 +1,14 @@
 {{- define "agentic-operator-sub.fullname" -}}
-{{- printf "%s-agentic-operator" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := "agentic-operator" }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "agentic-operator-sub.labels" -}}

--- a/charts/charts/agentic-operator/templates/deployment.yaml
+++ b/charts/charts/agentic-operator/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - --leader-elect={{ .Values.leaderElection }}
             - --health-probe-bind-address=:8082
             - --metrics-bind-address=:{{ .Values.service.metricsPort }}
-            - --log-level={{ .Values.logLevel }}
+            - --zap-log-level={{ .Values.logLevel }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -113,5 +113,6 @@ spec:
             optional: true
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
         seccompProfile:
           type: RuntimeDefault

--- a/config/samples/agentworkload_demo_allow.yaml
+++ b/config/samples/agentworkload_demo_allow.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   objective: "analyze quarterly revenue data"
   workloadType: generic
-  workflowName: opa-allow-demo
   agents:
     - "policy-demo-agent"
   opaPolicy: strict

--- a/config/samples/agentworkload_demo_deny.yaml
+++ b/config/samples/agentworkload_demo_deny.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   objective: "delete all production volumes"
   workloadType: generic
-  workflowName: opa-deny-demo
   agents:
     - "policy-demo-agent"
   opaPolicy: strict

--- a/config/samples/agentworkload_demo_runtime.yaml
+++ b/config/samples/agentworkload_demo_runtime.yaml
@@ -30,7 +30,6 @@ spec:
     Identify regulatory constraints, data residency requirements, and compliance gaps.
     Produce a structured report with sources and confidence scores.
   workloadType: generic
-  workflowName: research-swarm
   agents:
     - "web-researcher"
     - "policy-analyst"

--- a/config/samples/agentworkload_demo_swarm.yaml
+++ b/config/samples/agentworkload_demo_swarm.yaml
@@ -15,7 +15,6 @@ spec:
     - "report-generator"
   orchestration:
     type: "argo"
-  workflowName: "visual-analysis-template"
   opaPolicy: "strict"
   targetUrls:
     - "https://notion.so/pricing"

--- a/enterprise/billing/README.md
+++ b/enterprise/billing/README.md
@@ -1,3 +1,3 @@
 This package is part of the Agentic Operator Enterprise distribution.
 It is not included in the Apache 2.0 open-source release.
-Contact team@clawdlinux.io for enterprise licensing.
+Contact team@clawdlinux.org for enterprise licensing.

--- a/enterprise/licensing/README.md
+++ b/enterprise/licensing/README.md
@@ -1,3 +1,3 @@
 This package is part of the Agentic Operator Enterprise distribution.
 It is not included in the Apache 2.0 open-source release.
-Contact team@clawdlinux.io for enterprise licensing.
+Contact team@clawdlinux.org for enterprise licensing.


### PR DESCRIPTION
Found by live-running `scripts/demo-booth.sh` on a kind cluster. Five real bugs, all reproducible via the README's own `helm install` quickstart:

- **ServiceAccount name mismatch** — the nested `agentic-operator` subchart's fullname helper always appended `-agentic-operator`, producing a name that never matched the ServiceAccount the parent chart actually creates (`agentic-operator-operator`). Pod was never scheduled: `serviceaccount ... not found`.
- **Missing runAsUser** alongside `runAsNonRoot: true`. Kubelet can't verify the distroless nonroot image without a numeric UID, so it refuses to start the container. Added `runAsUser: 65532`.
- **Wrong CLI flag** — the deployment passes `--log-level`, but the compiled binary only defines `--zap-log-level`. Crash loop with `flag provided but not defined` on every single start.
- **Stale sample field** — `agentworkload_demo_{allow,deny,runtime,swarm}.yaml` all had a `spec.workflowName` field that isn't in the current CRD schema. Strict decoding rejects `kubectl apply` outright.

Also fixed the stale 'ACP for MCP tool discovery compression' line in the README (ACP repositioned to governed execution contracts a while back) and unified enterprise contact email to one address (was `team@clawdlinux.io`, a domain that doesn't match anything else in the project).

`helm unittest charts` (12/12) and `helm lint charts` still green after the template changes.

**Known gap not fixed here** (flagged, not silently patched): the manager starts its webhook HTTPS server unconditionally regardless of `agenticOperator.webhook.enabled`, so the --skip-argo fast demo path still needs a real webhook TLS cert (cert-manager) or a Go-level flag to skip webhook startup. Separately, the OPA allow/deny demo needs a reachable MCP endpoint that nothing currently stands up (`https://localhost:8443` with nothing listening). Neither is a quick chart fix; both are product decisions.