### PR TITLE
feat(runtime): dispatch all runtimes through the adapter registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,10 @@ flowchart LR
 
     subgraph plane["NineVigil governance plane"]
         OP["NineVigil Operator<br/>(license, OPA, cost)"]
+        RT["Runtime Adapter<br/>(spec.orchestration.type)"]
         ARGO["Argo Workflows"]
+        POD["BYO Pod"]
+        KAGENT["kagent Agent"]
         PODS["Agent Pods<br/>(gVisor, egress-sealed)"]
         PROXY["LiteLLM Proxy"]
     end
@@ -215,9 +218,14 @@ flowchart LR
     PE -->|Applies AgentWorkload| API
     AUD -->|Fetches chain checkpoint| API
     API -->|Watch events| OP
-    OP -->|Creates DAG| ARGO
+    OP -->|Selects runtime| RT
+    RT -->|argo| ARGO
+    RT -->|pod| POD
+    RT -->|kagent| KAGENT
     OP -->|Injects gVisor, seals egress| PODS
-    ARGO -->|Schedules steps| PODS
+    ARGO --> PODS
+    POD --> PODS
+    KAGENT --> PODS
     PODS -->|LLM calls| PROXY
     PROXY -.->|LLM: inference| LLMEP
     PODS -->|Writes artifacts| MINIO
@@ -226,11 +234,11 @@ flowchart LR
 
     classDef plane fill:#ede9fe,stroke:#7c3aed,color:#1e1b4b;
     classDef clients fill:#dcfce7,stroke:#16a34a,color:#052e16;
-    class OP,ARGO,PODS,PROXY plane;
+    class OP,RT,ARGO,POD,KAGENT,PODS,PROXY plane;
     class PE,AUD clients;
 ```
 
-The operator seals every agent pod (gVisor sandbox, default-deny egress to an approved allow-list) and appends a signed, hash-chained record of every run. An auditor verifies that record offline, months later, with `audit-verify`. The same seal and attestation apply whether the workload is a NineVigil AgentWorkload, an Argo DAG, or your own labeled pods.
+The operator picks the execution runtime from `spec.orchestration.type` (Argo, a BYO pod, or a kagent Agent) through a pluggable adapter, then seals every agent pod (gVisor sandbox, default-deny egress to an approved allow-list) and appends a signed, hash-chained record of every run. The seal and attestation are identical across runtimes because they are enforced at the pod and network layer, not the scheduler. An auditor verifies the record offline, months later, with `audit-verify`.
 
 ---
 

--- a/docs/04-architecture.md
+++ b/docs/04-architecture.md
@@ -19,7 +19,10 @@ flowchart LR
 
     subgraph plane["NineVigil governance plane"]
         OP["NineVigil Operator<br/>(license, OPA, cost)"]
+        RT["Runtime Adapter<br/>(spec.orchestration.type)"]
         ARGO["Argo Workflows"]
+        POD["BYO Pod"]
+        KAGENT["kagent Agent"]
         PODS["Agent Pods<br/>(gVisor, egress-sealed)"]
         PROXY["LiteLLM Proxy"]
     end
@@ -32,9 +35,14 @@ flowchart LR
     PE -->|Applies AgentWorkload| API
     AUD -->|Fetches chain checkpoint| API
     API -->|Watch events| OP
-    OP -->|Creates DAG| ARGO
+    OP -->|Selects runtime| RT
+    RT -->|argo| ARGO
+    RT -->|pod| POD
+    RT -->|kagent| KAGENT
     OP -->|Injects gVisor, seals egress| PODS
-    ARGO -->|Schedules steps| PODS
+    ARGO --> PODS
+    POD --> PODS
+    KAGENT --> PODS
     PODS -->|LLM calls| PROXY
     PROXY -.->|LLM: inference| LLMEP
     PODS -->|Writes artifacts| MINIO
@@ -43,18 +51,41 @@ flowchart LR
 
     classDef plane fill:#ede9fe,stroke:#7c3aed,color:#1e1b4b;
     classDef clients fill:#dcfce7,stroke:#16a34a,color:#052e16;
-    class OP,ARGO,PODS,PROXY plane;
+    class OP,RT,ARGO,POD,KAGENT,PODS,PROXY plane;
     class PE,AUD clients;
 ```
 
 The Platform Engineer applies an `AgentWorkload`. The operator watches the API
-server, injects a gVisor sandbox and a default-deny egress seal onto the agent
-pods, and schedules the run through Argo. Agent pods reach only the approved
-LLM endpoint (via the LiteLLM proxy) and write artifacts to MinIO. Every
-consequential action is appended to a hash-chained, HMAC-signed audit chain,
-with the chain head optionally mirrored to Sigstore Rekor. An auditor fetches
-the published checkpoint and verifies the whole chain offline with
-`audit-verify`, no trust in the cluster required.
+server and picks the execution runtime from `spec.orchestration.type` through a
+pluggable adapter: an Argo DAG for multi-step jobs, a bring-your-own single pod
+for simple ones, or a kagent Agent. Whichever runs, the operator injects a
+gVisor sandbox and a default-deny egress seal onto the agent pods, because that
+governance is enforced at the pod and network layer, not the scheduler. Agent
+pods reach only the approved LLM endpoint (via the LiteLLM proxy) and write
+artifacts to MinIO. Every consequential action is appended to a hash-chained,
+HMAC-signed audit chain, with the chain head optionally mirrored to Sigstore
+Rekor. An auditor fetches the published checkpoint and verifies the whole chain
+offline with `audit-verify`, no trust in the cluster required.
+
+## Runtimes and the adapter contract
+
+The execution runtime is pluggable. The operator selects it from
+`spec.orchestration.type` through a registry of `RuntimeAdapter` implementations
+in `pkg/runtime`.
+
+- `argo` (default): multi-step DAG workflows via Argo. Use it for parallel or
+  long-running agent jobs.
+- `pod`: a bring-your-own single pod. Use it for simple, single-shot agents. The
+  pod image comes from the `NINEVIGIL_AGENT_IMAGE` env var.
+- `kagent`: a kagent `Agent` (`kagent.dev/v1alpha2`), created via the
+  unstructured client with no Go dependency on kagent. Next adapter, see the
+  roadmap.
+
+Engineering rule: never hardcode a runtime in the controller. Add a runtime by
+implementing `runtime.RuntimeAdapter` and registering it in the registry, not by
+adding a branch in `Reconcile`. Governance (gVisor sandbox label, default-deny
+egress, audit chain) is applied at the pod and network layer, so every adapter
+is governed identically without per-adapter seal code.
 
 ## Components
 

--- a/internal/controller/agentworkload_controller.go
+++ b/internal/controller/agentworkload_controller.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -128,6 +129,9 @@ func (r *AgentWorkloadReconciler) ensureRuntimeDefaults() {
 	}
 	reg := runtimeadapter.NewRegistry()
 	reg.Register("argo", &runtimeadapter.ArgoWorkflowAdapter{Client: r.Client, Scheme: r.Scheme})
+	// pod is the bring-your-own single-pod runtime. Its image comes from the
+	// NINEVIGIL_AGENT_IMAGE env var; the adapter fails closed if it is unset.
+	reg.Register("pod", &runtimeadapter.PodRuntimeAdapter{Client: r.Client, Scheme: r.Scheme, Image: os.Getenv("NINEVIGIL_AGENT_IMAGE")})
 	r.RuntimeRegistry = reg
 }
 
@@ -174,8 +178,8 @@ func (r *AgentWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	} else {
 		// Object is being deleted -- run cleanup if our finalizer is present.
 		if controllerutil.ContainsFinalizer(&workload, AgentWorkloadFinalizer) {
-			if err := r.cleanupArgoWorkflow(ctx, &workload); err != nil {
-				log.Error(err, "failed to cleanup Argo workflow during finalization")
+			if err := r.cleanupViaRuntime(ctx, &workload); err != nil {
+				log.Error(err, "failed to clean up runtime execution during finalization")
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 			}
 			controllerutil.RemoveFinalizer(&workload, AgentWorkloadFinalizer)
@@ -345,9 +349,11 @@ func (r *AgentWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Check if this is an Argo-orchestrated workload
-	if workload.Spec.Orchestration != nil && workload.Spec.Orchestration.Type != nil && *workload.Spec.Orchestration.Type == "argo" {
-		return r.reconcileArgoWorkflow(ctx, &workload)
+	// Route orchestrated workloads through the runtime adapter registry. Any
+	// registered runtime (argo, pod, and future adapters) is dispatched here and
+	// governed identically. An unknown type fails closed with an actionable error.
+	if workload.Spec.Orchestration != nil && workload.Spec.Orchestration.Type != nil && strings.TrimSpace(*workload.Spec.Orchestration.Type) != "" {
+		return r.reconcileViaRuntime(ctx, &workload)
 	}
 
 	// Step 2: Connect to MCP server and fetch status
@@ -640,11 +646,13 @@ func pruneActions(actions []agenticv1alpha1.Action, maxSize int) []agenticv1alph
 	return actions[len(actions)-maxSize:]
 }
 
-// reconcileArgoWorkflow handles reconciliation for orchestrated workloads by
+// reconcileViaRuntime handles reconciliation for orchestrated workloads by
 // dispatching to the runtime adapter resolved from spec.orchestration.type.
 // The Argo adapter preserves all historical behavior; other registered
-// runtimes get the same governance and status mapping.
-func (r *AgentWorkloadReconciler) reconcileArgoWorkflow(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (ctrl.Result, error) {
+// runtimes (pod, and future adapters) get the same governance and status
+// mapping. The execution reference is stored in Status.ArgoWorkflow, which is
+// runtime-neutral despite its historical name.
+func (r *AgentWorkloadReconciler) reconcileViaRuntime(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	log.Info("Reconciling orchestrated workload", "name", workload.Name)
 
@@ -728,10 +736,10 @@ func (r *AgentWorkloadReconciler) reconcileArgoWorkflow(ctx context.Context, wor
 	return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 }
 
-// cleanupArgoWorkflow deletes the execution associated with this AgentWorkload
+// cleanupViaRuntime deletes the execution associated with this AgentWorkload
 // via the runtime adapter. Invoked from the finalizer path. Safe to call when
 // no execution was ever created.
-func (r *AgentWorkloadReconciler) cleanupArgoWorkflow(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) error {
+func (r *AgentWorkloadReconciler) cleanupViaRuntime(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) error {
 	log := logf.FromContext(ctx)
 
 	if workload.Status.ArgoWorkflow == nil || workload.Status.ArgoWorkflow.Name == "" {

--- a/internal/controller/runtime_wiring_test.go
+++ b/internal/controller/runtime_wiring_test.go
@@ -44,6 +44,28 @@ func TestEnsureRuntimeDefaults_RegistersArgo(t *testing.T) {
 	}
 }
 
+// TestEnsureRuntimeDefaults_RegistersPod verifies the bring-your-own single-pod
+// runtime is reachable through the registry, so a workload with
+// spec.orchestration.type: pod dispatches to the pod adapter instead of falling
+// through to the legacy MCP path.
+func TestEnsureRuntimeDefaults_RegistersPod(t *testing.T) {
+	r := &AgentWorkloadReconciler{}
+
+	r.ensureRuntimeDefaults()
+
+	registered := r.RuntimeRegistry.Registered()
+	found := false
+	for _, name := range registered {
+		if name == "pod" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("registered runtimes = %v, want pod present", registered)
+	}
+}
+
 // TestEnsureRuntimeDefaults_Idempotent verifies a second call does not replace
 // an already-configured registry (e.g. one injected by a test or by main).
 func TestEnsureRuntimeDefaults_Idempotent(t *testing.T) {


### PR DESCRIPTION
## What

The controller hardcoded `spec.orchestration.type == "argo"` and called the Argo path directly, so `pkg/runtime`'s registry and the pod adapter were dead code for dispatch. This wires dispatch through the registry so `spec.orchestration.type` actually selects the runtime.

- Any non-empty orchestration type routes through `registry.For()`. Unknown types fail closed with an actionable error instead of silently falling through to the MCP path.
- Registers the bring-your-own `pod` adapter (image from `NINEVIGIL_AGENT_IMAGE`, fails closed if unset).
- Renames `reconcileArgoWorkflow`/`cleanupArgoWorkflow` to `reconcileViaRuntime`/`cleanupViaRuntime` (runtime-neutral now).
- Adds a wiring test for the pod registration.

## Docs

- Architecture diagram (README + `04-architecture.md`) now shows the runtime adapter selecting argo/pod/kagent, all converging on the same gVisor-sandboxed, egress-sealed pods.
- New `Runtimes and the adapter contract` section documents the no-hardcode rule.

## Compatibility

Backward compatible. `type` unset or `argo` behaves exactly as before. No CRD change; the execution ref still lives in `Status.ArgoWorkflow` (runtime-neutral holder, generalizing the field name is a follow-up).

## Verification

`go build`, `go vet`, runtime unit tests, and the full envtest controller suite (`make test-controller`) all green locally.

This is Slice 1 of the runtime-adapter work. Slice 2 adds the kagent adapter (kagent.dev/v1alpha2 via unstructured, no Go dependency).

Note: ROADMAP.md and the untracked docs on main are unrelated in-progress work, not part of this PR.