### PR TITLE
fix: remove last two @clawdlinux.org emails missed on main

### DIFF
--- a/charts/charts/clawdlinux-observability/Chart.yaml
+++ b/charts/charts/clawdlinux-observability/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/Clawdlinux/agentic-operator-core
 maintainers:
   - name: Clawdlinux
-    email: team@clawdlinux.org
+    url: https://github.com/Clawdlinux
 keywords:
   - observability
   - opentelemetry

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,8 +197,7 @@ The operator automatically provisions:
 ## 🆘 Need Help?
 
 - 📖 Check [Troubleshooting](./10-troubleshooting.md)
-- 💬 Open an issue on [GitHub](https://github.com/Clawdlinux/agentic-operator-core)
-- 📧 Email oss@clawdlinux.org
+- 💬 Open an issue on [GitHub](https://github.com/Clawdlinux/agentic-operator-core/issues)
 
 ---
 


### PR DESCRIPTION
The direct-to-main email cleanup fixed SECURITY.md and the enterprise READMEs but left two behind. We own the domain but have no mailboxes.

- `docs/README.md`: dropped the oss@ email bullet, kept the issues link
- observability `Chart.yaml`: maintainer `url` instead of `email`

Scoped to those two files. ROADMAP.md and untracked docs are your in-progress work, left out.