### PR TITLE
refactor: drop ninevigil identifiers, rename to clawdlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Cursor, ChatGPT, custom Python) can provision its own Clawdlinux execution
 environments without a human running `kubectl`.
 
 ```bash
-export NINEVIGIL_MCP_TOKEN=$(uuidgen)
+export CLAWDLINUX_MCP_TOKEN=$(uuidgen)
 agentctl mcp serve --addr :8765 --default-namespace agentic-system
 ```
 

--- a/_staging/booth/README.md
+++ b/_staging/booth/README.md
@@ -1,6 +1,6 @@
 # Booth staging
 
-Fallback assets for the NineVigil attestation demo. Use these if the live run
+Fallback assets for the Clawdlinux attestation demo. Use these if the live run
 hiccups. Do not present from these by default. The live demo is the demo.
 
 ## attestation-fallback.jsonl

--- a/_staging/booth/rehearsal-checklist.md
+++ b/_staging/booth/rehearsal-checklist.md
@@ -1,6 +1,6 @@
 # Booth rehearsal checklist
 
-Cold-run gate for the NineVigil attestation demo. Run this 5 times on the actual
+Cold-run gate for the Clawdlinux attestation demo. Run this 5 times on the actual
 booth laptop, offline, before the summit. Assume venue wifi is dead. Tick every
 gate. If any gate fails twice, the demo is not booth-ready.
 
@@ -11,14 +11,14 @@ phases and adds explicit pass/fail gates the script does not assert for you.
 
 - [ ] Laptop has `kubectl`, `helm`, and `kind` (or `k3s`) installed and on PATH.
 - [ ] Seed the kind node-image cache with the same command the demo script uses:
-      `kind create cluster --name ninevigil-demo --wait 120s`
+      `kind create cluster --name clawdlinux-demo --wait 120s`
       This pulls the exact `kindest/node` tag for your installed `kind` binary.
       Without this, wifi-off `kind create cluster` fails immediately.
 - [ ] Pre-pull every image the demo needs, then point kind at the local cache so
       no phase pulls from the network:
-      - [ ] Keep `ninevigil-demo` running while you load images.
+      - [ ] Keep `clawdlinux-demo` running while you load images.
       - [ ] For each image the chart and samples use: `docker pull <img>` then
-            `kind load docker-image <img> --name ninevigil-demo`.
+            `kind load docker-image <img> --name clawdlinux-demo`.
       - [ ] Re-run the demo with wifi OFF. If any phase blocks on ImagePull, the
             cache is incomplete. Fix before the summit.
 - [ ] `audit-verify` built and on PATH: `go build -o ~/bin/audit-verify ./cmd/audit-verify`.
@@ -34,7 +34,7 @@ phases and adds explicit pass/fail gates the script does not assert for you.
 
 ## 2. Cluster prep (script: "Preparing Kubernetes cluster")
 
-- [ ] PASS gate: "Created kind cluster ninevigil-demo" (or "Reusing ...") within
+- [ ] PASS gate: "Created kind cluster clawdlinux-demo" (or "Reusing ...") within
       120s.
 - [ ] FAIL signal: kind create hangs past 120s. Usually a stale Docker state.
       Run `scripts/demo-booth.sh --cleanup` and retry.
@@ -97,7 +97,7 @@ phases and adds explicit pass/fail gates the script does not assert for you.
 ## 11. Teardown
 
 - [ ] `scripts/demo-booth.sh --cleanup` deletes the kind cluster.
-- [ ] Confirm `kind get clusters` no longer lists `ninevigil-demo`.
+- [ ] Confirm `kind get clusters` no longer lists `clawdlinux-demo`.
 
 ## Rehearsal log (fill this in — 5 cold runs, wifi off)
 

--- a/agentworkload.yaml
+++ b/agentworkload.yaml
@@ -4,7 +4,7 @@ metadata:
   name: demo-argo-gate
   namespace: agentic-system
   labels:
-    app.kubernetes.io/part-of: ninevigil
+    app.kubernetes.io/part-of: clawdlinux
     gate: demo
 spec:
   objective: "Run the Argo workload demo gate."

--- a/assets/github-social-banner.svg
+++ b/assets/github-social-banner.svg
@@ -56,7 +56,7 @@
       <path d="M32,-30 L42,-25" stroke="#3B82F6" stroke-width="1.2" stroke-linecap="round"/>
     </g>
 
-    <!-- NineVigil product mark (smaller, right side) -->
+    <!-- Clawdlinux product mark (smaller, right side) -->
     <g transform="translate(1060, 320) scale(0.7)">
       <path d="M0,-65 L40,-40 L50,5 L35,45 L0,60 L-35,45 L-50,5 L-40,-40 Z" fill="none" stroke="#3B82F6" stroke-width="2" opacity="0.25"/>
       <line x1="-40" y1="-40" x2="40" y2="-40" stroke="#3B82F6" stroke-width="1" opacity="0.15"/>
@@ -73,7 +73,7 @@
     </g>
 
     <!-- Text -->
-    <text x="420" y="260" font-family="Arial Black, Arial" font-weight="900" font-size="72" fill="#FFFFFF" letter-spacing="-1">NineVigil</text>
+    <text x="420" y="260" font-family="Arial Black, Arial" font-weight="900" font-size="72" fill="#FFFFFF" letter-spacing="-1">Clawdlinux</text>
     <text x="420" y="330" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#60A5FA" letter-spacing="1">The Agentic Service Mesh</text>
     <text x="420" y="370" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#94A3B8">for Enterprise Kubernetes</text>
 

--- a/assets/landing-hero.svg
+++ b/assets/landing-hero.svg
@@ -88,7 +88,7 @@
     </g>
 
     <!-- Main text content (left side) -->
-    <text x="80" y="230" font-family="Arial Black, Arial" font-weight="900" font-size="56" fill="#FFFFFF" letter-spacing="-1">NineVigil</text>
+    <text x="80" y="230" font-family="Arial Black, Arial" font-weight="900" font-size="56" fill="#FFFFFF" letter-spacing="-1">Clawdlinux</text>
 
     <text x="80" y="290" font-family="Arial, Helvetica, sans-serif" font-size="24" fill="#60A5FA" letter-spacing="0.5">The Agentic Service Mesh</text>
     <text x="80" y="325" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#94A3B8">for Enterprise Kubernetes</text>

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -24,7 +24,7 @@ global:
   #
   # This feature injects the gVisor RuntimeClass into agent workload pods.
   # It applies to any pod carrying the opt-in label, regardless of which
-  # agent runtime created it (NineVigil AgentWorkload, external runtimes,
+  # agent runtime created it (Clawdlinux AgentWorkload, external runtimes,
   # or custom pods).
   #
   # Add this label to a pod spec to opt in:

--- a/cmd/agentctl-web/demo_test.go
+++ b/cmd/agentctl-web/demo_test.go
@@ -51,7 +51,7 @@ func TestHandleDemoRendersLiveRuntimePods(t *testing.T) {
 				Labels: map[string]string{
 					"agentic.io/job-id":         "secure-research-swarm",
 					agentctl.RoleLabelKey:       "researcher",
-					"app.kubernetes.io/part-of": "ninevigil",
+					"app.kubernetes.io/part-of": "clawdlinux",
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/cmd/agentctl-web/templates/demo.html
+++ b/cmd/agentctl-web/templates/demo.html
@@ -64,7 +64,7 @@
     <div class="demo-hero">
         <div class="demo-kicker">{{if .Live}}Live cluster{{else}}Investor demo path{{end}}</div>
         <h1 id="demo-title">Run governed AI agents inside your cluster.</h1>
-        <p class="demo-copy">NineVigil is an open-source agent runtime for Kubernetes. It runs agent workloads where the data already lives, with policy, cost, and audit proof built in.</p>
+        <p class="demo-copy">Clawdlinux is an open-source agent runtime for Kubernetes. It runs agent workloads where the data already lives, with policy, cost, and audit proof built in.</p>
         <div class="demo-actions">
             <a class="btn btn-primary btn-demo" href="#run-sequence">Run demo</a>
             <a class="btn btn-secondary btn-demo" href="#audit-proof">View Audit Proof</a>

--- a/cmd/agentctl-web/templates/layout.html
+++ b/cmd/agentctl-web/templates/layout.html
@@ -13,7 +13,7 @@
     <nav class="navbar demo-navbar">
         <div class="nav-brand">
             <span class="logo">NV</span>
-            <span class="brand-text">NineVigil</span>
+            <span class="brand-text">Clawdlinux</span>
         </div>
         <div class="demo-nav-proof">
             <span class="demo-pill">Kubernetes runtime</span>

--- a/cmd/agentctl/mcp_serve.go
+++ b/cmd/agentctl/mcp_serve.go
@@ -47,7 +47,7 @@ func newMCPCommand(opts *cliOptions) *cobra.Command {
 		Short: "MCP (Model Context Protocol) server — agent-callable AgentWorkload API",
 		Long: `Run an MCP server that exposes AgentWorkload CRD verbs as tools an
 external orchestrator agent (Claude Desktop, Cursor, ChatGPT, custom) can call
-to provision its own NineVigil execution environments.
+to provision its own Clawdlinux execution environments.
 
 Six tools are registered:
   create_workload      provision a new AgentWorkload
@@ -68,13 +68,13 @@ func newMCPServeCommand(opts *cliOptions) *cobra.Command {
 		Short: "Start the MCP server",
 		Long: `Start an HTTP MCP server that exposes the six AgentWorkload tools.
 
-Auth: when env NINEVIGIL_MCP_TOKEN is set (or --auth-token is passed) every
+Auth: when env CLAWDLINUX_MCP_TOKEN is set (or --auth-token is passed) every
 request must carry "Authorization: Bearer <token>". Empty token disables auth
 — intended for local stdio transport on a trusted host.
 
 Examples:
   # HTTP transport on :8765 with bearer auth
-  NINEVIGIL_MCP_TOKEN=$(uuidgen) agentctl mcp serve --addr :8765
+  CLAWDLINUX_MCP_TOKEN=$(uuidgen) agentctl mcp serve --addr :8765
 
   # Stdio transport for Claude Desktop / Cursor MCP client config
   agentctl mcp serve --transport stdio`,
@@ -86,7 +86,7 @@ Examples:
 	cmd.Flags().StringVar(&srvOpts.transport, "transport", "http", "Transport: http|stdio")
 	cmd.Flags().StringVar(&srvOpts.defaultNamespace, "default-namespace", "agentic-system", "Namespace to use when a tool call omits one")
 	cmd.Flags().StringVar(&srvOpts.litellmURL, "litellm-url", "", "Override LiteLLM cost endpoint (default: in-cluster service)")
-	cmd.Flags().StringVar(&srvOpts.authTokenFlag, "auth-token", "", "Bearer token (or set NINEVIGIL_MCP_TOKEN)")
+	cmd.Flags().StringVar(&srvOpts.authTokenFlag, "auth-token", "", "Bearer token (or set CLAWDLINUX_MCP_TOKEN)")
 	return cmd
 }
 
@@ -97,7 +97,7 @@ func runMCPServe(ctx context.Context, opts *cliOptions, srvOpts *mcpServeOptions
 
 	token := srvOpts.authTokenFlag
 	if token == "" {
-		token = os.Getenv("NINEVIGIL_MCP_TOKEN")
+		token = os.Getenv("CLAWDLINUX_MCP_TOKEN")
 	}
 
 	server, err := mcp.NewServer(mcp.ServerConfig{
@@ -121,7 +121,7 @@ func runMCPServe(ctx context.Context, opts *cliOptions, srvOpts *mcpServeOptions
 }
 
 func runHTTPTransport(ctx context.Context, server *mcp.Server, srvOpts *mcpServeOptions, authed bool, w io.Writer) error {
-	authStatus := "DISABLED (set NINEVIGIL_MCP_TOKEN to enable)"
+	authStatus := "DISABLED (set CLAWDLINUX_MCP_TOKEN to enable)"
 	if authed {
 		authStatus = "ENABLED (Bearer token required)"
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Clawdlinux/agentic-operator-core/pkg/finops"
 )
 
-func TestFinOpsMetricsEndpointContainsNineVigilCostMetric(t *testing.T) {
+func TestFinOpsMetricsEndpointContainsClawdlinuxCostMetric(t *testing.T) {
 	t.Parallel()
 
 	reporter := finops.NewMemoryCostReporter()
@@ -38,8 +38,8 @@ func TestFinOpsMetricsEndpointContainsNineVigilCostMetric(t *testing.T) {
 		t.Fatalf("read body: %v", err)
 	}
 	body := string(bodyBytes)
-	if !strings.Contains(body, "ninevigil_agent_cost_dollars") {
-		t.Fatalf("metrics body missing ninevigil_agent_cost_dollars:\n%s", body)
+	if !strings.Contains(body, "clawdlinux_agent_cost_dollars") {
+		t.Fatalf("metrics body missing clawdlinux_agent_cost_dollars:\n%s", body)
 	}
 	if !strings.Contains(body, `model="openai/gpt-4o-mini"`) {
 		t.Fatalf("metrics body missing model label:\n%s", body)

--- a/config/grafana/dashboards/cost-by-workload.json
+++ b/config/grafana/dashboards/cost-by-workload.json
@@ -77,7 +77,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(ninevigil_agent_cost_dollars)",
+          "expr": "sum(clawdlinux_agent_cost_dollars)",
           "legendFormat": "total",
           "range": true,
           "refId": "A"
@@ -123,7 +123,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(ninevigil_agent_cost_dollars) by (workload, namespace, model)",
+          "expr": "sum(clawdlinux_agent_cost_dollars) by (workload, namespace, model)",
           "legendFormat": "{{namespace}}/{{workload}} {{model}}",
           "range": true,
           "refId": "A"

--- a/config/samples/agentworkload_demo_runtime.yaml
+++ b/config/samples/agentworkload_demo_runtime.yaml
@@ -53,7 +53,7 @@ metadata:
     agentic.io/job-id: secure-research-swarm
     agentworkload.clawdlinux.io/name: secure-research-swarm
     agentworkload.clawdlinux.io/role: researcher
-    app.kubernetes.io/part-of: ninevigil
+    app.kubernetes.io/part-of: clawdlinux
 spec:
   runtimeClassName: gvisor
   containers:
@@ -70,7 +70,7 @@ metadata:
     agentic.io/job-id: secure-research-swarm
     agentworkload.clawdlinux.io/name: secure-research-swarm
     agentworkload.clawdlinux.io/role: policy-analyst
-    app.kubernetes.io/part-of: ninevigil
+    app.kubernetes.io/part-of: clawdlinux
 spec:
   runtimeClassName: gvisor
   containers:
@@ -87,7 +87,7 @@ metadata:
     agentic.io/job-id: secure-research-swarm
     agentworkload.clawdlinux.io/name: secure-research-swarm
     agentworkload.clawdlinux.io/role: report-synthesizer
-    app.kubernetes.io/part-of: ninevigil
+    app.kubernetes.io/part-of: clawdlinux
 spec:
   runtimeClassName: gvisor
   containers:

--- a/docs/04-architecture.md
+++ b/docs/04-architecture.md
@@ -76,7 +76,7 @@ in `pkg/runtime`.
 - `argo` (default): multi-step DAG workflows via Argo. Use it for parallel or
   long-running agent jobs.
 - `pod`: a bring-your-own single pod. Use it for simple, single-shot agents. The
-  pod image comes from the `NINEVIGIL_AGENT_IMAGE` env var.
+  pod image comes from the `CLAWDLINUX_AGENT_IMAGE` env var.
 - `kagent`: runs the workload as a kagent `Agent` (`kagent.dev/v1alpha2`) in BYO
   mode, created through the unstructured client with no Go dependency on kagent.
   Requires kagent installed in the cluster. Same image source, same seal.

--- a/docs/DEMO-PLAN.md
+++ b/docs/DEMO-PLAN.md
@@ -13,7 +13,7 @@ A regulated fintech platform team wants to run an analysis agent. Security will 
 ./scripts/demo-booth.sh --cleanup  # to reset
 ```
 
-Run it once the night before. It provisions the kind cluster (`ninevigil-demo`), installs the operator, Argo, and shared services, and leaves evidence under `tests/harness/evidence/`. Use `--profile lean` if time or laptop capacity is constrained. Keep a recorded run (`--record`) as backup in case live wifi or Docker misbehaves.
+Run it once the night before. It provisions the kind cluster (`clawdlinux-demo`), installs the operator, Argo, and shared services, and leaves evidence under `tests/harness/evidence/`. Use `--profile lean` if time or laptop capacity is constrained. Keep a recorded run (`--record`) as backup in case live wifi or Docker misbehaves.
 
 ## Run of show
 

--- a/docs/PITCH-SCRIPT.md
+++ b/docs/PITCH-SCRIPT.md
@@ -42,11 +42,11 @@ Transition straight into the demo. No gap.
 
 `scripts/demo-booth.sh` is a gate script: it provisions and then proves five controls, printing PASS/FAIL evidence for each. Know what each phase does so you can narrate it instead of reading it.
 
-**Phase 0, setup.** Checks kubectl, helm, kind (or reuses k3s). Creates kind cluster `ninevigil-demo`. The platform profile installs the operator, Argo, and shared services via `tests/harness/setup.sh`. `--profile lean` installs the CRD, operator, NetworkPolicy, and gVisor sandbox while omitting Argo and shared services. The lean profile starts faster and does not depend on Argo scheduling; use it when the laptop or wifi is the risk.
+**Phase 0, setup.** Checks kubectl, helm, kind (or reuses k3s). Creates kind cluster `clawdlinux-demo`. The platform profile installs the operator, Argo, and shared services via `tests/harness/setup.sh`. `--profile lean` installs the CRD, operator, NetworkPolicy, and gVisor sandbox while omitting Argo and shared services. The lean profile starts faster and does not depend on Argo scheduling; use it when the laptop or wifi is the risk.
 
 **Phase 1, OPA allow/deny.** Applies `opa-allow-demo` (objective: "analyze quarterly revenue data") and waits for it to reach a running phase. Then applies `opa-deny-demo` (objective: "delete all production volumes") and waits for phase `PolicyDenied`, then prints the deny reason from the CRD status condition. What this proves: policy is evaluated by the operator against the manifest before execution, and the decision plus the reason is recorded on the Kubernetes object itself. The model is not in the loop.
 
-**Phase 2, cost.** Curls the operator's metrics endpoint from inside the pod and greps for `ninevigil_agent_cost_dollars`. What this proves: per-workload cost is a first-class metric, not a spreadsheet.
+**Phase 2, cost.** Curls the operator's metrics endpoint from inside the pod and greps for `clawdlinux_agent_cost_dollars`. What this proves: per-workload cost is a first-class metric, not a spreadsheet.
 
 **Phase 3, gVisor.** Confirms the `gvisor` RuntimeClass exists, then does a server-side dry-run of a pod labeled `agentic.clawdlinux.org/runtime-sandbox: gvisor` and shows that the mutating webhook injected `runtimeClassName: gvisor`. What this proves: isolation is applied by admission control based on a label. No agent code changes.
 

--- a/docs/agentctl/mcp.md
+++ b/docs/agentctl/mcp.md
@@ -30,16 +30,16 @@ truth a client needs.
 
 ```bash
 # 1. Set a bearer token (any opaque string)
-export NINEVIGIL_MCP_TOKEN=$(uuidgen)
+export CLAWDLINUX_MCP_TOKEN=$(uuidgen)
 
 # 2. Boot the server (uses your KUBECONFIG context)
 agentctl mcp serve --addr :8765 --default-namespace agentic-system
 
 # 3. From another terminal — discover tools
-curl -H "Authorization: Bearer $NINEVIGIL_MCP_TOKEN" http://127.0.0.1:8765/tools | jq
+curl -H "Authorization: Bearer $CLAWDLINUX_MCP_TOKEN" http://127.0.0.1:8765/tools | jq
 
 # 4. Create a workload
-curl -H "Authorization: Bearer $NINEVIGIL_MCP_TOKEN" \
+curl -H "Authorization: Bearer $CLAWDLINUX_MCP_TOKEN" \
      -H "Content-Type: application/json" \
      -X POST http://127.0.0.1:8765/call_tool \
      -d '{"tool":"create_workload","params":{
@@ -60,7 +60,7 @@ kubectl get agentworkloads -n agentic-system
 ## Auth
 
 `agentctl mcp serve` enforces `Authorization: Bearer <token>` when
-`NINEVIGIL_MCP_TOKEN` (or `--auth-token`) is non-empty. An unset token
+`CLAWDLINUX_MCP_TOKEN` (or `--auth-token`) is non-empty. An unset token
 **disables auth entirely** — only do this for local stdio transport on a
 trusted host.
 

--- a/docs/rfcs/0001-cross-cluster-agent-identity.md
+++ b/docs/rfcs/0001-cross-cluster-agent-identity.md
@@ -50,7 +50,7 @@ Clawdlinux's positioning is **air-gapped, zero-egress, regulated-industry agent 
 
 **SPIFFE** (Secure Production Identity Framework For Everyone) is a CNCF graduated specification (2022) defining:
 
-- **SPIFFE ID** — a URI of the form `spiffe://<trust_domain>/<path>`, e.g. `spiffe://ninevigil-us-east.example.com/agent/research-swarm/instance-42`.
+- **SPIFFE ID** — a URI of the form `spiffe://<trust_domain>/<path>`, e.g. `spiffe://clawdlinux-us-east.example.com/agent/research-swarm/instance-42`.
 - **SVID** (SPIFFE Verifiable Identity Document) — the cryptographic document presenting a SPIFFE ID. Two flavors: X.509-SVID (mTLS) and JWT-SVID (HTTP headers).
 - **Trust bundle** — the set of CA certificates / public keys a workload uses to verify SVIDs from a given trust domain.
 - **Workload API** — a local Unix socket (`/run/spire/sockets/agent.sock`) that workloads call to fetch their SVID without holding any long-lived secret.
@@ -149,13 +149,13 @@ spec:
     # Opt-in: if absent, agent uses ServiceAccount + operator JWT only.
     spiffe:
       enabled: true
-      trustDomain: "ninevigil-us-east.example.com"
+      trustDomain: "clawdlinux-us-east.example.com"
       # Optional: explicit SPIFFE ID path. Default: /agent/<namespace>/<name>
       idPath: "/agent/tenant-fintech/research-swarm"
       # Trust domains this agent is allowed to authenticate to.
       federatedTo:
-        - "ninevigil-eu-west.example.com"
-        - "ninevigil-restricted.example.com"
+        - "clawdlinux-eu-west.example.com"
+        - "clawdlinux-restricted.example.com"
       # Workload API socket mount mode: sidecar | init | hostpath
       injectionMode: "sidecar"
 ```
@@ -173,7 +173,7 @@ Proposed v2 (federation-capable):
 Agent A → Agent B: POST /a2a/handshake
   Authorization: Bearer <jwt-svid>
   X-A2A-Version: 2
-  X-A2A-TrustDomain: ninevigil-us-east.example.com
+  X-A2A-TrustDomain: clawdlinux-us-east.example.com
 ```
 
 Receiving agent (B):
@@ -279,7 +279,7 @@ Deprecation timeline: **no deprecation of v1 planned.** Operator-issued JWT rema
 4. **A2A skill-level authorization** — once we have SPIFFE IDs, do we add a policy like "only `spiffe://*/agent/tenant-fintech/*` can call the `analyze-portfolio` skill"? OPA-based, separate from this RFC?
 5. **Performance of JWT-SVID validation on every A2A call** — measure overhead, consider caching verified IDs for short windows.
 6. **Cross-cloud (AWS IAM ↔ GCP SA ↔ Azure AD)** — explicitly deferred to a future RFC. Confirm scope is acceptable.
-7. **SPIRE agent placement** — DaemonSet on every node, or only nodes labeled `ninevigil.io/agent-host=true`? Trade-off: simplicity vs blast radius.
+7. **SPIRE agent placement** — DaemonSet on every node, or only nodes labeled `clawdlinux.io/agent-host=true`? Trade-off: simplicity vs blast radius.
 
 ---
 

--- a/examples/mcp-claude-desktop/README.md
+++ b/examples/mcp-claude-desktop/README.md
@@ -1,7 +1,7 @@
-# Claude Desktop ↔ NineVigil MCP
+# Claude Desktop ↔ Clawdlinux MCP
 
 This example shows how to wire [Claude Desktop](https://claude.ai/download)
-to NineVigil's MCP server, so Claude can provision and manage AgentWorkloads
+to Clawdlinux's MCP server, so Claude can provision and manage AgentWorkloads
 on your cluster from a chat conversation.
 
 We use the **stdio transport** here — no separate HTTP server, no shim
@@ -24,10 +24,10 @@ Copy `claude_desktop_config.json` to:
 - Linux: `~/.config/Claude/claude_desktop_config.json`
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
-If you already have other MCP servers configured, merge the `mcpServers.ninevigil`
+If you already have other MCP servers configured, merge the `mcpServers.clawdlinux`
 entry into your existing config — do not overwrite the file.
 
-Then **restart Claude Desktop**. The six NineVigil tools will appear in the
+Then **restart Claude Desktop**. The six Clawdlinux tools will appear in the
 tool picker (Settings → Developer → MCP servers).
 
 ## 3. Try it
@@ -49,7 +49,7 @@ Claude will call `create_workload`. Then ask:
 - Stdio mode does **not** enforce bearer auth — it assumes the spawning
   process (Claude Desktop) is trusted on your machine. Do not use stdio
   transport over SSH, sockets, or any non-local channel. For remote agents,
-  use `--transport http` with `NINEVIGIL_MCP_TOKEN`.
+  use `--transport http` with `CLAWDLINUX_MCP_TOKEN`.
 - The bundled config sets `KUBECONFIG` to `~/.kube/config`. For
   out-of-cluster use against a managed cluster, point `KUBECONFIG` at a
   context whose ServiceAccount has CRUD on `agentworkloads` plus read on

--- a/examples/mcp-claude-desktop/claude_desktop_config.json
+++ b/examples/mcp-claude-desktop/claude_desktop_config.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "ninevigil": {
+    "clawdlinux": {
       "command": "agentctl",
       "args": [
         "mcp",

--- a/examples/mcp-orchestrator/README.md
+++ b/examples/mcp-orchestrator/README.md
@@ -1,6 +1,6 @@
-# NineVigil MCP demo — Python orchestrator
+# Clawdlinux MCP demo — Python orchestrator
 
-Tiny script that drives the NineVigil MCP server over HTTP using only Python
+Tiny script that drives the Clawdlinux MCP server over HTTP using only Python
 stdlib (`urllib`). Demonstrates discovery + sequential creation of three
 AgentWorkloads + status polling. The script that powers the YC demo recording.
 
@@ -16,8 +16,8 @@ AgentWorkloads + status polling. The script that powers the YC demo recording.
 agentctl mcp serve --addr 127.0.0.1:8765 --auth-token demo
 
 # 2. In this directory
-NINEVIGIL_MCP_ENDPOINT=http://127.0.0.1:8765 \
-NINEVIGIL_MCP_TOKEN=demo \
+CLAWDLINUX_MCP_ENDPOINT=http://127.0.0.1:8765 \
+CLAWDLINUX_MCP_TOKEN=demo \
 python3 orchestrator.py
 ```
 

--- a/examples/mcp-orchestrator/orchestrator.py
+++ b/examples/mcp-orchestrator/orchestrator.py
@@ -1,4 +1,4 @@
-"""Tiny orchestrator that drives the NineVigil MCP server over plain HTTP.
+"""Tiny orchestrator that drives the Clawdlinux MCP server over plain HTTP.
 
 We deliberately use stdlib `urllib` rather than the `mcp` SDK so this script
 runs with zero pip installs against the local server. Swap in `mcp.Client` if
@@ -13,9 +13,9 @@ import time
 import urllib.request
 import urllib.error
 
-ENDPOINT = os.environ.get("NINEVIGIL_MCP_ENDPOINT", "http://127.0.0.1:8765")
-TOKEN = os.environ.get("NINEVIGIL_MCP_TOKEN", "")
-NAMESPACE = os.environ.get("NINEVIGIL_NAMESPACE", "agentic-system")
+ENDPOINT = os.environ.get("CLAWDLINUX_MCP_ENDPOINT", "http://127.0.0.1:8765")
+TOKEN = os.environ.get("CLAWDLINUX_MCP_TOKEN", "")
+NAMESPACE = os.environ.get("CLAWDLINUX_NAMESPACE", "agentic-system")
 
 WORKLOADS = [
     {

--- a/internal/controller/agentworkload_controller.go
+++ b/internal/controller/agentworkload_controller.go
@@ -130,11 +130,11 @@ func (r *AgentWorkloadReconciler) ensureRuntimeDefaults() {
 	reg := runtimeadapter.NewRegistry()
 	reg.Register("argo", &runtimeadapter.ArgoWorkflowAdapter{Client: r.Client, Scheme: r.Scheme})
 	// pod is the bring-your-own single-pod runtime. Its image comes from the
-	// NINEVIGIL_AGENT_IMAGE env var; the adapter fails closed if it is unset.
-	reg.Register("pod", &runtimeadapter.PodRuntimeAdapter{Client: r.Client, Scheme: r.Scheme, Image: os.Getenv("NINEVIGIL_AGENT_IMAGE")})
+	// CLAWDLINUX_AGENT_IMAGE env var; the adapter fails closed if it is unset.
+	reg.Register("pod", &runtimeadapter.PodRuntimeAdapter{Client: r.Client, Scheme: r.Scheme, Image: os.Getenv("CLAWDLINUX_AGENT_IMAGE")})
 	// kagent runs the workload as a kagent Agent (kagent.dev/v1alpha2) via the
 	// unstructured client, no Go dependency. Same image source, same governance.
-	reg.Register("kagent", &runtimeadapter.KagentAdapter{Client: r.Client, Image: os.Getenv("NINEVIGIL_AGENT_IMAGE")})
+	reg.Register("kagent", &runtimeadapter.KagentAdapter{Client: r.Client, Image: os.Getenv("CLAWDLINUX_AGENT_IMAGE")})
 	r.RuntimeRegistry = reg
 }
 

--- a/landing/public/landing-hero.svg
+++ b/landing/public/landing-hero.svg
@@ -88,7 +88,7 @@
     </g>
 
     <!-- Main text content (left side) -->
-    <text x="80" y="230" font-family="Arial Black, Arial" font-weight="900" font-size="56" fill="#FFFFFF" letter-spacing="-1">NineVigil</text>
+    <text x="80" y="230" font-family="Arial Black, Arial" font-weight="900" font-size="56" fill="#FFFFFF" letter-spacing="-1">Clawdlinux</text>
 
     <text x="80" y="290" font-family="Arial, Helvetica, sans-serif" font-size="24" fill="#60A5FA" letter-spacing="0.5">The Agentic Service Mesh</text>
     <text x="80" y="325" font-family="Arial, Helvetica, sans-serif" font-size="20" fill="#94A3B8">for Enterprise Kubernetes</text>

--- a/landing/src/components/Comparison.jsx
+++ b/landing/src/components/Comparison.jsx
@@ -63,7 +63,7 @@ const Comparison = () => {
   ];
 
   const runtimes = [
-    { name: 'NineVigil AgentWorkload', supported: true },
+    { name: 'Clawdlinux AgentWorkload', supported: true },
     { name: 'CNCF agent runtimes (kagent, etc.)', supported: true },
     { name: 'Custom agent pods', supported: true },
     { name: 'Kubeflow pipelines', supported: true },
@@ -115,7 +115,7 @@ const Comparison = () => {
             </span>
           </h2>
           <p className="text-lg max-w-2xl mx-auto" style={{ color: currentTheme.text.tertiary }}>
-            NineVigil adds regulated controls around any Kubernetes agent runtime. The runtime handles lifecycle. We handle compliance.
+            Clawdlinux adds regulated controls around any Kubernetes agent runtime. The runtime handles lifecycle. We handle compliance.
           </p>
         </motion.div>
 
@@ -185,7 +185,7 @@ const Comparison = () => {
             ))}
           </div>
           <p className="text-xs mt-4" style={{ color: currentTheme.text.muted }}>
-            The runtime handles agent lifecycle and tools. NineVigil handles multi-tenancy, audit, spend, and air-gapped compliance. Use both.
+            The runtime handles agent lifecycle and tools. Clawdlinux handles multi-tenancy, audit, spend, and air-gapped compliance. Use both.
           </p>
         </motion.div>
 

--- a/landing/src/components/Footer.jsx
+++ b/landing/src/components/Footer.jsx
@@ -10,10 +10,10 @@ const LEGAL = {
     content: `Last updated: March 2026
 
 1. Acceptance of Terms
-By accessing clawdlinux.org or the NineVigil project materials (formerly Agentic Operator), you agree to these terms. If you do not agree, do not use the site or distributed materials.
+By accessing clawdlinux.org or the Clawdlinux project materials (formerly Agentic Operator), you agree to these terms. If you do not agree, do not use the site or distributed materials.
 
 2. Open Source License
-NineVigil core source code is licensed under the Apache License 2.0. Your use of the repository source code is governed by that license and the notices included in the project.
+Clawdlinux core source code is licensed under the Apache License 2.0. Your use of the repository source code is governed by that license and the notices included in the project.
 
 3. Website Content
 Documentation, manifests, examples, and release notes are provided for informational purposes. Separate commercial offerings and managed support may be subject to separate agreements.
@@ -223,7 +223,7 @@ export default function Footer() {
                   className="text-lg font-bold"
                   style={{ fontFamily: "'Syne', sans-serif", color: currentTheme.text.primary }}
                 >
-                  NineVigil
+                  Clawdlinux
                 </span>
               </div>
               <p
@@ -242,7 +242,7 @@ export default function Footer() {
                 className="text-xs mt-1"
                 style={{ color: currentTheme.text.muted, fontFamily: "'DM Sans', sans-serif" }}
               >
-                NineVigil · Apache 2.0 · Clawdlinux
+                Clawdlinux · Apache 2.0 · Clawdlinux
               </p>
 
               {/* GitHub only */}

--- a/landing/src/components/OpenSource.jsx
+++ b/landing/src/components/OpenSource.jsx
@@ -134,7 +134,7 @@ export default function OpenSource() {
           className="text-center text-lg mb-12"
           style={{ color: currentTheme.text.tertiary, fontFamily: "'DM Sans', sans-serif" }}
         >
-          NineVigil is open source for policy-aware AI workloads on Kubernetes. Inspect, extend, and self-host.
+          Clawdlinux is open source for policy-aware AI workloads on Kubernetes. Inspect, extend, and self-host.
         </motion.p>
 
         {/* Repo card */}

--- a/landing/src/components/Positioning.jsx
+++ b/landing/src/components/Positioning.jsx
@@ -43,7 +43,7 @@ const TIMELINE = [
   {
     phase: 'Solution',
     title: 'Kubernetes for agents',
-    detail: 'NineVigil is the operational layer. It sits between your agent framework and your K8s cluster. One CRD to deploy, one protocol for agents to talk, one bill per workload.',
+    detail: 'Clawdlinux is the operational layer. It sits between your agent framework and your K8s cluster. One CRD to deploy, one protocol for agents to talk, one bill per workload.',
   },
   {
     phase: 'Moat',
@@ -115,7 +115,7 @@ export default function Positioning() {
           }}
         >
           Every agent framework lets you build. None of them let you deploy, govern, and bill in production.
-          NineVigil fills that gap — the Kubernetes-native control plane for autonomous AI agents.
+          Clawdlinux fills that gap — the Kubernetes-native control plane for autonomous AI agents.
         </p>
       </motion.div>
 

--- a/landing/src/components/ProductsAcl.jsx
+++ b/landing/src/components/ProductsAcl.jsx
@@ -9,7 +9,7 @@ import {
 } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 
-const ACL_GITHUB = 'https://github.com/Clawdlinux/ninevigil-acp';
+const ACL_GITHUB = 'https://github.com/Clawdlinux/clawdlinux-acp';
 const OPERATOR_GITHUB = 'https://github.com/Clawdlinux/agentic-operator-core';
 
 const PRODUCTS = [
@@ -132,7 +132,7 @@ export default function ProductsAcl() {
             lineHeight: 1.6,
           }}
         >
-          NineVigil ships the operational layer (Kubernetes operator) and the
+          Clawdlinux ships the operational layer (Kubernetes operator) and the
           data layer (compact agent-native representation format) for
           production AI agents in regulated environments.
         </p>

--- a/landing/src/components/Waitlist.jsx
+++ b/landing/src/components/Waitlist.jsx
@@ -33,7 +33,7 @@ export default function Waitlist() {
   };
 
   const openMailFallback = (payload) => {
-    const subject = `NineVigil Pilot Request: ${payload.company || payload.name}`;
+    const subject = `Clawdlinux Pilot Request: ${payload.company || payload.name}`;
     const body = [
       `Name: ${payload.name}`,
       `Email: ${payload.email}`,

--- a/pkg/finops/memory_reporter.go
+++ b/pkg/finops/memory_reporter.go
@@ -60,7 +60,7 @@ func NewMemoryCostReporter() *MemoryCostReporter {
 	)
 	costDollarsGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "ninevigil_agent_cost_dollars",
+			Name: "clawdlinux_agent_cost_dollars",
 			Help: "Estimated USD cost per agent workload.",
 		},
 		[]string{"workload", "namespace", "model"},

--- a/pkg/finops/memory_reporter_test.go
+++ b/pkg/finops/memory_reporter_test.go
@@ -114,7 +114,7 @@ func TestMemoryCostReporter_OllamaFree(t *testing.T) {
 	}
 }
 
-func TestMemoryCostReporter_PrometheusCollectorEmitsNineVigilCostMetric(t *testing.T) {
+func TestMemoryCostReporter_PrometheusCollectorEmitsClawdlinuxCostMetric(t *testing.T) {
 	t.Parallel()
 
 	r := NewMemoryCostReporter()
@@ -133,7 +133,7 @@ func TestMemoryCostReporter_PrometheusCollectorEmitsNineVigilCostMetric(t *testi
 		t.Fatalf("gather metrics: %v", err)
 	}
 	for _, family := range metricFamilies {
-		if family.GetName() != "ninevigil_agent_cost_dollars" {
+		if family.GetName() != "clawdlinux_agent_cost_dollars" {
 			continue
 		}
 		if len(family.GetMetric()) != 1 {
@@ -145,5 +145,5 @@ func TestMemoryCostReporter_PrometheusCollectorEmitsNineVigilCostMetric(t *testi
 		}
 		return
 	}
-	t.Fatal("ninevigil_agent_cost_dollars metric not found")
+	t.Fatal("clawdlinux_agent_cost_dollars metric not found")
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -27,7 +27,7 @@ limitations under the License.
 //	get_workload_cost    -> LiteLLM cost-attribution hook
 //	delete_workload      -> delete
 //
-// Auth is bearer-token only this sprint (env NINEVIGIL_MCP_TOKEN). Full RBAC
+// Auth is bearer-token only this sprint (env CLAWDLINUX_MCP_TOKEN). Full RBAC
 // integration (OIDC/SPIFFE) is deferred to v0.5 per the Phase 2 spec.
 package mcp
 

--- a/pkg/runtime/adapter.go
+++ b/pkg/runtime/adapter.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package runtime defines the RuntimeAdapter interface that decouples NineVigil
+// Package runtime defines the RuntimeAdapter interface that decouples Clawdlinux
 // governance controls from the underlying agent execution engine.
 //
 // The reconciler calls RuntimeAdapter methods instead of Argo-specific code
 // directly. Each adapter implements the same egress-seal, attestation, and
-// lifecycle contract. This lets NineVigil work with AgentWorkload CRDs,
+// lifecycle contract. This lets Clawdlinux work with AgentWorkload CRDs,
 // external labeled pods, CNCF agent runtimes, or any future engine without
 // code changes in the controller.
 package runtime
@@ -48,7 +48,7 @@ type ExecutionStatus struct {
 }
 
 // RuntimeAdapter is the interface every execution engine must implement.
-// NineVigil governance controls (gVisor injection, egress seal, audit,
+// Clawdlinux governance controls (gVisor injection, egress seal, audit,
 // attestation) apply identically regardless of which adapter is active.
 type RuntimeAdapter interface {
 	// Capabilities returns what this adapter supports.

--- a/pkg/runtime/kagent_adapter.go
+++ b/pkg/runtime/kagent_adapter.go
@@ -42,7 +42,7 @@ var kagentGVK = schema.GroupVersionKind{Group: kagentGroup, Version: kagentVersi
 
 // KagentAdapter runs an AgentWorkload as a kagent Agent (kagent.dev/v1alpha2)
 // in BYO mode: kagent deploys our agent image and serves it over A2A. We stamp
-// the NineVigil governance labels onto kagent's pods through its deployment
+// the Clawdlinux governance labels onto kagent's pods through its deployment
 // label passthrough, so the gVisor injector and the egress NetworkPolicy seal
 // them identically to every other runtime. No Go dependency on kagent:
 // everything goes through the unstructured client.
@@ -68,7 +68,7 @@ func (a *KagentAdapter) Capabilities() RuntimeCapabilities {
 // agent image is configured rather than creating an unusable Agent.
 func (a *KagentAdapter) Execute(ctx context.Context, workload *agenticv1alpha1.AgentWorkload) (*ExecutionStatus, error) {
 	if a.Image == "" {
-		return nil, fmt.Errorf("kagent adapter: agent image is required (set NINEVIGIL_AGENT_IMAGE)")
+		return nil, fmt.Errorf("kagent adapter: agent image is required (set CLAWDLINUX_AGENT_IMAGE)")
 	}
 	agent := a.buildAgent(workload)
 	if err := a.Client.Create(ctx, agent); err != nil && !apierrors.IsAlreadyExists(err) {

--- a/pkg/runtime/labels.go
+++ b/pkg/runtime/labels.go
@@ -38,7 +38,7 @@ const (
 )
 
 // governanceLabels returns the pod labels that place a workload's pods under
-// NineVigil governance. Two are load-bearing: the gVisor RuntimeClass injector
+// Clawdlinux governance. Two are load-bearing: the gVisor RuntimeClass injector
 // keys on the sandbox label, and the default-deny egress NetworkPolicy selects
 // on part-of. Every adapter stamps these onto the pods it creates so the seal
 // is identical across runtimes, whether the scheduler is Argo, a plain pod, or

--- a/scripts/clean-cluster-test.sh
+++ b/scripts/clean-cluster-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 GREEN="$(printf '\033[32m')"
 RED="$(printf '\033[31m')"
 RESET="$(printf '\033[0m')"
-CLUSTER="ninevigil-demo"
+CLUSTER="clawdlinux-demo"
 cleanup() { kind delete cluster --name "${CLUSTER}" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 

--- a/scripts/demo-booth.sh
+++ b/scripts/demo-booth.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-CLUSTER_NAME="${CLUSTER_NAME:-ninevigil-demo}"
+CLUSTER_NAME="${CLUSTER_NAME:-clawdlinux-demo}"
 NS_OPERATOR="${NS_OPERATOR:-agentic-system}"
 NS_ARGO="${NS_ARGO:-argo-workflows}"
 NS_SHARED="${NS_SHARED:-shared-services}"
@@ -43,7 +43,7 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Runs the NineVigil booth demo gate.
+Runs the Clawdlinux booth demo gate.
 
 Options:
   --cluster NAME    kind cluster name. Default: ${CLUSTER_NAME}
@@ -374,7 +374,7 @@ check_cost_metrics() {
   metric_output="$(kubectl -n "${NS_OPERATOR}" exec "${pod_name}" -- sh -c \
     'if command -v curl >/dev/null 2>&1; then curl -fsS --max-time 3 http://127.0.0.1:8080/metrics; elif command -v wget >/dev/null 2>&1; then wget -qO- --timeout=3 http://127.0.0.1:8080/metrics; else exit 127; fi' \
     2>/dev/null || true)"
-  metric_line="$(printf '%s\n' "${metric_output}" | grep 'ninevigil_agent_cost_dollars' | grep -v '^#' | head -1 || true)"
+  metric_line="$(printf '%s\n' "${metric_output}" | grep 'clawdlinux_agent_cost_dollars' | grep -v '^#' | head -1 || true)"
   if [[ -n "${metric_line}" ]]; then
     printf '%bCost tracking:%b %s\n' "${GREEN}" "${RESET}" "${metric_line}"
     COST_OK=yes
@@ -389,7 +389,7 @@ check_cost_metrics() {
     return
   fi
 
-  warn "Cost tracking: ninevigil_agent_cost_dollars not available"
+  warn "Cost tracking: clawdlinux_agent_cost_dollars not available"
 }
 
 verify_gvisor() {

--- a/tests/smoke/test_grafana_dashboard.sh
+++ b/tests/smoke/test_grafana_dashboard.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 cd "${REPO_ROOT}"
 
 DASHBOARD="config/grafana/dashboards/cost-by-workload.json"
-METRIC="ninevigil_agent_cost_dollars"
+METRIC="clawdlinux_agent_cost_dollars"
 PASS=0
 FAIL=0
 
@@ -51,7 +51,7 @@ for panel in dashboard.get("panels", []):
         errors.append(f"panel {panel.get('title')!r} uses datasource {datasource!r}")
     for target in targets:
         expr = target.get("expr", "")
-        if "ninevigil_agent_cost_dollars" not in expr:
+        if "clawdlinux_agent_cost_dollars" not in expr:
             continue
         match = re.search(r"by\s*\(([^)]*)\)", expr)
         if not match:
@@ -66,11 +66,11 @@ for panel in dashboard.get("panels", []):
             if f"{{{{{label}}}}}" not in legend:
                 errors.append(f"panel {panel.get('title')!r} missing {label} in legend {legend!r}")
 if not any(
-    "ninevigil_agent_cost_dollars" in target.get("expr", "")
+    "clawdlinux_agent_cost_dollars" in target.get("expr", "")
     for panel in dashboard.get("panels", [])
     for target in panel.get("targets", [])
 ):
-    errors.append("no Prometheus target references ninevigil_agent_cost_dollars")
+    errors.append("no Prometheus target references clawdlinux_agent_cost_dollars")
 if not grouped_cost_query_found:
   errors.append("no cost target groups by workload, namespace, and model")
 if errors:


### PR DESCRIPTION
## What does this PR do?

Completes the single-brand migration by removing every remaining `ninevigil` token from code, scripts, charts, config, examples, landing, and docs. After this, the repo has one brand: Clawdlinux.

40 files, case-aware rename (`NINEVIGIL`/`NineVigil`/`ninevigil` to the Clawdlinux equivalents). `git grep -Ii ninevigil` returns nothing.

## Breaking changes

- Metric `ninevigil_agent_cost_dollars` → `clawdlinux_agent_cost_dollars`
- Env var `NINEVIGIL_AGENT_IMAGE` → `CLAWDLINUX_AGENT_IMAGE`
- Env var `NINEVIGIL_MCP_TOKEN` → `CLAWDLINUX_MCP_TOKEN`
- kind cluster default `ninevigil-demo` → `clawdlinux-demo`

All readers updated in lockstep: Grafana dashboard, smoke test, Go tests, demo scripts, and docs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] CI/infrastructure

## Verification

- `go build ./...` passes.
- `go test ./pkg/finops/... ./cmd/... ./pkg/mcp/... ./pkg/runtime/...` passes.
- Grafana dashboard JSON validates.
- `bash -n` on demo, clean-cluster, and grafana smoke scripts passes.
- The controller envtest suite needs `kubebuilder/bin/etcd` (not present locally); it is unrelated to this rename and runs in CI.

## Related issues

Follow-up to the prose sweep in #174.