### PR TITLE
docs: align sibling-repo references with Agent Native Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The wedge: Clawdlinux emits a signed, tamper-evident attestation artifact for ea
 | Runtime isolation | gVisor `RuntimeClass` injection for labeled pods |
 | Audit | Tamper-evident audit chain |
 | Cost | Per-workload budget and chargeback hooks |
-| Context | ACP: governed execution contracts on top of MCP tool calls |
+| Context | Agent Native Format (ANF): token-minimal context for agents, plus a governed execution runtime over MCP |
 | Delivery | Air-gapped install path and offline licensing |
 | Orchestration | Argo Workflows DAG orchestration |
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -47,9 +47,9 @@ What they get out of it, in their words: "we can finally say yes to the agent pr
 
 What we deliberately do not do: build another agent framework, host their data (there is no SaaS in the loop), or ask them to rewrite agents. Governance wraps what they have.
 
-## ACP in one paragraph
+## Agent Native Format in one paragraph
 
-Agent Contract Protocol is the same philosophy applied to tool calls. MCP answers what tools exist; ACP answers what execution is allowed for this agent right now. The server consumes MCP `tools/list` and returns a signed execution contract: scoped capabilities, identity binding, credential injection at the proxy (secrets never enter model context), declared ordering, egress and approval policy. Measured side effect: 64.7% to 97.4% fewer setup tokens and one round trip instead of up to 21, across five benchmark scenarios (see agent-contract-protocol/results). Separate repo, separate spec (v0.2 draft), feeds the same audit chain.
+Agent Native Format (ANF) is the sibling repo. Its headline is a token-minimal view format. It translates system state into far fewer tokens for agents (see FORMAT.md). It also ships an execution runtime that applies the same governance philosophy to tool calls. MCP answers what tools exist. The runtime answers what execution is allowed for this agent right now. The server consumes MCP `tools/list` and returns a signed execution contract: scoped capabilities, identity binding, credential injection at the proxy (secrets never enter model context), declared ordering, egress and approval policy. Measured side effect: 64.7% to 97.4% fewer setup tokens and one round trip instead of up to 21, across five benchmark scenarios (see agent-native-format/results). Separate repo, separate spec, feeds the same audit chain.
 
 ## Repo map
 
@@ -57,13 +57,13 @@ Two product repos plus a website, all under github.com/Clawdlinux.
 
 `agentic-operator-core` is the platform. `api/` and `internal/controller/` hold the CRD and reconcilers. `internal/admission/` is the gVisor RuntimeClass injector. `pkg/` has the subsystems: `audit` (hash chain), `runtime` (adapters), `finops`, `opa`, `llm`, `argo`, `multitenancy`, `mcp`. `cmd/` builds the operator, `agentctl`, `audit-verify`, and the license generator. `charts/` is the Helm umbrella with subcharts for Argo, LiteLLM, MinIO, Postgres, Browserless, and observability. `agents/` is the Python LangGraph runtime with A2A. `examples/` has the multi-agent swarm and SRE scenarios. `scripts/demo-booth.sh` is the reproducible demo. `docs/` is numbered 01 through 12 plus RFCs.
 
-`agent-contract-protocol` is the ACP spec (SPEC.md), Go reference server, Python client, adapters, and the benchmark harness with checked-in results.
+`agent-native-format` is the ANF format spec (FORMAT.md) plus an execution runtime: protocol spec (SPEC.md), Go reference server, Python client, adapters, and the benchmark harness with checked-in results.
 
 `clawdlinux-website` is the public site (clawdlinux.org).
 
 ## Honest state of the build
 
-Working today: CRD and reconciliation lifecycle, Argo DAG orchestration, Cilium egress policy generation, audit chain and offline verifier, gVisor injector, runtime adapters (AgentWorkload, BYO pods, Argo), LiteLLM routing, per-workload cost tracking, multi-tenancy with quotas, offline JWT licensing, Helm umbrella chart, agentctl with an MCP server mode, Grafana dashboards, the kind-based demo gate, ACP reference server with measured benchmarks.
+Working today: CRD and reconciliation lifecycle, Argo DAG orchestration, Cilium egress policy generation, audit chain and offline verifier, gVisor injector, runtime adapters (AgentWorkload, BYO pods, Argo), LiteLLM routing, per-workload cost tracking, multi-tenancy with quotas, offline JWT licensing, Helm umbrella chart, agentctl with an MCP server mode, Grafana dashboards, the kind-based demo gate, ANF execution runtime reference server with measured benchmarks.
 
 Not done, do not claim it: webhook admission validation for the CRD, Homebrew tap, air-gapped install smoke test as CI, per-runtime sandbox label guide, multi-cluster identity federation (SPIFFE/SPIRE, RFC-0001, gated on 6 external use cases or 1 paying customer), SOC 2, managed SaaS. Enterprise billing and licensing internals live in a private repo; the OSS tree has boundary READMEs only.
 

--- a/docs/MARKET-EVIDENCE.md
+++ b/docs/MARKET-EVIDENCE.md
@@ -17,7 +17,7 @@ Third-party sources behind the problem statement. Use these in decks and posts i
 ## Community signal
 
 - X: @JacobSobolev (May 19, 2026) on cross-cluster agent identity pain; triggered RFC-0001. https://x.com/JacobSobolev/status/2056631848009085244
-- MCP cost and friction evidence (Perplexity moving off MCP, Apideck 143K-token benchmark, Scalekit 4-32x CLI comparison): tracked with caveats in agent-contract-protocol/docs/references.md. Verify canonical links before quoting publicly.
+- MCP cost and friction evidence (Perplexity moving off MCP, Apideck 143K-token benchmark, Scalekit 4-32x CLI comparison): tracked with caveats in agent-native-format/docs/references.md. Verify canonical links before quoting publicly.
 
 ## Usage rules
 

--- a/docs/PITCH-SCRIPT.md
+++ b/docs/PITCH-SCRIPT.md
@@ -25,7 +25,7 @@ Walk the six target steps quickly. Say: "This slide describes the target product
 "Target customer: a fund's platform team wants agents analyzing filings and market data. Infosec banned agent SaaS, so the project is stuck. In the target deployment, they install one bundle inside their perimeter. They point LiteLLM at an approved model and label existing agent pods. Platform ships the workload. Security reviews the controls. Compliance receives the product attestation package."
 
 **Slide 7, What exists (60s).**
-"Everything on this slide is in a public repo you can read tonight. 180 commits since February. The ACP numbers are measured, checked-in benchmarks, not projections: 64 to 97 percent context reduction against raw MCP, one round trip instead of up to 21."
+"Everything on this slide is in a public repo you can read tonight. 180 commits since February. The execution runtime numbers are measured, checked-in benchmarks, not projections: 64 to 97 percent context reduction against raw MCP, one round trip instead of up to 21."
 
 **Slide 8, Where we are (60s). Do not rush this one.**
 "Honest state: built but not validated. Pre-revenue, zero customers, and I have a kill criterion: ten real conversations with named platform and security engineers by July 15, or I stop building features until I have them. I am telling you this because if you join, your first job is making sure we never ship into a vacuum again."


### PR DESCRIPTION
The sibling repo agent-contract-protocol is renamed to agent-native-format and reframed to lead with ANF, the token-minimal view format. See Clawdlinux/agent-native-format#22.

## Changed (docs only, no code)
- docs/DESIGN.md: 'ACP in one paragraph' section, repo-map line, and the 'working today' list now describe the sibling repo as ANF with the execution runtime as a component.
- docs/MARKET-EVIDENCE.md: agent-contract-protocol -> agent-native-format path.
- README.md: capability table Context row reframed to ANF.
- docs/PITCH-SCRIPT.md: 'ACP numbers' -> 'execution runtime numbers'.

## Deliberately left as-is
- ROADMAP.md May 2026 entry: dated history, kept accurate to what happened.
- clawd.acp.* OTel span attributes + acp-cache Grafana dashboard: stable telemetry contract for the execution-contract manifest, which still exists as the runtime. Renaming breaks dashboards and downstream span consumers. The observability chart docs that name 'ACP manifest IDs' are kept for consistency with the attribute name.

## Flagged for a separate decision (not touched)
- landing/ sub-app has stale content (dead clawdlinux-acp slug, old PRODUCT 01/02 framing). It has its own vercel.json and a CI quality gate, so it is live. Needs its own update pass.
- naming-decision.md + RALPH_BACKLOG.md carry a stale, never-ratified 'Concord' recommendation that now conflicts with the ANF decision.

No code changed. Telemetry and CRDs untouched.