### PR TITLE
fix: remove nonexistent @clawdlinux.org contact emails

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,14 +13,15 @@ responsibly. **Do not open a public GitHub issue.**
 
 ### How to report
 
-1. Email **security@clawdlinux.org** with a description of the vulnerability.
+1. Use GitHub's private vulnerability reporting: open the repository's
+   **Security** tab and choose **Report a vulnerability**.
 2. Include steps to reproduce, affected versions, and potential impact.
-3. We will acknowledge receipt within **48 hours**.
+3. We will acknowledge the report within **48 hours**.
 4. We aim to provide a fix or mitigation within **7 days** for critical issues.
 
 ### What to expect
 
-- A confirmation email within 48 hours.
+- An acknowledgement on the report within 48 hours.
 - Regular updates on the status of your report.
 - Credit in the release notes (unless you prefer anonymity).
 

--- a/charts/charts/clawdlinux-observability/Chart.yaml
+++ b/charts/charts/clawdlinux-observability/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/Clawdlinux/agentic-operator-core
 maintainers:
   - name: Clawdlinux
-    email: team@clawdlinux.org
+    url: https://github.com/Clawdlinux
 keywords:
   - observability
   - opentelemetry

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,8 +197,7 @@ The operator automatically provisions:
 ## 🆘 Need Help?
 
 - 📖 Check [Troubleshooting](./10-troubleshooting.md)
-- 💬 Open an issue on [GitHub](https://github.com/Clawdlinux/agentic-operator-core)
-- 📧 Email oss@clawdlinux.org
+- 💬 Open an issue on [GitHub](https://github.com/Clawdlinux/agentic-operator-core/issues)
 
 ---
 

--- a/enterprise/billing/README.md
+++ b/enterprise/billing/README.md
@@ -1,3 +1,3 @@
 This package is part of the Agentic Operator Enterprise distribution.
 It is not included in the Apache 2.0 open-source release.
-Contact team@clawdlinux.org for enterprise licensing.
+For enterprise licensing, open an issue at https://github.com/Clawdlinux/agentic-operator-core/issues

--- a/enterprise/licensing/README.md
+++ b/enterprise/licensing/README.md
@@ -1,3 +1,3 @@
 This package is part of the Agentic Operator Enterprise distribution.
 It is not included in the Apache 2.0 open-source release.
-Contact team@clawdlinux.org for enterprise licensing.
+For enterprise licensing, open an issue at https://github.com/Clawdlinux/agentic-operator-core/issues


### PR DESCRIPTION
We own the domain but have no mailboxes set up, so every `@clawdlinux.org` email in the repo pointed at nothing. Replaced each with a real GitHub channel:

- `SECURITY.md`: GitHub private vulnerability reporting instead of security@
- `docs/README.md`: dropped the email bullet, kept the issues link
- observability `Chart.yaml`: maintainer `url` instead of `email`
- enterprise billing/licensing READMEs: open a GitHub issue

No functional change. Scoped to the five files with fake emails. ROADMAP.md and the untracked docs/ files are unrelated in-progress work and are intentionally not part of this PR.