### PR TITLE
docs: add Clawdlinux booth readiness bundle

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,23 +1,28 @@
 # Roadmap
 
-Public roadmap for NineVigil. Updated quarterly.
+Public roadmap for Clawdlinux. Updated quarterly. For the architecture and use case, read [docs/DESIGN.md](docs/DESIGN.md) first.
 
-## Scope Note
+## The problem we are solving
 
-kagent is becoming a strong CNCF base runtime for agents on Kubernetes.
+Enterprises in regulated industries cannot ship AI agents to production. Not because the agents do not work, but because nobody can answer the governance questions: who is the agent acting as, what can it reach, what did it cost, and can an auditor verify what it did after the fact. Gartner expects over 40% of agentic AI projects to be canceled by end of 2027, with inadequate risk controls named as a cause. The runtimes are getting good. The controls around them are the gap.
 
-NineVigil will not compete with that layer by default. The open-source core now focuses on regulated controls around agent workloads:
+## The vision
 
-- gVisor runtime isolation
-- audit trails
-- FinOps attribution
-- policy and egress controls
-- air-gapped packaging
-- ACP integration for MCP context compression
+Every agent run on Kubernetes leaves a signed, tamper-evident, offline-verifiable attestation artifact, and runs inside a declared egress boundary, regardless of which runtime executes it. Clawdlinux is that governance plane: air-gapped by default, runtime-agnostic by design, delivered as one Helm chart.
 
-Issues that build generic registries, Envoy routing, sidecar buses, or broad multi-cluster runtime features should move behind validation gates. They stay valid only if a regulated deployment needs them.
+## How we got here
 
-## Current (Q1 2026)
+- **Feb 2026.** Project started as an enterprise agent-swarm orchestration platform (operator, AgentWorkload CRD, Argo DAGs, multi-tenancy, licensing, cost tracking). Initial wedge idea: visual market analysis for hedge funds needing zero data leakage.
+- **Mar to Apr 2026.** Core platform hardened: Cilium FQDN egress generation, LiteLLM routing, MinIO artifacts, Python LangGraph runtime with A2A, full-cycle integration tests, Helm umbrella chart.
+- **May 2026.** ACP (Agent Contract Protocol) spun out as its own repo and spec. Benchmarks landed: 64.7% to 97.4% token reduction vs raw MCP, one round trip. Briefly explored a consumer AgentOS direction; reversed within the month. Enterprise K8s is the business.
+- **Jun 2026.** Positioning locked: we sell the attestation and governance plane, not a runtime. CNCF runtimes are supported, not competed with. Runtime adapter interface shipped so AgentWorkload, BYO pods, and external runtimes get the same seal and attestation. ACP repositioned from token compression to governed execution contracts. gVisor RuntimeClass injector and offline audit-verify shipped.
+- **Jul 2026.** Demo gate (`scripts/demo-booth.sh`) reproducible on kind. Focus: validation conversations and the Jul 22 Agentic Summit booth. Fintech is the anchor vertical.
+
+## Scope note
+
+Strong CNCF base runtimes for agents on Kubernetes exist and are improving. Clawdlinux does not compete with that layer. The open-source core focuses on regulated controls around agent workloads: gVisor isolation, audit trails, FinOps attribution, policy and egress controls, air-gapped packaging, and ACP integration. Issues that build generic registries, Envoy routing, sidecar buses, or broad multi-cluster runtime features stay behind validation gates. They are valid only if a regulated deployment needs them.
+
+## Shipped (Q1 2026)
 
 - [x] AgentWorkload CRD with full reconciliation lifecycle
 - [x] Argo Workflows DAG orchestration
@@ -31,62 +36,44 @@ Issues that build generic registries, Envoy routing, sidecar buses, or broad mul
 - [x] Helm chart with subchart dependencies
 - [x] Full-cycle integration test suite
 
-## Next (Q2 2026)
+## Shipped (Q2 2026)
 
-- [x] `agentctl` CLI for workload management from terminal
-- [x] **MCP server (`agentctl mcp serve`) — agent-callable workload provisioning** ([#140](https://github.com/Clawdlinux/agentic-operator-core/issues/140))
-- [ ] Homebrew tap for agentctl
-- [x] Agent observability dashboard (Grafana templates)
-- [x] Cost dashboard with per-workload token spend visualization
-- [ ] Webhook admission controller for CRD validation
-- [x] OPA policy library for common agent guardrails
+- [x] `agentctl` CLI for workload management
+- [x] MCP server (`agentctl mcp serve`) for agent-callable provisioning ([#140](https://github.com/Clawdlinux/agentic-operator-core/issues/140))
+- [x] Tamper-evident audit chain with offline `audit-verify`
 - [x] gVisor RuntimeClass + pod admission injector for labeled agent pods
-- [ ] Runtime adapter interface (AgentWorkload, external pods, CNCF runtimes)
+- [x] Runtime adapter interface (AgentWorkload, BYO pods, external runtimes)
+- [x] OPA policy library for common agent guardrails
+- [x] Grafana observability and per-workload cost dashboards
+- [x] Reproducible booth demo gate on kind
+
+## Now (Q3 2026)
+
+Priority order. Validation before features.
+
+- [ ] 10 real conversations with named platform/security engineers by Jul 15 (kill criterion for everything below it)
+- [ ] Jul 22 Agentic Summit booth demo, fintech use case
+- [ ] Air-gapped install smoke test in CI
+- [ ] Webhook admission controller for CRD validation
 - [ ] Per-runtime sandbox label guide
 - [ ] ACP RemoteMCPServer wrapper example
-- [ ] Air-gapped install smoke test
+- [ ] Homebrew tap for agentctl
 
-## Future (Q3-Q4 2026)
+## Later (Q4 2026+, all validation-gated)
 
-- [ ] Multi-cluster federation (validation-gated)
-- [ ] GPU-aware scheduling for local model inference (only for regulated local model deployments)
+- [ ] Cross-cluster agent identity federation (SPIFFE/SPIRE). RFC: [docs/rfcs/0001-cross-cluster-agent-identity.md](docs/rfcs/0001-cross-cluster-agent-identity.md). Gate: 6+ distinct external use cases or 1 paying customer request.
+- [ ] Multi-cluster federation
+- [ ] GPU-aware scheduling for local model inference (regulated local-model deployments only)
 - [ ] Agent evaluation framework (evals-as-code)
-- [ ] Managed SaaS offering (hosted control plane)
-- [ ] SOC 2 Type II compliance certification
-- [ ] Plugin SDK for regulated control extensions
+- [ ] SOC 2 Type II
 - [ ] Web UI for audit, spend, and sandbox state
+- [ ] Managed SaaS offering (hosted control plane)
+- [ ] Plugin SDK for regulated control extensions
 
-## Issues To Re-Scope
+## Issues to re-scope
 
-These open issues are likely too close to the base runtime layer unless a design partner asks for them:
+Too close to the base runtime layer unless a design partner asks: #119 Envoy ExtProc routing, #120 Gateway API InferencePool, #121 multi-cluster discovery, #123 NATS/Kafka sidecars, #124 backpressure, #97-#112 registry/identity backlog. Research, not committed roadmap, until they pass a customer validation gate.
 
-- #119 Envoy ExtProc capability routing
-- #120 Gateway API InferencePool / InferenceModel integration
-- #121 Multi-cluster discovery
-- #123 NATS/Kafka sidecar injection
-- #124 Backpressure signaling
-- #97-#112 Agent registry and identity backlog
+## How to influence the roadmap
 
-Keep these as research, not committed roadmap, until they pass a customer validation gate.
-
-## Exploring (RFC stage — not yet committed)
-
-These items have published design documents and are collecting community signal. Implementation begins only after the validation gate in each RFC is met.
-
-### Cross-Cluster Agent Identity Federation (SPIFFE/SPIRE)
-
-- **RFC:** [`docs/rfcs/0001-cross-cluster-agent-identity.md`](docs/rfcs/0001-cross-cluster-agent-identity.md)
-- **Discussion:** _(link added when GitHub Discussion is open)_
-- **Tentative target:** v0.4.0 (Q3 2026)
-- **Validation gate:** 6+ distinct external use cases in the Discussion **OR** 1 paying customer request
-- **Motivation:** Enterprise NineVigil deployments span multiple K8s clusters (multi-region, multi-tenant, multi-org). Agents in Cluster A need verifiable identity when calling services or other agents in Cluster B. Existing options (shared secrets, mTLS without workload identity, central OIDC) all fail for air-gapped and regulated environments.
-- **Proposed approach:** SPIFFE/SPIRE (CNCF graduated) for workload identity federation. Opt-in per `AgentWorkload`, additive to existing ServiceAccount + JWT identity. A2A protocol gains v2 handshake carrying JWT-SVIDs across trust domains.
-- **Triggered by:** [@JacobSobolev on X](https://x.com/JacobSobolev/status/2056631848009085244) (19 May 2026)
-
-## How to Influence the Roadmap
-
-- Open an issue with the `enhancement` label
-- Join the discussion in GitHub Discussions
-- Submit a PR — we review all contributions
-
-Items are prioritized by community demand and production adoption feedback.
+Open an issue with the `enhancement` label, join GitHub Discussions, or send a PR. Items are prioritized by community demand and production deployment feedback. Anything a regulated design partner needs jumps the queue.

--- a/docs/DEMO-PLAN.md
+++ b/docs/DEMO-PLAN.md
@@ -23,13 +23,13 @@ Run it once the night before. It provisions the kind cluster (`ninevigil-demo`),
 
 3. Policy allow vs deny (2 min). Apply the allow workload (`objective: analyze quarterly revenue data`), it proceeds. Apply the deny workload (`objective: delete all production volumes`), OPA rejects it. Same policy, no model involved in the decision.
 
-4. Isolation and egress (2 min). Show the agent pod running under the gVisor RuntimeClass and the generated NetworkPolicy. The agent can only reach the FQDNs its manifest declared. This is enforced at the kernel and network layer, not by asking the model nicely.
+4. Isolation and egress (2 min). Show the gVisor RuntimeClass injection and the generated NetworkPolicy. On kind, demonstrate that the Kubernetes-native controls exist and are reviewable. Do not claim live packet enforcement in this environment. Production clusters with Cilium enforce the declared FQDN boundary at the network layer.
 
 5. Cost (1 min). Show the per-workload cost metric. Every run has an owner and a price.
 
-6. The closer: tamper-evident audit (3 min). Show the audit chain entries for the run. Run `audit-verify` against a snapshot: PASS. Now edit one row in the snapshot and run it again: FAIL, chain broken at that seq. "This is what your auditor gets. They do not have to trust us or you. They recompute the chain offline."
+6. The closer: tamper-evident audit (3 min). Use the checked-in signed artifact and demo key from [`_staging/booth/README.md`](../_staging/booth/README.md). Run `audit-verify --source jsonl --path _staging/booth/attestation-fallback.jsonl --key <demo-kid=base64-key>` for PASS. Create `/tmp/tampered.jsonl` with the documented `sed` command, then run the same verifier against it for FAIL. "This is what your auditor gets. They do not have to trust us or you. They recompute the chain offline."
 
-7. Optional, if audience is technical and time allows (`--with-swarm`): the three-agent swarm (`agentworkload_demo_swarm.yaml`), scraper, synthesizer, report generator through an Argo DAG, same controls applied to a multi-agent run.
+7. Optional, if audience is technical and time allows (`--with-swarm`): the three-agent swarm (`config/samples/agentworkload_demo_swarm.yaml`), scraper, synthesizer, report generator through an Argo DAG, same controls applied to a multi-agent run.
 
 ## Talk track guardrails
 

--- a/docs/DEMO-PLAN.md
+++ b/docs/DEMO-PLAN.md
@@ -1,0 +1,40 @@
+# Demo Plan
+
+One demo, 10 to 12 minutes, runs entirely on a local kind cluster via `scripts/demo-booth.sh`. Written for the co-founder walkthrough and the Jul 22 booth. Everything here is reproducible today; no step depends on unshipped code.
+
+## The story we are telling
+
+A regulated fintech platform team wants to run an analysis agent. Security will only sign off if three things are provable: the agent cannot do destructive work, cannot reach anything outside a declared allowlist, and every action is recorded in a way an auditor can verify offline later. We show all three, then break the audit trail on purpose and watch verification fail.
+
+## Prep (before the call, not during)
+
+```
+./scripts/demo-booth.sh --profile platform  # kind + operator + Argo + shared services
+./scripts/demo-booth.sh --cleanup  # to reset
+```
+
+Run it once the night before. It provisions the kind cluster (`ninevigil-demo`), installs the operator, Argo, and shared services, and leaves evidence under `tests/harness/evidence/`. Use `--profile lean` if time or laptop capacity is constrained. Keep a recorded run (`--record`) as backup in case live wifi or Docker misbehaves.
+
+## Run of show
+
+1. Frame (1 min). "Agent runtimes are getting good. What blocks production in a bank is governance: identity, blast radius, cost, and proof. We wrap any agent workload with those controls. Here is the whole thing on my laptop, air-gap friendly."
+
+2. The manifest is the contract (2 min). Show `config/samples/agentworkload_demo_allow.yaml`. Point at the parts security cares about: `opaPolicy: strict`, the approval threshold, the declared endpoint. The review surface is a YAML file in a PR, not a prompt.
+
+3. Policy allow vs deny (2 min). Apply the allow workload (`objective: analyze quarterly revenue data`), it proceeds. Apply the deny workload (`objective: delete all production volumes`), OPA rejects it. Same policy, no model involved in the decision.
+
+4. Isolation and egress (2 min). Show the agent pod running under the gVisor RuntimeClass and the generated NetworkPolicy. The agent can only reach the FQDNs its manifest declared. This is enforced at the kernel and network layer, not by asking the model nicely.
+
+5. Cost (1 min). Show the per-workload cost metric. Every run has an owner and a price.
+
+6. The closer: tamper-evident audit (3 min). Show the audit chain entries for the run. Run `audit-verify` against a snapshot: PASS. Now edit one row in the snapshot and run it again: FAIL, chain broken at that seq. "This is what your auditor gets. They do not have to trust us or you. They recompute the chain offline."
+
+7. Optional, if audience is technical and time allows (`--with-swarm`): the three-agent swarm (`agentworkload_demo_swarm.yaml`), scraper, synthesizer, report generator through an Argo DAG, same controls applied to a multi-agent run.
+
+## Talk track guardrails
+
+Do not name competitor runtimes as problems. Do not claim SPIFFE/multi-cluster, SOC 2, webhook validation, or an air-gapped CI gate; they are roadmap. If asked "does this work with runtime X": "the adapter interface covers our CRD, plain labeled pods, and external runtimes; the seal and attestation contract is the same for all three."
+
+## Failure modes and fallbacks
+
+Docker/kind flaky: play the recorded run, narrate live. Argo slow to schedule: use the lean profile, the policy and audit story does not need it. Question you cannot answer: "good question, that is exactly the kind of thing we gate the roadmap on, tell me more about your setup."

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,74 @@
+# Clawdlinux Design Doc
+
+Status: living document, July 2026. If you read one doc about this project, read this one.
+
+## The one-glance version
+
+Enterprises want to run AI agents on their own Kubernetes clusters. Their security and compliance teams keep saying no, because nobody can answer four questions about an autonomous agent: who is it acting as, what can it reach, what did it cost, and can we prove what it did six months later.
+
+Clawdlinux is a governance plane that answers those questions for any agent workload on Kubernetes. It does not compete with agent runtimes. It wraps them.
+
+The wedge is the combination of two controls in one self-hosted deployment:
+
+1. A signed, hash-chained attestation artifact for every agent run, verifiable offline with a small CLI (`audit-verify`). An auditor can replay what an agent did months later inside an air-gapped cluster.
+2. A zero-egress seal at the network boundary. The agent can only reach the FQDNs its manifest declares. Enforced by Cilium, not by prompting the model to behave.
+
+Everything else (gVisor isolation, cost attribution, Argo orchestration, LiteLLM routing) supports that wedge.
+
+## Architecture
+
+Everything in the governance plane runs inside one Kubernetes cluster, which can be fully air-gapped. The operator also runs the tenant controller (namespaces, RBAC, quotas), the offline JWT license validator, and the gVisor RuntimeClass injector. Runtime adapters (`pkg/runtime`) apply the same seal and attestation contract to our AgentWorkload CRD, BYO labeled pods, and external CNCF runtimes. Shared services (Argo, LiteLLM, MinIO, Postgres, Grafana, Browserless) ship as subcharts of one Helm umbrella chart.
+
+Data flow for one run: AgentWorkload applied -> license and OPA policy check -> Cilium egress policy generated from the manifest's declared FQDNs -> Argo DAG executes agent pods (gVisor if labeled) -> every LLM call, tool call, and state transition appended to the audit chain -> cost recorded per workload -> signed attestation artifact written to MinIO -> chain head checkpointed.
+
+Tamper anywhere in that record and `audit-verify` fails the chain. That is the demo moment.
+
+## Why the audit chain is trustworthy
+
+Each event hash commits to the previous one (seq, timestamp, tenant, workload, actor, action, payload hash, prev hash, fixed binary encoding). Rows are HMAC-signed with a key held in a Kubernetes Secret. Storage is append-only with no UPDATE/DELETE grants. The chain head is published periodically to a ConfigMap and optionally mirrored to Sigstore Rekor. Verification is a pure function over bytes, so a third party recomputes the chain offline without trusting our server. Code: `pkg/audit`, CLI: `cmd/audit-verify`.
+
+## Anchor use case: compliance-bound market analysis at a financial institution
+
+Customer assumptions, stated plainly:
+
+- A hedge fund or bank platform team, 5 to 50 engineers, already running Kubernetes 1.27+.
+- They are under SEC/FINRA/FCA-style audit obligations. Cloud AI SaaS is banned or heavily gated by infosec.
+- They want agents that scrape and analyze market data, summarize filings, or triage alerts. The tech works. Deployment is blocked on governance, not capability.
+- They have an approved LLM path: a local vLLM box in the air gap, or a vetted external API behind an egress allowlist.
+
+How they integrate, day one to day thirty:
+
+1. `helm install` the umbrella chart from an OCI artifact we hand them. Air-gapped clusters load images from the same bundle. No registry pulls, no license server callbacks (JWT verified offline).
+2. Point LiteLLM at their approved model endpoint. Nothing else in the stack knows or cares which model it is.
+3. Bring their agents. Three adoption paths, cheapest first: label existing pods (they get the gVisor seal and audit for free), wrap them in an AgentWorkload CRD (they also get Argo DAG orchestration, budgets, and routing), or run a supported CNCF runtime behind the adapter.
+4. Compliance officer gets a standing artifact: for each run, who ran it, what it touched, what it cost, signed and replayable. When the auditor shows up, they hand over a snapshot and the `audit-verify` binary instead of a week of log archaeology.
+
+What they get out of it, in their words: "we can finally say yes to the agent project" (platform lead), "blast radius is declared in a manifest I can review in a PR" (security), "evidence collection went from days to a command" (compliance), "I know what each agent costs per run" (whoever owns the cloud bill).
+
+What we deliberately do not do: build another agent framework, host their data (there is no SaaS in the loop), or ask them to rewrite agents. Governance wraps what they have.
+
+## ACP in one paragraph
+
+Agent Contract Protocol is the same philosophy applied to tool calls. MCP answers what tools exist; ACP answers what execution is allowed for this agent right now. The server consumes MCP `tools/list` and returns a signed execution contract: scoped capabilities, identity binding, credential injection at the proxy (secrets never enter model context), declared ordering, egress and approval policy. Measured side effect: 64.7% to 97.4% fewer setup tokens and one round trip instead of up to 21, across five benchmark scenarios (see agent-contract-protocol/results). Separate repo, separate spec (v0.2 draft), feeds the same audit chain.
+
+## Repo map
+
+Two product repos plus a website, all under github.com/Clawdlinux.
+
+`agentic-operator-core` is the platform. `api/` and `internal/controller/` hold the CRD and reconcilers. `internal/admission/` is the gVisor RuntimeClass injector. `pkg/` has the subsystems: `audit` (hash chain), `runtime` (adapters), `finops`, `opa`, `llm`, `argo`, `multitenancy`, `mcp`. `cmd/` builds the operator, `agentctl`, `audit-verify`, and the license generator. `charts/` is the Helm umbrella with subcharts for Argo, LiteLLM, MinIO, Postgres, Browserless, and observability. `agents/` is the Python LangGraph runtime with A2A. `examples/` has the multi-agent swarm and SRE scenarios. `scripts/demo-booth.sh` is the reproducible demo. `docs/` is numbered 01 through 12 plus RFCs.
+
+`agent-contract-protocol` is the ACP spec (SPEC.md), Go reference server, Python client, adapters, and the benchmark harness with checked-in results.
+
+`clawdlinux-website` is the public site (clawdlinux.org).
+
+## Honest state of the build
+
+Working today: CRD and reconciliation lifecycle, Argo DAG orchestration, Cilium egress policy generation, audit chain and offline verifier, gVisor injector, runtime adapters (AgentWorkload, BYO pods, Argo), LiteLLM routing, per-workload cost tracking, multi-tenancy with quotas, offline JWT licensing, Helm umbrella chart, agentctl with an MCP server mode, Grafana dashboards, the kind-based demo gate, ACP reference server with measured benchmarks.
+
+Not done, do not claim it: webhook admission validation for the CRD, Homebrew tap, air-gapped install smoke test as CI, per-runtime sandbox label guide, multi-cluster identity federation (SPIFFE/SPIRE, RFC-0001, gated on 6 external use cases or 1 paying customer), SOC 2, managed SaaS. Enterprise billing and licensing internals live in a private repo; the OSS tree has boundary READMEs only.
+
+The rule we run by: anything that smells like rebuilding the runtime layer sits behind a validation gate until a real deployment asks for it. See ROADMAP.md.
+
+## Positioning constraints (read before writing public copy)
+
+We sell the attestation and governance plane. Runtimes underneath are supported details. Never make a named runtime the subject of a problem sentence, never claim a competitor lacks something it has, mention competitors at most once per asset in a supported-runtimes context. Full guardrails in STRATEGY_positioning_runtime_agnostic.md.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -71,4 +71,4 @@ The rule we run by: anything that smells like rebuilding the runtime layer sits 
 
 ## Positioning constraints (read before writing public copy)
 
-We sell the attestation and governance plane. Runtimes underneath are supported details. Never make a named runtime the subject of a problem sentence, never claim a competitor lacks something it has, mention competitors at most once per asset in a supported-runtimes context. Full guardrails in STRATEGY_positioning_runtime_agnostic.md.
+We sell the attestation and governance plane. Runtimes underneath are supported details. Never make a named runtime the subject of a problem sentence, never claim a competitor lacks something it has, and mention competitors only in a supported-runtimes context. See [the architecture guide](04-architecture.md) and [roadmap](../ROADMAP.md).

--- a/docs/MARKET-EVIDENCE.md
+++ b/docs/MARKET-EVIDENCE.md
@@ -1,0 +1,25 @@
+# Market Evidence
+
+Third-party sources behind the problem statement. Use these in decks and posts instead of inventing numbers. Last checked Jul 3, 2026.
+
+## Analyst and research data
+
+- Gartner (Jun 2025): over 40% of agentic AI projects will be canceled by end of 2027; escalating costs, unclear business value, and inadequate risk controls. https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027
+- Gartner (May 2026): uniform governance across AI agents leads to enterprise agent failure; 17% of orgs have deployed agents, 60%+ expect to within two years; through 2027 manual AI compliance exposes 75% of regulated organizations to fines exceeding 5% of global revenue. https://www.gartner.com/en/newsroom/press-releases/2026-05-26-gartner-says-applying-uniform-governance-across-ai-agents-will-lead-to-enterprise-ai-agent-failure
+- AIRQ report via Help Net Security (Jun 2026): only 11% of 100 assessed production agents pass the security bar; 98% carry the lethal trifecta (private data access, untrusted content exposure, outbound actions). https://www.helpnetsecurity.com/2026/06/03/research-ai-agent-security-capability/
+- CrowdStrike (via press, 2026): prompt injection attacks impacted 90+ organizations in 2025.
+
+## Incidents and regulatory gaps
+
+- The Register (May 2026): US bank self-reported after sending customer data to an unauthorized AI app. https://www.theregister.com/security/2026/05/12/us-bank-reports-itself-after-ai-customer-data-mishap/5238787
+- Fed SR 26-2 (Apr 2026): updated model risk guidance explicitly excludes generative and agentic AI from validation and documentation requirements; examiners are improvising. Coverage: https://www.techtimes.com/articles/318340/20260613/bank-ai-oversight-expands-every-exam-generative-ai-bypasses-sr-26-2-kill-switch-gap-grows.htm
+- VentureBeat (Apr 2026): agent credentials living beside untrusted code; blast-radius architectures (credential isolation, JIT identity) as the emerging pattern. https://venturebeat.com/security/ai-agent-zero-trust-architecture-audit-credential-isolation-anthropic-nvidia-nemoclaw
+
+## Community signal
+
+- X: @JacobSobolev (May 19, 2026) on cross-cluster agent identity pain; triggered RFC-0001. https://x.com/JacobSobolev/status/2056631848009085244
+- MCP cost and friction evidence (Perplexity moving off MCP, Apideck 143K-token benchmark, Scalekit 4-32x CLI comparison): tracked with caveats in agent-contract-protocol/docs/references.md. Verify canonical links before quoting publicly.
+
+## Usage rules
+
+State the source and date next to every number. If a stat cannot be traced to a link on this page, it does not go in a public asset. No projections of our own revenue or TAM until we have customer data.

--- a/docs/MARKET-EVIDENCE.md
+++ b/docs/MARKET-EVIDENCE.md
@@ -7,7 +7,6 @@ Third-party sources behind the problem statement. Use these in decks and posts i
 - Gartner (Jun 2025): over 40% of agentic AI projects will be canceled by end of 2027; escalating costs, unclear business value, and inadequate risk controls. https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027
 - Gartner (May 2026): uniform governance across AI agents leads to enterprise agent failure; 17% of orgs have deployed agents, 60%+ expect to within two years; through 2027 manual AI compliance exposes 75% of regulated organizations to fines exceeding 5% of global revenue. https://www.gartner.com/en/newsroom/press-releases/2026-05-26-gartner-says-applying-uniform-governance-across-ai-agents-will-lead-to-enterprise-ai-agent-failure
 - AIRQ report via Help Net Security (Jun 2026): only 11% of 100 assessed production agents pass the security bar; 98% carry the lethal trifecta (private data access, untrusted content exposure, outbound actions). https://www.helpnetsecurity.com/2026/06/03/research-ai-agent-security-capability/
-- CrowdStrike (via press, 2026): prompt injection attacks impacted 90+ organizations in 2025.
 
 ## Incidents and regulatory gaps
 

--- a/docs/PITCH-SCRIPT.md
+++ b/docs/PITCH-SCRIPT.md
@@ -1,0 +1,80 @@
+# Pitch Script: Co-founder Deck + Demo
+
+Companion to the current co-founder deck and [DEMO-PLAN.md](DEMO-PLAN.md). Total runtime: ~10 min deck, ~10 min demo, rest conversation. The deck earns attention, the demo earns belief, the conversation earns the signal. Do not skip the conversation to show more product.
+
+## Part 1: Deck script, slide by slide
+
+Times are targets. If she interrupts with questions, good, let her. The deck is a spine, not a cage.
+
+**Slide 1, Title (30s).**
+"Clawdlinux provides regulated controls for AI agents on Kubernetes. One sentence version: every agent run leaves a signed, offline-verifiable record, and runs inside a network seal it cannot escape. I am not building another agent framework. I am building the thing that lets a bank say yes to one."
+
+**Slide 2, Problem (90s).**
+"Agents work now. What does not work is getting them past a security review. These are not my numbers." Walk the rings left to right. Land on: "Gartner says 40 percent of these projects die, and names inadequate risk controls as a reason. Only 11 percent of production agents pass an independent security bar. The demand curve and the controls curve have a gap. That gap is the company."
+
+**Slide 3, Why now (90s).**
+"Four things happened at once. Strong open runtimes became available, so we no longer need to rebuild that layer. Incidents went from hypothetical to a bank self-reporting to its regulator. Fed guidance explicitly excludes agentic AI, so auditors are improvising. The buyers who need verifiable evidence most are also the ones that often cannot use a hosted control plane. We start with self-hosted and air-gapped deployments."
+
+**Slide 4, What we built (90s).**
+"Our wedge combines two controls in one self-hosted deployment. First, attestation: every LLM call, tool call, and approval goes into a hash chain, HMAC-signed, and a small CLI recomputes the whole chain offline. The auditor does not have to trust me, or you, or the customer. Second, the egress seal: the agent reaches only the endpoints its manifest declares, enforced by Cilium at the network layer. Not a system prompt asking the model to behave. gVisor and OPA wrap around those." Pause. "Key design decision: same contract whether the workload is our CRD, someone's existing pods, or a third-party runtime. We wrap, we do not replace."
+
+**Slide 5, How a run works (60s).**
+Walk the six steps quickly. The line that matters: "Notice policy is decided before anything runs, and evidence is produced whether or not anyone asks for it. Compliance is a byproduct of running, not a project after running."
+
+**Slide 6, Use case (90s).**
+"Concrete customer: a fund's platform team wants agents analyzing filings and market data. Infosec banned agent SaaS, so the project is stuck. With us: they helm install one bundle inside their perimeter, point LiteLLM at whatever model they already approved, and label their existing agent pods. Three people get unblocked: platform lead ships, security reviews a YAML diff instead of a prompt, compliance hands the auditor a snapshot and a binary instead of a week of log archaeology."
+
+**Slide 7, What exists (60s).**
+"Everything on this slide is in a public repo you can read tonight. 180 commits since February. The ACP numbers are measured, checked-in benchmarks, not projections: 64 to 97 percent context reduction against raw MCP, one round trip instead of up to 21."
+
+**Slide 8, Where we are (60s). Do not rush this one.**
+"Honest state: built but not validated. Pre-revenue, zero customers, and I have a kill criterion: ten real conversations with named platform and security engineers by July 15, or I stop building features until I have them. I am telling you this because if you join, your first job is making sure we never ship into a vacuum again."
+
+**Slide 9, Roadmap (45s).**
+"The roadmap has gates, not wishes. SPIFFE federation, SOC 2, managed offering: all of it waits for a customer to pull it. The only committed work is validation and the July 22 booth."
+
+**Slide 10, The ask (90s).**
+"Why you. This product is a trust claim, and trust claims need a security person whose name carries weight. Three things you would own: the threat model, attack our own chain before a red team does; compliance mapping, what will SEC, FINRA, RBI examiners actually accept; and security-side go-to-market, the CISO conversations I cannot credibly have alone. Concrete next step if you are in: we pick one design-partner profile together and you pressure-test the demo like a hostile auditor. Want to see it now?"
+
+Transition straight into the demo. No gap.
+
+## Part 2: What the demo actually is, technically
+
+`scripts/demo-booth.sh` is a gate script: it provisions and then proves five controls, printing PASS/FAIL evidence for each. Know what each phase does so you can narrate it instead of reading it.
+
+**Phase 0, setup.** Checks kubectl, helm, kind (or reuses k3s). Creates kind cluster `ninevigil-demo`. The platform profile installs the operator, Argo, and shared services via `tests/harness/setup.sh`. `--profile lean` installs the CRD, operator, NetworkPolicy, and gVisor sandbox while omitting Argo and shared services. The lean profile starts faster and does not depend on Argo scheduling; use it when the laptop or wifi is the risk.
+
+**Phase 1, OPA allow/deny.** Applies `opa-allow-demo` (objective: "analyze quarterly revenue data") and waits for it to reach a running phase. Then applies `opa-deny-demo` (objective: "delete all production volumes") and waits for phase `PolicyDenied`, then prints the deny reason from the CRD status condition. What this proves: policy is evaluated by the operator against the manifest before execution, and the decision plus the reason is recorded on the Kubernetes object itself. The model is not in the loop.
+
+**Phase 2, cost.** Curls the operator's metrics endpoint from inside the pod and greps for `ninevigil_agent_cost_dollars`. What this proves: per-workload cost is a first-class metric, not a spreadsheet.
+
+**Phase 3, gVisor.** Confirms the `gvisor` RuntimeClass exists, then does a server-side dry-run of a pod labeled `agentic.clawdlinux.org/runtime-sandbox: gvisor` and shows that the mutating webhook injected `runtimeClassName: gvisor`. What this proves: isolation is applied by admission control based on a label. No agent code changes.
+
+**Phase 4, NetworkPolicy.** Confirms the egress policy objects are installed in the namespace. What this proves: the seal exists as a Kubernetes-native object security can review. (On kind, Cilium FQDN enforcement is not fully live; do not claim packet-level blocking in this environment, claim policy generation and show the object.)
+
+**Phase 5, swarm (`--with-swarm` only).** Applies `demo-competitive-swarm`: three agents (competitor-scraper, llm-synthesizer, report-generator) compiled into an Argo Workflow DAG. What this proves: the same controls wrap a multi-agent pipeline, and orchestration is delegated to Argo rather than reinvented.
+
+**The audit tamper closer is manual, not in the script.** It uses `cmd/audit-verify` against an audit snapshot: run it clean for PASS, edit one row, run again for FAIL at the broken seq. Rehearse this end to end at least once before the call. If you cannot get a clean PASS/FAIL cycle working in the demo environment, cut it from the live demo and show the `pkg/audit` design instead; a fumbled trust demo is worse than none.
+
+**Flags cheat sheet.** `--profile platform|lean` selects the deployment profile, `--with-swarm` adds the Argo swarm scenario, `--record` captures the terminal with script(1), and `--cleanup` deletes the cluster. Evidence lands in `tests/harness/evidence/booth-<timestamp>/`.
+
+**What the demo does NOT show. Say so if asked.** No real LLM traffic unless an endpoint is configured; the allow workload exercises lifecycle, not inference quality. No packet-level egress blocking on kind. No SPIFFE, no multi-cluster, no SOC 2. Saying "that part is roadmap" out loud is what makes the rest believable.
+
+## Part 3: Turning the demo into signal and customers
+
+The demo is not the product. The demo is bait for a specific conversation. The high-value signal is not "cool demo", it is evidence someone would deploy or pay.
+
+**Signal ladder, weakest to strongest.** Compliment < asks technical questions < describes their own environment unprompted < names a specific blocked project < agrees to a follow-up with a named colleague < asks for the install bundle < agrees to a scoped pilot with dates. Everything below "describes their own environment" counts toward nothing. Your Jul 15 kill criterion counts only conversations where they talk about THEIR stack, not yours.
+
+**The three questions to ask everyone who sees the demo.** Ask, then shut up:
+1. "Do you have an agent project that is stuck right now? What is it stuck on?" (Discovers whether the pain is real and whether it is governance-shaped.)
+2. "Who in your org would have to say yes to something like this, and what would they need to see?" (Maps the buying committee and gives you the artifact list for the pilot.)
+3. "If I gave you the air-gapped bundle Monday, what would stop you from installing it?" (Surfaces the real objection: procurement, priority, missing feature, or no actual pain.)
+
+**The one CTA.** Free design-partner pilot for regulated enterprises, already on the website. Scope it tight when you offer it: "30 days, one use case, your cluster, we help install, you give us a weekly 30-minute call and an honest verdict." A tight scope is easier to say yes to and produces a reference or a lesson either way.
+
+**Disqualify fast.** No Kubernetes, no regulated pressure, or no stuck project: be polite, take nothing, move on. A pipeline of unqualified enthusiasm is how the last two engineering-over-validation cycles happened.
+
+**Follow-up discipline.** Same-day note with exactly three things: the repo link, the one thing they said they cared about, and the single next step you proposed. No decks attached unless they asked.
+
+**For the Shrishti call specifically.** The customer-signal framing doubles as the co-founder test. If she starts asking question 2 and 3 style questions at YOU, unprompted, that is the strongest positive signal you can get from a security co-founder candidate: she is already selling it in her head. If she only critiques the crypto, she is an advisor, not a co-founder. Both outcomes are useful; know which one you got before the call ends.

--- a/docs/PITCH-SCRIPT.md
+++ b/docs/PITCH-SCRIPT.md
@@ -54,7 +54,7 @@ Transition straight into the demo. No gap.
 
 **Phase 5, swarm (`--with-swarm` only).** Applies `demo-competitive-swarm`: three agents (competitor-scraper, llm-synthesizer, report-generator) compiled into an Argo Workflow DAG. What this proves: the same controls wrap a multi-agent pipeline, and orchestration is delegated to Argo rather than reinvented.
 
-**The audit tamper closer is manual, not in the script.** It uses `cmd/audit-verify` against an audit snapshot: run it clean for PASS, edit one row, run again for FAIL at the broken seq. Rehearse this end to end at least once before the call. If you cannot get a clean PASS/FAIL cycle working in the demo environment, cut it from the live demo and show the `pkg/audit` design instead; a fumbled trust demo is worse than none.
+**The audit tamper closer uses the signed fallback artifact.** Follow [`_staging/booth/README.md`](../_staging/booth/README.md): run `audit-verify --source jsonl --path _staging/booth/attestation-fallback.jsonl --key <demo-kid=base64-key>` for PASS, use the documented `sed` command to create `/tmp/tampered.jsonl`, then verify that file for FAIL. Rehearse this end to end at least once before the call. If you cannot get a clean PASS/FAIL cycle working, cut it from the live demo and show the `pkg/audit` design instead; a fumbled trust demo is worse than none.
 
 **Flags cheat sheet.** `--profile platform|lean` selects the deployment profile, `--with-swarm` adds the Argo swarm scenario, `--record` captures the terminal with script(1), and `--cleanup` deletes the cluster. Evidence lands in `tests/harness/evidence/booth-<timestamp>/`.
 

--- a/video/booth-animated-loop.html
+++ b/video/booth-animated-loop.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Clawdlinux booth loop</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22><rect width=%2232%22 height=%2232%22 rx=%226%22 fill=%22%23141B3D%22/><text x=%2216%22 y=%2222%22 text-anchor=%22middle%22 font-family=%22monospace%22 font-size=%2218%22 fill=%22%235B8DEF%22>C</text></svg>">
+<style>
+  :root{
+    --navy:#141B3D; --navy2:#1E2761; --ice:#CADCFC; --accent:#5B8DEF;
+    --green:#4ADE80; --red:#F87171; --muted:#8CA0C9;
+  }
+  *{margin:0;padding:0;box-sizing:border-box;font-family:'SF Mono','JetBrains Mono',Menlo,monospace}
+  html,body{height:100%;background:var(--navy);overflow:hidden;cursor:none}
+  #stage{position:relative;width:100vw;height:100vh}
+
+  .lane{position:absolute;left:4vw;right:4vw;height:34vh;border-radius:18px;background:var(--navy2);opacity:.35;transition:opacity .6s}
+  .lane.active{opacity:1}
+  #laneTop{top:12vh}
+  #laneBot{top:52vh}
+  .laneLabel{position:absolute;top:14px;left:22px;font-size:2.2vh;letter-spacing:.12em;color:var(--muted)}
+  #laneTop .laneLabel{color:var(--red)}
+  #laneBot .laneLabel{color:var(--green)}
+
+  .node{position:absolute;top:50%;transform:translateY(-50%);width:9vw;height:9vw;max-width:110px;max-height:110px;border-radius:16px;background:var(--navy);display:flex;flex-direction:column;align-items:center;justify-content:center;border:2px solid #2b3670;font-size:1.7vh;color:var(--ice);text-align:center;gap:6px}
+  .node .glyph{font-size:3.6vh}
+  .n1{left:6%}.n2{left:31%}.n3{left:56%}.n4{left:81%}
+
+  .packet{position:absolute;top:50%;width:2.2vh;height:2.2vh;border-radius:50%;background:var(--accent);transform:translateY(-50%);opacity:0;box-shadow:0 0 12px var(--accent)}
+  .packet.bad{background:var(--red);box-shadow:0 0 12px var(--red)}
+  .packet.good{background:var(--green);box-shadow:0 0 12px var(--green)}
+
+  #caption{position:absolute;bottom:5vh;left:0;right:0;text-align:center;font-size:3.4vh;color:var(--ice);font-weight:700;transition:opacity .4s}
+  #subcap{position:absolute;bottom:1.6vh;left:0;right:0;text-align:center;font-size:1.9vh;color:var(--muted)}
+  #title{position:absolute;top:2.5vh;left:0;right:0;text-align:center;font-size:3vh;color:#fff;font-weight:700;letter-spacing:.06em}
+  #title span{color:var(--accent)}
+
+  .stamp{position:absolute;font-size:2.6vh;font-weight:700;padding:.5vh 1.4vh;border-radius:8px;opacity:0;transform:scale(.6)}
+  .stamp.show{animation:pop .45s forwards}
+  @keyframes pop{to{opacity:1;transform:scale(1)}}
+  #stampLeak{top:17%;left:72%;color:var(--red);border:2px solid var(--red);background:rgba(248,113,113,.12)}
+  #stampBlock{top:57%;left:60%;color:var(--green);border:2px solid var(--green);background:rgba(74,222,128,.12)}
+  #stampFail{top:17%;left:40%;color:var(--red);border:2px solid var(--red);background:rgba(248,113,113,.12)}
+  #stampPass{top:57%;left:40%;color:var(--green);border:2px solid var(--green);background:rgba(74,222,128,.12)}
+
+  .chain{position:absolute;bottom:12px;left:22px;right:22px;height:5vh;display:flex;gap:6px;align-items:center}
+  .link{flex:1;height:3.2vh;border-radius:6px;background:#232c5c;border:1px solid #33407e;display:flex;align-items:center;justify-content:center;font-size:1.5vh;color:var(--muted);transition:all .3s}
+  .link.signed{background:rgba(74,222,128,.15);border-color:var(--green);color:var(--green)}
+  .link.tampered{background:rgba(248,113,113,.2);border-color:var(--red);color:var(--red)}
+  .wall{position:absolute;top:18%;bottom:18%;left:74.5%;width:6px;border-radius:3px;background:var(--green);opacity:0;box-shadow:0 0 16px var(--green)}
+</style>
+</head>
+<body>
+<div id="stage">
+  <div id="title">CLAWD<span>LINUX</span> :: can you prove what your agent did?</div>
+
+  <div class="lane" id="laneTop">
+    <div class="laneLabel">WITHOUT CONTROLS</div>
+    <div class="node n1"><div class="glyph">AI</div>AI agent</div>
+    <div class="node n2"><div class="glyph">KEY</div>prod creds</div>
+    <div class="node n3"><div class="glyph">DATA</div>customer data</div>
+    <div class="node n4" style="border-color:#7f1d1d"><div class="glyph">?</div>unknown endpoint</div>
+    <div class="packet" id="pkt1"></div>
+    <div class="chain" id="chainTop"></div>
+  </div>
+
+  <div class="lane" id="laneBot">
+    <div class="laneLabel">WITH CLAWDLINUX</div>
+    <div class="node n1"><div class="glyph">AI</div>same agent</div>
+    <div class="node n2"><div class="glyph">POLICY</div>policy gate</div>
+    <div class="node n3"><div class="glyph">ALLOW</div>declared endpoints only</div>
+    <div class="node n4" style="border-color:#7f1d1d"><div class="glyph">?</div>unknown endpoint</div>
+    <div class="wall" id="wall"></div>
+    <div class="packet" id="pkt2"></div>
+    <div class="chain" id="chainBot"></div>
+  </div>
+
+  <div class="stamp" id="stampLeak">DATA LEFT THE BUILDING</div>
+  <div class="stamp" id="stampBlock">BLOCKED AT THE NETWORK</div>
+  <div class="stamp" id="stampFail">TAMPER NOT DETECTED</div>
+  <div class="stamp" id="stampPass">TAMPER CAUGHT: FAIL @ seq 42</div>
+
+  <div id="caption"></div>
+  <div id="subcap">github.com/Clawdlinux &nbsp;|&nbsp; free pilot for regulated teams &nbsp;|&nbsp; scan the QR</div>
+</div>
+
+<script>
+const $=id=>document.getElementById(id);
+const cap=$('caption');
+const laneTop=$('laneTop'), laneBot=$('laneBot');
+
+// build audit chains
+for(const [el,n] of [[$('chainTop'),8],[$('chainBot'),8]]){
+  for(let i=0;i<n;i++){const d=document.createElement('div');d.className='link';d.textContent='log '+(i+35);el.appendChild(d);}
+}
+const topLinks=[...$('chainTop').children], botLinks=[...$('chainBot').children];
+
+function say(t){cap.style.opacity=0;setTimeout(()=>{cap.textContent=t;cap.style.opacity=1},350)}
+function movePacket(p,fromPct,toPct,ms){return new Promise(res=>{
+  p.style.transition='none';p.style.left=fromPct+'%';p.style.opacity=1;
+  requestAnimationFrame(()=>requestAnimationFrame(()=>{
+    p.style.transition=`left ${ms}ms linear`;p.style.left=toPct+'%';
+    setTimeout(res,ms);
+  }));
+})}
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+function reset(){
+  for(const s of ['stampLeak','stampBlock','stampFail','stampPass'])$(s).classList.remove('show');
+  $('pkt1').style.opacity=0;$('pkt2').style.opacity=0;$('wall').style.opacity=0;
+  topLinks.forEach(l=>l.className='link');botLinks.forEach(l=>l.className='link');
+}
+
+async function loop(){
+  while(true){
+    reset();
+    // BEAT 1: unprotected lane (18s)
+    laneTop.classList.add('active');laneBot.classList.remove('active');
+    say('An agent with prod credentials reads a poisoned document...');
+    const p1=$('pkt1');p1.classList.remove('good');p1.classList.add('bad');
+    await movePacket(p1,8,33,2200);await movePacket(p1,33,58,2200);
+    say('...and sends customer data somewhere nobody approved.');
+    await movePacket(p1,58,83,2600);
+    $('stampLeak').classList.add('show');
+    await sleep(2500);
+    say('The logs? Plain rows in a database. Anyone can edit them.');
+    topLinks[4].classList.add('tampered');topLinks[4].textContent='edited';
+    await sleep(1800);
+    $('stampFail').classList.add('show');
+    await sleep(3500);
+
+    // BEAT 2: protected lane (20s)
+    reset();
+    laneBot.classList.add('active');laneTop.classList.remove('active');
+    say('Same agent, wrapped by Clawdlinux. Egress is declared in a manifest.');
+    const p2=$('pkt2');p2.classList.remove('bad');p2.classList.add('good');
+    await movePacket(p2,8,33,2000);
+    say('Policy gate: destructive intent rejected before anything runs.');
+    await movePacket(p2,33,58,2000);
+    await sleep(800);
+    say('It tries the unknown endpoint anyway...');
+    p2.classList.remove('good');p2.classList.add('bad');
+    await movePacket(p2,58,72,1500);
+    $('wall').style.opacity=1;$('stampBlock').classList.add('show');
+    p2.style.opacity=0;
+    await sleep(3000);
+
+    // BEAT 3: signed chain + tamper caught (15s)
+    $('stampBlock').classList.remove('show');
+    say('Every action lands in a hash-chained, signed audit trail.');
+    for(let i=0;i<botLinks.length;i++){botLinks[i].classList.add('signed');await sleep(280);}
+    await sleep(1200);
+    say('Someone edits one row of history...');
+    botLinks[4].classList.remove('signed');botLinks[4].classList.add('tampered');botLinks[4].textContent='seq 42';
+    await sleep(1500);
+    for(let i=5;i<botLinks.length;i++){botLinks[i].classList.remove('signed');botLinks[i].classList.add('tampered');}
+    $('stampPass').classList.add('show');
+    say('audit-verify recomputes the chain offline. Signed, not just logged.');
+    await sleep(4500);
+  }
+}
+loop();
+</script>
+</body>
+</html>

--- a/video/booth-loop.tape
+++ b/video/booth-loop.tape
@@ -10,8 +10,8 @@
 # - one beat every ~15-20s: policy deny -> signed chain -> tamper caught
 # - brand colors: navy background, ice-blue text, green/red for pass/fail
 #
-# PREREQ: run against the live demo cluster (scripts/demo-booth.sh --profile lean done once,
-# audit snapshot present at /tmp/audit-snapshot.db). Rehearse before recording.
+# PREREQ: run against the live demo cluster (scripts/demo-booth.sh --profile lean done once)
+# from the repository root. The signed fallback artifact is checked in under _staging/booth/.
 
 Output video/booth-loop.gif
 Output video/booth-loop.mp4
@@ -33,10 +33,10 @@ Sleep 2s
 Type "# an agent asks to delete production volumes"
 Enter
 Sleep 1s
-Type "kubectl apply -f agentworkload_demo_deny.yaml"
+Type "kubectl apply -f config/samples/agentworkload_demo_deny.yaml"
 Enter
 Sleep 3s
-Type "kubectl get agentworkload opa-deny-demo -o jsonpath='{.status.phase}'"
+Type "kubectl -n agentic-system get agentworkload opa-deny-demo -o jsonpath='{.status.phase}'"
 Enter
 Sleep 2.5s
 # expected output: PolicyDenied
@@ -48,7 +48,7 @@ Sleep 4s
 Type "clear && echo '  every action -> hash-chained, HMAC-signed audit entry'"
 Enter
 Sleep 1s
-Type "audit-verify /tmp/audit-snapshot.db"
+Type "audit-verify --source jsonl --path _staging/booth/attestation-fallback.jsonl --key booth-demo-2026=bmluZXZpZ2lsLWJvb3RoLWRlbW8tYXR0ZXN0YXRpb24ta2V5LTMyYg=="
 Enter
 Sleep 3s
 # expected output: chain OK ... PASS
@@ -60,13 +60,13 @@ Sleep 4s
 Type "# now someone edits one row of history..."
 Enter
 Sleep 1s
-Type "sqlite3 /tmp/audit-snapshot.db \"UPDATE audit SET actor='nobody' WHERE seq=42\""
+Type "sed 's/\"actor\":\"policy-analyst\"/\"actor\":\"ghost-actor\"/' _staging/booth/attestation-fallback.jsonl > /tmp/tampered.jsonl"
 Enter
 Sleep 2s
-Type "audit-verify /tmp/audit-snapshot.db"
+Type "audit-verify --source jsonl --path /tmp/tampered.jsonl --key booth-demo-2026=bmluZXZpZ2lsLWJvb3RoLWRlbW8tYXR0ZXN0YXRpb24ta2V5LTMyYg=="
 Enter
 Sleep 3s
-# expected output: chain BROKEN at seq=42 ... FAIL
+# expected output: FAIL at seq=4 ... entry_hash mismatch
 Type "# CAUGHT. Signed, not just logged."
 Enter
 Sleep 3s

--- a/video/booth-loop.tape
+++ b/video/booth-loop.tape
@@ -1,0 +1,77 @@
+# booth-loop.tape
+# VHS script for the Agentic Summit booth screen loop.
+# Install: brew install vhs   (needs ffmpeg + ttyd)
+# Record:  vhs video/booth-loop.tape
+# Outputs GIF for laptop screens and MP4 for a TV.
+#
+# Design rules baked in:
+# - 55 seconds, no audio, on-screen text only (booth noise kills narration)
+# - no hard start or end: someone glancing mid-loop still gets one full beat
+# - one beat every ~15-20s: policy deny -> signed chain -> tamper caught
+# - brand colors: navy background, ice-blue text, green/red for pass/fail
+#
+# PREREQ: run against the live demo cluster (scripts/demo-booth.sh --profile lean done once,
+# audit snapshot present at /tmp/audit-snapshot.db). Rehearse before recording.
+
+Output video/booth-loop.gif
+Output video/booth-loop.mp4
+
+Set FontSize 22
+Set FontFamily "JetBrains Mono"
+Set Width 1920
+Set Height 1080
+Set Padding 40
+Set Theme { "background": "#141B3D", "foreground": "#CADCFC", "green": "#4ADE80", "red": "#F87171", "blue": "#5B8DEF", "cursor": "#5B8DEF" }
+Set TypingSpeed 40ms
+
+# ---- Beat 0: standing banner (2s) ----
+Type "clear && echo '  Clawdlinux :: can you prove what your agent did?'"
+Enter
+Sleep 2s
+
+# ---- Beat 1: policy gate (18s) ----
+Type "# an agent asks to delete production volumes"
+Enter
+Sleep 1s
+Type "kubectl apply -f agentworkload_demo_deny.yaml"
+Enter
+Sleep 3s
+Type "kubectl get agentworkload opa-deny-demo -o jsonpath='{.status.phase}'"
+Enter
+Sleep 2.5s
+# expected output: PolicyDenied
+Type "# DENIED by policy before anything ran. The model never got a vote."
+Enter
+Sleep 4s
+
+# ---- Beat 2: signed evidence (15s) ----
+Type "clear && echo '  every action -> hash-chained, HMAC-signed audit entry'"
+Enter
+Sleep 1s
+Type "audit-verify /tmp/audit-snapshot.db"
+Enter
+Sleep 3s
+# expected output: chain OK ... PASS
+Type "# PASS. An auditor can recompute this offline. No trust required."
+Enter
+Sleep 4s
+
+# ---- Beat 3: tamper caught (15s) ----
+Type "# now someone edits one row of history..."
+Enter
+Sleep 1s
+Type "sqlite3 /tmp/audit-snapshot.db \"UPDATE audit SET actor='nobody' WHERE seq=42\""
+Enter
+Sleep 2s
+Type "audit-verify /tmp/audit-snapshot.db"
+Enter
+Sleep 3s
+# expected output: chain BROKEN at seq=42 ... FAIL
+Type "# CAUGHT. Signed, not just logged."
+Enter
+Sleep 3s
+
+# ---- Loop point: QR CTA (5s) ----
+Type "clear && echo '  github.com/Clawdlinux  |  free pilot for regulated teams  |  scan the QR'"
+Enter
+Sleep 4s


### PR DESCRIPTION
## What does this PR do?

Adds the booth strategy, market evidence, pitch script, demo plan, and passive display sources for the Jul 22 summit. Public-facing copy uses Clawdlinux while command-sensitive compatibility identifiers remain unchanged.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] CI/infrastructure

## Checklist

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes (or relevant subset)
- [x] No private-repo content leaked into OSS core
- [x] Commit is signed off (`git commit -s`)
- [x] Documentation updated

Go checks are not required because no Go files changed.

## How to test

- open `video/booth-animated-loop.html` at 1920x1080 and verify the Clawdlinux loop
- run `vhs video/booth-loop.tape` when VHS and ffmpeg are installed
- review `docs/DEMO-PLAN.md` and `docs/PITCH-SCRIPT.md` against current demo behavior
- run the issue-first, OSS/private-boundary, and secret-scan gates

## Validation performed

- browser render checked with no console errors
- `bash -n scripts/demo-booth.sh scripts/record-demo.sh`
- `scripts/check_issue_first_policy.sh`
- `scripts/check_oss_private_boundary.sh`
- `scripts/scan_secrets.sh`
- `git diff --check`

VHS and ffmpeg are not installed locally, so MP4/GIF rendering was not run. Stale architecture PNG/SVG exports are intentionally excluded.

## Related issues

No existing open issue matched this documentation and booth-source bundle.
