### PR TITLE
fix(demo): make lean profile reproducible on local kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ manager
 
 # Logs and test outputs
 *.log
+demos/*.cast
+demos/live/*.typescript
 # Build artifacts
 *.log
 generate-license

--- a/_staging/booth/rehearsal-checklist.md
+++ b/_staging/booth/rehearsal-checklist.md
@@ -45,9 +45,10 @@ phases and adds explicit pass/fail gates the script does not assert for you.
 - [ ] FAIL signal: deadline hit. Check `kubectl -n agentic-system describe pod`.
       Almost always an un-cached image. Go back to step 0.
 
-## 4. Stack install (script: "Installing ... stack")
+## 4. Deployment profile (script: "Installing ... profile")
 
-- [ ] Decide path before you start: full (Argo) or `--skip-argo` (Week 2 gate).
+- [ ] Decide before you start: `--profile platform` (Argo and shared services)
+      or `--profile lean` (operator and governance controls only).
       Rehearse the one you will present.
 - [ ] PASS gate: helm install completes within `HELM_TIMEOUT` (default 180s).
 - [ ] FAIL signal: helm timeout. Raise `HELM_TIMEOUT=300s` only if the laptop is
@@ -88,9 +89,9 @@ phases and adds explicit pass/fail gates the script does not assert for you.
 - [ ] If the live run hiccups, fall back to `_staging/booth/attestation-fallback.jsonl`
       and run the same verify + tamper demo. Never debug live on a prospect's time.
 
-## 10. Multi-agent swarm (script: "PHASE 2", needs --full)
+## 10. Multi-agent swarm (optional scenario, needs `--with-swarm`)
 
-- [ ] Only if presenting the swarm: run with `--full`.
+- [ ] Only if presenting the swarm: run with `--with-swarm` and the platform profile.
 - [ ] PASS gate: 3-agent swarm reaches a terminal state without manual nudging.
 
 ## 11. Teardown
@@ -113,6 +114,6 @@ demo time budget. Anything less and you are gambling on the venue.
 
 ## Optional: record a backup
 
-- [ ] `scripts/demo-booth.sh --full --record` captures terminal output with
+- [ ] `scripts/demo-booth.sh --profile platform --with-swarm --record` captures terminal output with
       script(1). Keep one clean recording as a last-resort fallback if the laptop
       itself dies.

--- a/agentworkload.yaml
+++ b/agentworkload.yaml
@@ -1,15 +1,15 @@
 apiVersion: agentic.clawdlinux.org/v1alpha1
 kind: AgentWorkload
 metadata:
-  name: week1-pod-gate
+  name: demo-argo-gate
   namespace: agentic-system
   labels:
     app.kubernetes.io/part-of: ninevigil
-    gate: week1
+    gate: demo
 spec:
-  objective: "Run the Week 1 pod creation gate."
+  objective: "Run the Argo workload demo gate."
   workloadType: generic
-  jobId: week1-pod-gate
+  jobId: demo-argo-gate
   orchestration:
     type: argo
   targetUrls:

--- a/scripts/clean-cluster-test.sh
+++ b/scripts/clean-cluster-test.sh
@@ -12,7 +12,7 @@ kind delete cluster --name "${CLUSTER}" || true
 kind create cluster --name "${CLUSTER}" --wait 60s
 
 set +e
-./scripts/demo-booth.sh --skip-argo
+./scripts/demo-booth.sh --profile lean
 exit_code=$?
 set -e
 if (( exit_code == 0 )); then

--- a/scripts/demo-booth.sh
+++ b/scripts/demo-booth.sh
@@ -9,19 +9,21 @@ NS_OPERATOR="${NS_OPERATOR:-agentic-system}"
 NS_ARGO="${NS_ARGO:-argo-workflows}"
 NS_SHARED="${NS_SHARED:-shared-services}"
 HELM_TIMEOUT="${HELM_TIMEOUT:-180s}"
+OPERATOR_IMAGE="${OPERATOR_IMAGE:-ghcr.io/clawdlinux/agentic-operator-core/agentic-operator}"
+OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG:-latest}"
 
 ALLOW_MANIFEST="${REPO_ROOT}/config/samples/agentworkload_demo_allow.yaml"
 DENY_MANIFEST="${REPO_ROOT}/config/samples/agentworkload_demo_deny.yaml"
 SWARM_MANIFEST="${REPO_ROOT}/config/samples/agentworkload_demo_swarm.yaml"
 EVIDENCE_DIR="${EVIDENCE_DIR:-${REPO_ROOT}/tests/harness/evidence/booth-$(date +%Y%m%dT%H%M%S)}"
 
-SKIP_ARGO=false
-FULL=false
+DEMO_PROFILE="${DEMO_PROFILE:-platform}"
+WITH_SWARM=false
 RECORD=false
 CLEANUP=false
 ORIGINAL_ARGS=("$@")
 
-if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+if [[ ( -t 1 || "${FORCE_COLOR:-}" == "1" ) && -z "${NO_COLOR:-}" ]]; then
   BOLD="$(printf '\033[1m')"
   GREEN="$(printf '\033[32m')"
   RED="$(printf '\033[31m')"
@@ -45,8 +47,10 @@ Runs the NineVigil booth demo gate.
 
 Options:
   --cluster NAME    kind cluster name. Default: ${CLUSTER_NAME}
-  --skip-argo       Skip Argo/shared-services setup. Week 2 gate path.
-  --full            Run Phase 2 multi-agent swarm demo.
+  --profile NAME    Deployment profile: platform or lean. Default: ${DEMO_PROFILE}
+  --with-swarm      Run the optional Argo multi-agent swarm scenario.
+  --skip-argo       Compatibility alias for --profile lean.
+  --full            Compatibility alias for --with-swarm.
   --record          Record terminal output with script(1).
   --cleanup         Delete the kind cluster and exit.
   -h, --help        Show this help.
@@ -55,6 +59,9 @@ Environment:
   DEMO_MCP_ENDPOINT Override https://localhost:8443 in sample manifests.
   HELM_TIMEOUT      Helm wait timeout. Default: ${HELM_TIMEOUT}
   NS_OPERATOR       Operator namespace. Default: ${NS_OPERATOR}
+  OPERATOR_IMAGE    Operator image repository. Default: ${OPERATOR_IMAGE}
+  OPERATOR_IMAGE_TAG Operator image tag. Default: ${OPERATOR_IMAGE_TAG}
+  FORCE_COLOR       Set to 1 to preserve ANSI colors through a recorder or pipe.
 EOF
 }
 
@@ -72,12 +79,24 @@ parse_args() {
         CLUSTER_NAME="$2"
         shift 2
         ;;
+      --profile)
+        [[ $# -ge 2 ]] || die "--profile requires platform or lean"
+        case "$2" in
+          platform|lean)
+            DEMO_PROFILE="$2"
+            ;;
+          *)
+            die "invalid profile: $2 (expected platform or lean)"
+            ;;
+        esac
+        shift 2
+        ;;
       --skip-argo)
-        SKIP_ARGO=true
+        DEMO_PROFILE=lean
         shift
         ;;
-      --full)
-        FULL=true
+      --with-swarm|--full)
+        WITH_SWARM=true
         shift
         ;;
       --record)
@@ -213,19 +232,25 @@ wait_for_operator() {
   die "Operator pod did not reach Running"
 }
 
-install_full_stack() {
-  step "Installing full stack with tests/harness/setup.sh"
+install_platform_profile() {
+  step "Installing platform profile with Argo and shared services"
   HELM_TIMEOUT="${HELM_TIMEOUT}" bash "${REPO_ROOT}/tests/harness/setup.sh" || {
-    die "setup.sh failed. For Week 2, rerun with --skip-argo to bypass Argo."
+    die "setup.sh failed. Rerun with --profile lean to omit Argo and shared services."
   }
   wait_for_operator
 }
 
-install_week2_stack() {
-  step "Installing Week 2 stack without Argo"
+install_lean_profile() {
+  step "Installing lean profile without Argo or shared services"
+  local operator_image="${OPERATOR_IMAGE}:${OPERATOR_IMAGE_TAG}"
+  if command -v kind >/dev/null 2>&1 && docker image inspect "${operator_image}" >/dev/null 2>&1; then
+    kind load docker-image "${operator_image}" --name "${CLUSTER_NAME}" >/dev/null
+    ok "Loaded local operator image: ${operator_image}"
+  fi
   ensure_namespace "${NS_OPERATOR}"
   kubectl apply -f "${REPO_ROOT}/config/crd/agentworkload_crd.yaml" >/dev/null
 
+  # Suppress webhook resources and process registration in the lean profile.
   helm upgrade --install agentic-operator "${REPO_ROOT}/charts" \
     --namespace "${NS_OPERATOR}" \
     --create-namespace \
@@ -240,6 +265,9 @@ install_week2_stack() {
     --set global.runtimeSandbox.enabled=true \
     --set global.runtimeSandbox.createRuntimeClass=true \
     --set agenticOperator.webhook.enabled=false \
+    --set agentic-operator.env.ENABLE_WEBHOOKS=false \
+    --set agentic-operator.image.repository="${OPERATOR_IMAGE}" \
+    --set agentic-operator.image.tag="${OPERATOR_IMAGE_TAG}" \
     --set agentic-operator.image.pullPolicy=IfNotPresent \
     --timeout "${HELM_TIMEOUT}" \
     --wait >/dev/null
@@ -304,9 +332,17 @@ deny_reason() {
 
 show_workload_evidence() {
   step "AgentWorkload status"
-  kubectl -n "${NS_OPERATOR}" get agentworkload -o wide || true
-  echo ""
-  kubectl -n "${NS_OPERATOR}" describe agentworkload opa-allow-demo || true
+  kubectl -n "${NS_OPERATOR}" get agentworkload \
+    -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,OBJECTIVE:.spec.objective' || true
+
+  local action confidence
+  action="$(kubectl -n "${NS_OPERATOR}" get agentworkload opa-allow-demo \
+    -o jsonpath='{.status.executedActions[-1].name}' 2>/dev/null || true)"
+  confidence="$(kubectl -n "${NS_OPERATOR}" get agentworkload opa-allow-demo \
+    -o jsonpath='{.status.executedActions[-1].confidence}' 2>/dev/null || true)"
+  if [[ -n "${action}" ]]; then
+    printf '%bExecuted action:%b %s (confidence %s)\n' "${GREEN}" "${RESET}" "${action}" "${confidence:-unknown}"
+  fi
 }
 
 show_agent_pods() {
@@ -468,14 +504,14 @@ workflow_phase() {
 }
 
 run_swarm_demo() {
-  if [[ "${FULL}" != "true" ]]; then
-    SWARM_PHASE="skipped (use --full)"
+  if [[ "${WITH_SWARM}" != "true" ]]; then
+    SWARM_PHASE="skipped (use --with-swarm)"
     return
   fi
 
-  step "PHASE 2: Multi-Agent Swarm"
-  if [[ "${SKIP_ARGO}" == "true" ]]; then
-    warn "Swarm skipped because --skip-argo disables Argo installation"
+  step "Optional scenario: Multi-Agent Swarm"
+  if [[ "${DEMO_PROFILE}" == "lean" ]]; then
+    warn "Swarm skipped because the lean profile does not install Argo"
     SWARM_PHASE="skipped (no argo)"
     return
   fi
@@ -528,7 +564,7 @@ print_summary() {
     "${GVISOR_OK:-no}" \
     "${NETWORK_POLICY_OK:-no}" \
     "${COST_OK:-no}" \
-    "${SWARM_PHASE:-skipped (use --full)}"
+    "${SWARM_PHASE:-skipped (use --with-swarm)}"
   echo ""
   if [[ "${DENY_PHASE:-}" != "PolicyDenied" ]]; then
     warn "DENY needs a reachable HTTPS MCP endpoint to reach OPA. Set DEMO_MCP_ENDPOINT for live booth runs."
@@ -537,6 +573,15 @@ print_summary() {
 
 main() {
   parse_args "$@"
+  case "${DEMO_PROFILE}" in
+    platform|lean) ;;
+    *)
+      die "invalid profile: ${DEMO_PROFILE} (expected platform or lean)"
+      ;;
+  esac
+  if [[ "${WITH_SWARM}" == "true" && "${DEMO_PROFILE}" == "lean" ]]; then
+    die "--with-swarm requires --profile platform because the swarm uses Argo"
+  fi
   start_recording_if_requested
 
   if [[ "${CLEANUP}" == "true" ]]; then
@@ -546,10 +591,10 @@ main() {
 
   check_prerequisites
   ensure_cluster
-  if [[ "${SKIP_ARGO}" == "true" ]]; then
-    install_week2_stack
+  if [[ "${DEMO_PROFILE}" == "lean" ]]; then
+    install_lean_profile
   else
-    install_full_stack
+    install_platform_profile
   fi
   verify_gvisor
   verify_network_policy

--- a/scripts/demo-booth.sh
+++ b/scripts/demo-booth.sh
@@ -59,8 +59,8 @@ Environment:
   DEMO_MCP_ENDPOINT Override https://localhost:8443 in sample manifests.
   HELM_TIMEOUT      Helm wait timeout. Default: ${HELM_TIMEOUT}
   NS_OPERATOR       Operator namespace. Default: ${NS_OPERATOR}
-  OPERATOR_IMAGE    Operator image repository. Default: ${OPERATOR_IMAGE}
-  OPERATOR_IMAGE_TAG Operator image tag. Default: ${OPERATOR_IMAGE_TAG}
+  OPERATOR_IMAGE    Lean-profile operator image repository. Default: ${OPERATOR_IMAGE}
+  OPERATOR_IMAGE_TAG Lean-profile operator image tag. Default: ${OPERATOR_IMAGE_TAG}
   FORCE_COLOR       Set to 1 to preserve ANSI colors through a recorder or pipe.
 EOF
 }

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -8,10 +8,22 @@ mkdir -p demos
 STAMP="$(date +%Y%m%d)"
 LOG_FILE="demos/demo-${STAMP}.log"
 CAST_FILE="demos/demo-${STAMP}.cast"
-DEMO_CMD="set -o pipefail; ./scripts/demo-booth.sh --skip-argo | tee ${LOG_FILE}"
+DEMO_PROFILE="${DEMO_PROFILE:-lean}"
+case "${DEMO_PROFILE}" in
+  platform|lean) ;;
+  *)
+    echo "Invalid DEMO_PROFILE: ${DEMO_PROFILE} (expected platform or lean)" >&2
+    exit 1
+    ;;
+esac
+
+printf -v DEMO_RUNNER '%q ' env FORCE_COLOR=1 ./scripts/demo-booth.sh --profile "${DEMO_PROFILE}"
+printf -v QUOTED_LOG_FILE '%q' "${LOG_FILE}"
+DEMO_CMD="set -o pipefail; ${DEMO_RUNNER}| tee ${QUOTED_LOG_FILE}"
 
 if command -v asciinema >/dev/null 2>&1; then
-  asciinema rec "${CAST_FILE}" --command "bash -lc '${DEMO_CMD}'"
+  printf -v ASCIINEMA_COMMAND 'bash -lc %q' "${DEMO_CMD}"
+  asciinema rec "${CAST_FILE}" --command "${ASCIINEMA_COMMAND}"
 else
   bash -lc "${DEMO_CMD}"
 fi


### PR DESCRIPTION
## Summary

- Replace stale Week 1/2 runtime labels with platform and lean deployment profiles.
- Add canonical `--profile` and `--with-swarm` options while preserving old aliases.
- Support local architecture-compatible operator images and disable webhook registration in the lean profile.
- Make recording command construction shell-safe and preserve ANSI colors.
- Keep raw and timed recording artifacts local through `.gitignore`.
- Reduce workload evidence output to a concise demo view.

## Local validation

- `make test-go` passed.
- Shell syntax, profile validation, Helm rendering, and YAML dry-run passed.
- Local arm64 kind run completed with `ALLOW: Completed` and `DENY: PolicyDenied`.
- Colored replay available locally at `demos/live/demo-booth.typescript`.
- Latest-model independent verifier: PASS.

## Scope

Only 6 reviewed files are included. Existing ROADMAP, assets, and untracked event docs remain outside this PR.