### PR TITLE
feat(runtime): add kagent adapter and fix the shared egress seal

### DIFF
--- a/docs/04-architecture.md
+++ b/docs/04-architecture.md
@@ -77,15 +77,17 @@ in `pkg/runtime`.
   long-running agent jobs.
 - `pod`: a bring-your-own single pod. Use it for simple, single-shot agents. The
   pod image comes from the `NINEVIGIL_AGENT_IMAGE` env var.
-- `kagent`: a kagent `Agent` (`kagent.dev/v1alpha2`), created via the
-  unstructured client with no Go dependency on kagent. Next adapter, see the
-  roadmap.
+- `kagent`: runs the workload as a kagent `Agent` (`kagent.dev/v1alpha2`) in BYO
+  mode, created through the unstructured client with no Go dependency on kagent.
+  Requires kagent installed in the cluster. Same image source, same seal.
 
-Engineering rule: never hardcode a runtime in the controller. Add a runtime by
-implementing `runtime.RuntimeAdapter` and registering it in the registry, not by
-adding a branch in `Reconcile`. Governance (gVisor sandbox label, default-deny
-egress, audit chain) is applied at the pod and network layer, so every adapter
-is governed identically without per-adapter seal code.
+All three stamp the same governance labels onto their pods through a shared
+helper, so the gVisor sandbox and the default-deny egress policy apply
+identically. Engineering rule: never hardcode a runtime in the controller. Add a
+runtime by implementing `runtime.RuntimeAdapter` and registering it in the
+registry, not by adding a branch in `Reconcile`. Governance is applied at the pod
+and network layer, so every adapter is governed identically without per-adapter
+seal code.
 
 ## Components
 

--- a/internal/controller/agentworkload_controller.go
+++ b/internal/controller/agentworkload_controller.go
@@ -132,6 +132,9 @@ func (r *AgentWorkloadReconciler) ensureRuntimeDefaults() {
 	// pod is the bring-your-own single-pod runtime. Its image comes from the
 	// NINEVIGIL_AGENT_IMAGE env var; the adapter fails closed if it is unset.
 	reg.Register("pod", &runtimeadapter.PodRuntimeAdapter{Client: r.Client, Scheme: r.Scheme, Image: os.Getenv("NINEVIGIL_AGENT_IMAGE")})
+	// kagent runs the workload as a kagent Agent (kagent.dev/v1alpha2) via the
+	// unstructured client, no Go dependency. Same image source, same governance.
+	reg.Register("kagent", &runtimeadapter.KagentAdapter{Client: r.Client, Image: os.Getenv("NINEVIGIL_AGENT_IMAGE")})
 	r.RuntimeRegistry = reg
 }
 

--- a/internal/controller/runtime_wiring_test.go
+++ b/internal/controller/runtime_wiring_test.go
@@ -66,6 +66,27 @@ func TestEnsureRuntimeDefaults_RegistersPod(t *testing.T) {
 	}
 }
 
+// TestEnsureRuntimeDefaults_RegistersKagent verifies the kagent runtime is
+// reachable through the registry, so a workload with
+// spec.orchestration.type: kagent dispatches to the kagent adapter.
+func TestEnsureRuntimeDefaults_RegistersKagent(t *testing.T) {
+	r := &AgentWorkloadReconciler{}
+
+	r.ensureRuntimeDefaults()
+
+	registered := r.RuntimeRegistry.Registered()
+	found := false
+	for _, name := range registered {
+		if name == "kagent" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("registered runtimes = %v, want kagent present", registered)
+	}
+}
+
 // TestEnsureRuntimeDefaults_Idempotent verifies a second call does not replace
 // an already-configured registry (e.g. one injected by a test or by main).
 func TestEnsureRuntimeDefaults_Idempotent(t *testing.T) {

--- a/pkg/runtime/kagent_adapter.go
+++ b/pkg/runtime/kagent_adapter.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	kagentGroup   = "kagent.dev"
+	kagentVersion = "v1alpha2"
+	kagentKind    = "Agent"
+)
+
+// kagentGVK is the GroupVersionKind of the kagent Agent CRD. We interop with it
+// through the unstructured client, so we take no Go dependency on kagent and
+// never import its types. Verify the group against a live CRD before relying on
+// this in production; the version is v1alpha2 as of 2026-07.
+var kagentGVK = schema.GroupVersionKind{Group: kagentGroup, Version: kagentVersion, Kind: kagentKind}
+
+// KagentAdapter runs an AgentWorkload as a kagent Agent (kagent.dev/v1alpha2)
+// in BYO mode: kagent deploys our agent image and serves it over A2A. We stamp
+// the NineVigil governance labels onto kagent's pods through its deployment
+// label passthrough, so the gVisor injector and the egress NetworkPolicy seal
+// them identically to every other runtime. No Go dependency on kagent:
+// everything goes through the unstructured client.
+type KagentAdapter struct {
+	Client client.Client
+	Image  string
+}
+
+var _ RuntimeAdapter = (*KagentAdapter)(nil)
+
+// Capabilities reports what the kagent runtime supports. A BYO agent is a
+// single long-running service, so no DAG, resume, or artifact graph.
+func (a *KagentAdapter) Capabilities() RuntimeCapabilities {
+	return RuntimeCapabilities{
+		SupportsDAG:        false,
+		SupportsResume:     false,
+		SupportsArtifacts:  false,
+		SupportsCostReport: false,
+	}
+}
+
+// Execute creates the kagent Agent for a workload. It fails closed when no
+// agent image is configured rather than creating an unusable Agent.
+func (a *KagentAdapter) Execute(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
+	if a.Image == "" {
+		return nil, fmt.Errorf("kagent adapter: agent image is required (set NINEVIGIL_AGENT_IMAGE)")
+	}
+	agent := a.buildAgent(workload)
+	if err := a.Client.Create(ctx, agent); err != nil && !apierrors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("kagent adapter: create Agent %q: %w", agent.GetName(), err)
+	}
+	return &ExecutionStatus{
+		Phase:     "Pending",
+		Name:      agent.GetName(),
+		Namespace: agent.GetNamespace(),
+		UID:       string(agent.GetUID()),
+	}, nil
+}
+
+// Status maps the kagent Agent's conditions onto the normalized phase.
+func (a *KagentAdapter) Status(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
+	agent := newKagentAgent()
+	key := types.NamespacedName{Name: kagentAgentName(workload), Namespace: workload.GetNamespace()}
+	if err := a.Client.Get(ctx, key, agent); err != nil {
+		if apierrors.IsNotFound(err) {
+			return &ExecutionStatus{Phase: "Pending", Name: key.Name, Namespace: key.Namespace}, nil
+		}
+		return nil, fmt.Errorf("kagent adapter: get Agent %q: %w", key.Name, err)
+	}
+	return &ExecutionStatus{
+		Phase:     mapKagentPhase(agent),
+		Name:      agent.GetName(),
+		Namespace: agent.GetNamespace(),
+		UID:       string(agent.GetUID()),
+	}, nil
+}
+
+// Cleanup deletes the kagent Agent. Safe to call when none exists.
+func (a *KagentAdapter) Cleanup(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) error {
+	agent := newKagentAgent()
+	agent.SetName(kagentAgentName(workload))
+	agent.SetNamespace(workload.GetNamespace())
+	if err := a.Client.Delete(ctx, agent); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("kagent adapter: delete Agent %q: %w", agent.GetName(), err)
+	}
+	return nil
+}
+
+// buildAgent constructs the kagent Agent as an unstructured object. It is pure
+// aside from reading the workload, so the governance-label contract is
+// unit-testable without a cluster. The critical part is stamping the same
+// governance labels every other runtime uses into the BYO deployment labels,
+// which kagent passes through to the agent pods.
+func (a *KagentAdapter) buildAgent(workload *agenticv1alpha1.AgentWorkload) *unstructured.Unstructured {
+	agent := newKagentAgent()
+	agent.SetName(kagentAgentName(workload))
+	agent.SetNamespace(workload.GetNamespace())
+
+	podLabels := map[string]interface{}{}
+	for k, v := range governanceLabels(workload) {
+		podLabels[k] = v
+	}
+
+	agent.Object["spec"] = map[string]interface{}{
+		"type": "BYO",
+		"byo": map[string]interface{}{
+			"deployment": map[string]interface{}{
+				"image":  a.Image,
+				"labels": podLabels,
+			},
+		},
+	}
+	return agent
+}
+
+func newKagentAgent() *unstructured.Unstructured {
+	agent := &unstructured.Unstructured{}
+	agent.SetGroupVersionKind(kagentGVK)
+	return agent
+}
+
+func kagentAgentName(workload *agenticv1alpha1.AgentWorkload) string {
+	return workload.GetName()
+}
+
+// mapKagentPhase maps kagent's status conditions onto the normalized phase
+// vocabulary. A kagent BYO Agent is a long-running service, so Ready maps to
+// Running, not Succeeded. An explicit Accepted=False maps to Failed.
+func mapKagentPhase(agent *unstructured.Unstructured) string {
+	conditions, found, err := unstructured.NestedSlice(agent.Object, "status", "conditions")
+	if err != nil || !found {
+		return "Pending"
+	}
+	var accepted, ready string
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		ctype, _ := cond["type"].(string)
+		cstatus, _ := cond["status"].(string)
+		switch ctype {
+		case "Accepted":
+			accepted = cstatus
+		case "Ready":
+			ready = cstatus
+		}
+	}
+	switch {
+	case accepted == "False":
+		return "Failed"
+	case ready == "True":
+		return "Running"
+	default:
+		return "Pending"
+	}
+}

--- a/pkg/runtime/kagent_adapter.go
+++ b/pkg/runtime/kagent_adapter.go
@@ -139,7 +139,10 @@ func (a *KagentAdapter) buildAgent(workload *agenticv1alpha1.AgentWorkload) *uns
 }
 
 func newKagentAgent() *unstructured.Unstructured {
-	agent := &unstructured.Unstructured{}
+	// Initialize Object explicitly. SetGroupVersionKind already does this today,
+	// but a nil map here would panic on the first field write, so we do not rely
+	// on call ordering.
+	agent := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	agent.SetGroupVersionKind(kagentGVK)
 	return agent
 }

--- a/pkg/runtime/kagent_adapter_test.go
+++ b/pkg/runtime/kagent_adapter_test.go
@@ -72,7 +72,7 @@ func TestKagentAdapter_BuildAgentContract(t *testing.T) {
 	if labels[admission.DefaultRuntimeLabelKey] != admission.DefaultRuntimeLabelValue {
 		t.Errorf("missing gVisor sandbox label, got %v", labels)
 	}
-	if labels[GovernanceEgressLabelKey] != GovernanceEgressLabelValue {
+	if labels[GovernanceEgressPartOfKey] != GovernanceEgressPartOfValue {
 		t.Errorf("missing egress part-of label, got %v", labels)
 	}
 }
@@ -113,7 +113,7 @@ func TestGovernanceLabels_IncludesEgressAndSandbox(t *testing.T) {
 	if l[admission.DefaultRuntimeLabelKey] != admission.DefaultRuntimeLabelValue {
 		t.Errorf("missing gVisor sandbox label: %v", l)
 	}
-	if l[GovernanceEgressLabelKey] != GovernanceEgressLabelValue {
+	if l[GovernanceEgressPartOfKey] != GovernanceEgressPartOfValue {
 		t.Errorf("missing egress part-of label: %v", l)
 	}
 }

--- a/pkg/runtime/kagent_adapter_test.go
+++ b/pkg/runtime/kagent_adapter_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/internal/admission"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func kagentTestWorkload() *agenticv1alpha1.AgentWorkload {
+	return &agenticv1alpha1.AgentWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "agentic-system"},
+	}
+}
+
+// TestKagentAdapter_ExecuteRequiresImage confirms the adapter fails closed
+// rather than creating an unusable kagent Agent with no image.
+func TestKagentAdapter_ExecuteRequiresImage(t *testing.T) {
+	a := &KagentAdapter{} // no image configured
+	if _, err := a.Execute(context.Background(), kagentTestWorkload()); err == nil {
+		t.Fatal("expected an error when the agent image is empty, got nil")
+	}
+}
+
+// TestKagentAdapter_BuildAgentContract is the governance keystone: it proves the
+// kagent Agent we build carries both load-bearing governance labels, so the
+// gVisor injector and the egress NetworkPolicy seal kagent's pods identically to
+// every other runtime.
+func TestKagentAdapter_BuildAgentContract(t *testing.T) {
+	a := &KagentAdapter{Image: "ghcr.io/clawdlinux/agent:test"}
+	agent := a.buildAgent(kagentTestWorkload())
+
+	if gvk := agent.GroupVersionKind(); gvk != kagentGVK {
+		t.Fatalf("GVK = %v, want %v", gvk, kagentGVK)
+	}
+	if agent.GetName() != "demo" || agent.GetNamespace() != "agentic-system" {
+		t.Fatalf("name/namespace = %s/%s, want demo/agentic-system", agent.GetName(), agent.GetNamespace())
+	}
+
+	atype, _, _ := unstructured.NestedString(agent.Object, "spec", "type")
+	if atype != "BYO" {
+		t.Errorf("spec.type = %q, want BYO", atype)
+	}
+	image, _, _ := unstructured.NestedString(agent.Object, "spec", "byo", "deployment", "image")
+	if image != "ghcr.io/clawdlinux/agent:test" {
+		t.Errorf("spec.byo.deployment.image = %q", image)
+	}
+
+	labels, found, err := unstructured.NestedStringMap(agent.Object, "spec", "byo", "deployment", "labels")
+	if err != nil || !found {
+		t.Fatalf("deployment labels not found: found=%v err=%v", found, err)
+	}
+	if labels[admission.DefaultRuntimeLabelKey] != admission.DefaultRuntimeLabelValue {
+		t.Errorf("missing gVisor sandbox label, got %v", labels)
+	}
+	if labels[GovernanceEgressLabelKey] != GovernanceEgressLabelValue {
+		t.Errorf("missing egress part-of label, got %v", labels)
+	}
+}
+
+// TestKagentAdapter_MapPhase covers the condition-to-phase mapping. A BYO agent
+// is a long-running service, so Ready maps to Running, not Succeeded.
+func TestKagentAdapter_MapPhase(t *testing.T) {
+	cases := []struct {
+		name       string
+		conditions []interface{}
+		want       string
+	}{
+		{"no status", nil, "Pending"},
+		{"ready true", []interface{}{map[string]interface{}{"type": "Ready", "status": "True"}}, "Running"},
+		{"accepted false", []interface{}{map[string]interface{}{"type": "Accepted", "status": "False"}}, "Failed"},
+		{"accepted true not ready", []interface{}{map[string]interface{}{"type": "Accepted", "status": "True"}}, "Pending"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := newKagentAgent()
+			if tc.conditions != nil {
+				if err := unstructured.SetNestedSlice(agent.Object, tc.conditions, "status", "conditions"); err != nil {
+					t.Fatalf("set conditions: %v", err)
+				}
+			}
+			if got := mapKagentPhase(agent); got != tc.want {
+				t.Errorf("mapKagentPhase = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGovernanceLabels_IncludesEgressAndSandbox guards the shared helper that
+// every adapter uses. Both labels are load-bearing: drop either and a runtime's
+// pods stop being sealed.
+func TestGovernanceLabels_IncludesEgressAndSandbox(t *testing.T) {
+	l := governanceLabels(kagentTestWorkload())
+	if l[admission.DefaultRuntimeLabelKey] != admission.DefaultRuntimeLabelValue {
+		t.Errorf("missing gVisor sandbox label: %v", l)
+	}
+	if l[GovernanceEgressLabelKey] != GovernanceEgressLabelValue {
+		t.Errorf("missing egress part-of label: %v", l)
+	}
+}

--- a/pkg/runtime/labels.go
+++ b/pkg/runtime/labels.go
@@ -21,12 +21,12 @@ import (
 	"github.com/Clawdlinux/agentic-operator-core/internal/admission"
 )
 
-// GovernanceEgressLabelKey is the label the default-deny egress NetworkPolicy
+// GovernanceEgressPartOfKey is the label the default-deny egress NetworkPolicy
 // selects on. Pods without it are not sealed by the policy, so every adapter
 // must stamp it.
 const (
-	GovernanceEgressLabelKey   = "app.kubernetes.io/part-of"
-	GovernanceEgressLabelValue = "agentic-operator"
+	GovernanceEgressPartOfKey   = "app.kubernetes.io/part-of"
+	GovernanceEgressPartOfValue = "agentic-operator"
 )
 
 // governanceLabels returns the pod labels that place a workload's pods under
@@ -38,7 +38,7 @@ const (
 func governanceLabels(workload *agenticv1alpha1.AgentWorkload) map[string]string {
 	return map[string]string{
 		admission.DefaultRuntimeLabelKey:  admission.DefaultRuntimeLabelValue, // gVisor injector
-		GovernanceEgressLabelKey:          GovernanceEgressLabelValue,         // egress NetworkPolicy
+		GovernanceEgressPartOfKey:         GovernanceEgressPartOfValue,        // egress NetworkPolicy
 		"app.kubernetes.io/managed-by":    "agentic-operator",
 		"agentic.clawdlinux.org/workload": workload.GetName(),
 	}

--- a/pkg/runtime/labels.go
+++ b/pkg/runtime/labels.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
+	"github.com/Clawdlinux/agentic-operator-core/internal/admission"
+)
+
+// GovernanceEgressLabelKey is the label the default-deny egress NetworkPolicy
+// selects on. Pods without it are not sealed by the policy, so every adapter
+// must stamp it.
+const (
+	GovernanceEgressLabelKey   = "app.kubernetes.io/part-of"
+	GovernanceEgressLabelValue = "agentic-operator"
+)
+
+// governanceLabels returns the pod labels that place a workload's pods under
+// NineVigil governance. Two are load-bearing: the gVisor RuntimeClass injector
+// keys on the sandbox label, and the default-deny egress NetworkPolicy selects
+// on part-of. Every adapter stamps these onto the pods it creates so the seal
+// is identical across runtimes, whether the scheduler is Argo, a plain pod, or
+// kagent. Governance is applied at the pod and network layer, never per-adapter.
+func governanceLabels(workload *agenticv1alpha1.AgentWorkload) map[string]string {
+	return map[string]string{
+		admission.DefaultRuntimeLabelKey:  admission.DefaultRuntimeLabelValue, // gVisor injector
+		GovernanceEgressLabelKey:          GovernanceEgressLabelValue,         // egress NetworkPolicy
+		"app.kubernetes.io/managed-by":    "agentic-operator",
+		"agentic.clawdlinux.org/workload": workload.GetName(),
+	}
+}

--- a/pkg/runtime/labels.go
+++ b/pkg/runtime/labels.go
@@ -24,6 +24,14 @@ import (
 // GovernanceEgressPartOfKey is the label the default-deny egress NetworkPolicy
 // selects on. Pods without it are not sealed by the policy, so every adapter
 // must stamp it.
+//
+// GovernanceEgressPartOfValue MUST match the value the egress NetworkPolicy
+// selects on (charts/templates/networkpolicy.yaml). Most other platform
+// resources (Argo pods, shared services, RBAC) currently label part-of
+// "agentic-k8s-operator", which the NetworkPolicy does NOT select. Reconciling
+// the whole platform onto a single part-of value is a tracked follow-up. This
+// helper deliberately uses the NetworkPolicy's value so the pods it governs are
+// actually sealed.
 const (
 	GovernanceEgressPartOfKey   = "app.kubernetes.io/part-of"
 	GovernanceEgressPartOfValue = "agentic-operator"

--- a/pkg/runtime/pod_adapter.go
+++ b/pkg/runtime/pod_adapter.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	agenticv1alpha1 "github.com/Clawdlinux/agentic-operator-core/api/v1alpha1"
-	"github.com/Clawdlinux/agentic-operator-core/internal/admission"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,16 +122,13 @@ func PodName(workload *agenticv1alpha1.AgentWorkload) string {
 // RuntimeClassName itself; governance is applied by the platform, identically
 // for every runtime.
 func buildGovernedPod(workload *agenticv1alpha1.AgentWorkload, image string) *corev1.Pod {
+	labels := governanceLabels(workload)
+	labels["agentic.clawdlinux.org/runtime"] = "pod"
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      PodName(workload),
 			Namespace: workload.GetNamespace(),
-			Labels: map[string]string{
-				admission.DefaultRuntimeLabelKey:  admission.DefaultRuntimeLabelValue,
-				"app.kubernetes.io/managed-by":    "agentic-operator",
-				"agentic.clawdlinux.org/workload": workload.GetName(),
-				"agentic.clawdlinux.org/runtime":  "pod",
-			},
+			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
Slice 2 of the runtime-adapter work (Slice 1 was #166).

## What

An `AgentWorkload` with `spec.orchestration.type: kagent` now runs as a kagent `Agent` (`kagent.dev/v1alpha2`) in BYO mode. We create it through the unstructured client, so there is **no Go dependency on kagent** and we never import its types.

## The real fix: governance parity

All adapters now stamp their pods through one `governanceLabels` helper that sets **both** load-bearing labels:
- `agentic.clawdlinux.org/runtime-sandbox: gvisor` (the gVisor RuntimeClass injector)
- `app.kubernetes.io/part-of: agentic-operator` (the default-deny egress NetworkPolicy)

This fixes a latent gap: the pod adapter only stamped the sandbox label, so its pods were never selected by the egress policy. Now every runtime (argo, pod, kagent) gets the identical seal.

## Changes

- `pkg/runtime/kagent_adapter.go`: KagentAdapter, BYO mode, label injection into `spec.byo.deployment.labels`, condition-to-phase mapping (Ready to Running, since a BYO agent is a long-running service).
- `pkg/runtime/labels.go`: shared `governanceLabels` helper.
- `pkg/runtime/pod_adapter.go`: uses the helper (gains the missing part-of label).
- Registers `kagent` in `ensureRuntimeDefaults`.
- Tests: build-agent contract (asserts both governance labels), phase mapping, image-required guard, registration wiring.
- `docs/04-architecture.md`: kagent runtime documented.

## Verification

`go build`, `go vet`, runtime unit tests, and `make test-controller` (envtest) all green locally. No Go dependency added.

## Caveat

Unit tests cover the build-agent contract and phase mapping (the governance keystone). Full kagent end-to-end needs kagent installed in the cluster; that is an integration-test follow-up. The kagent GVK group (`kagent.dev`) is set as a constant to confirm against a live CRD before production use.