### PR TITLE
fix(demo): harden provider-backed booth flow

### DIFF
--- a/charts/templates/rbac.yaml
+++ b/charts/templates/rbac.yaml
@@ -59,9 +59,18 @@ rules:
   - apiGroups: ["agentic.clawdlinux.org"]
     resources:
       - agentworkloads
-      - agentworkloads/status
-      - agentworkloads/finalizers
+      - agentcards
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["agentic.clawdlinux.org"]
+    resources:
+      - agentworkloads/status
+      - agentcards/status
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["agentic.clawdlinux.org"]
+    resources:
+      - agentworkloads/finalizers
+      - agentcards/finalizers
+    verbs: ["update"]
   # RBAC (for sub-agent service accounts — namespace-scoped only)
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources:

--- a/charts/templates/webhook.yaml
+++ b/charts/templates/webhook.yaml
@@ -7,6 +7,7 @@
 {{- $webhookServiceName := printf "%s-webhook-service" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- $selfSignedIssuerName := printf "%s-selfsigned-issuer" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- $runtimeSandbox := .Values.global.runtimeSandbox }}
+{{- $agentWorkloadWebhookEnabled := .Values.agenticOperator.webhook.agentWorkloadEnabled | default false }}
 ---
 apiVersion: v1
 kind: Service
@@ -25,6 +26,7 @@ spec:
       port: 443
       targetPort: webhook
       protocol: TCP
+{{- if $agentWorkloadWebhookEnabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -50,6 +52,8 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 10
+  {{- end }}
+  {{- if or $agentWorkloadWebhookEnabled $runtimeSandbox.enabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -60,6 +64,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ include "agentic-operator.namespace" . }}/{{ include "agentic-operator.fullname" . }}-webhook-cert
 webhooks:
+  {{- if $agentWorkloadWebhookEnabled }}
   - name: magentworkload.agentic.clawdlinux.org
     clientConfig:
       service:
@@ -75,6 +80,7 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1"]
     timeoutSeconds: 10
+  {{- end }}
   {{- if $runtimeSandbox.enabled }}
   - name: runtimeclass-pods.agentic.clawdlinux.org
     clientConfig:
@@ -95,6 +101,7 @@ webhooks:
       matchLabels:
         {{ $runtimeSandbox.selectorLabelKey }}: {{ $runtimeSandbox.selectorLabelValue | quote }}
   {{- end }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/tests/operator_rbac_test.yaml
+++ b/charts/tests/operator_rbac_test.yaml
@@ -1,0 +1,49 @@
+suite: operator controller RBAC
+templates:
+  - templates/rbac.yaml
+tests:
+  - it: grants the running controllers access to AgentWorkload and AgentCard resources
+    set:
+      license.key: dev-license
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - agentic.clawdlinux.org
+            resources:
+              - agentworkloads
+              - agentcards
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+        documentIndex: 1
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - agentic.clawdlinux.org
+            resources:
+              - agentworkloads/status
+              - agentcards/status
+            verbs:
+              - get
+              - update
+              - patch
+        documentIndex: 1
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - agentic.clawdlinux.org
+            resources:
+              - agentworkloads/finalizers
+              - agentcards/finalizers
+            verbs:
+              - update
+        documentIndex: 1

--- a/charts/tests/runtime_sandbox_test.yaml
+++ b/charts/tests/runtime_sandbox_test.yaml
@@ -49,29 +49,29 @@ tests:
           selectorLabelKey: agentic.clawdlinux.org/runtime-sandbox
           selectorLabelValue: gvisor
     asserts:
-      - documentIndex: 2
+      - documentIndex: 1
         equal:
           path: kind
           value: MutatingWebhookConfiguration
         template: webhook.yaml
-      - documentIndex: 2
+      - documentIndex: 1
         equal:
           path: apiVersion
           value: admissionregistration.k8s.io/v1
         template: webhook.yaml
-      - documentIndex: 2
+      - documentIndex: 1
         equal:
-          path: webhooks[1].name
+          path: webhooks[0].name
           value: runtimeclass-pods.agentic.clawdlinux.org
         template: webhook.yaml
-      - documentIndex: 2
+      - documentIndex: 1
         equal:
-          path: webhooks[1].clientConfig.service.path
+          path: webhooks[0].clientConfig.service.path
           value: /mutate-v1-pod-runtimeclass
         template: webhook.yaml
-      - documentIndex: 2
+      - documentIndex: 1
         equal:
-          path: webhooks[1].objectSelector.matchLabels["agentic.clawdlinux.org/runtime-sandbox"]
+          path: webhooks[0].objectSelector.matchLabels["agentic.clawdlinux.org/runtime-sandbox"]
           value: gvisor
         template: webhook.yaml
 
@@ -121,9 +121,9 @@ tests:
           selectorLabelKey: regulated.agentic.dev/sandbox
           selectorLabelValue: strict
     asserts:
-      - documentIndex: 2
+      - documentIndex: 1
         equal:
-          path: webhooks[1].objectSelector.matchLabels["regulated.agentic.dev/sandbox"]
+          path: webhooks[0].objectSelector.matchLabels["regulated.agentic.dev/sandbox"]
           value: strict
         template: webhook.yaml
       - contains:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -88,6 +88,9 @@ agenticOperator:
   # Webhook admission control (requires cert-manager)
   webhook:
     enabled: true
+    # The current controller binary serves only the runtime-sandbox pod webhook.
+    # Enable this only after AgentWorkload defaulting/validation routes are registered.
+    agentWorkloadEnabled: false
     createSelfSignedIssuer: true
     issuerRef:
       name: ""   # defaults to <release>-selfsigned-issuer

--- a/scripts/demo-booth.sh
+++ b/scripts/demo-booth.sh
@@ -275,6 +275,21 @@ reject_credential_newlines() {
   fi
 }
 
+valid_litellm_master_key() {
+  local value="$1"
+  [[ "${value}" == sk-* && ${#value} -ge 19 && "${value}" != *$'\n'* && "${value}" != *$'\r'* ]]
+}
+
+decode_base64() {
+  if printf '' | base64 --decode >/dev/null 2>&1; then
+    base64 --decode
+  elif printf '' | base64 -D >/dev/null 2>&1; then
+    base64 -D
+  else
+    return 1
+  fi
+}
+
 load_demo_credentials() {
   local openai_from_environment=false
   local anthropic_from_environment=false
@@ -402,13 +417,27 @@ install_cert_manager() {
 
 create_runtime_provider_secret() {
   step "Creating runtime provider Secret"
+  local existing_master_key=""
+  local existing_master_key_with_sentinel=""
   local master_key
   if [[ -n "${LITELLM_MASTER_KEY:-}" ]]; then
     reject_credential_newlines "LITELLM_MASTER_KEY" "${LITELLM_MASTER_KEY}" "environment"
+    valid_litellm_master_key "${LITELLM_MASTER_KEY}" ||
+      die "LITELLM_MASTER_KEY must start with sk- and contain at least 16 key characters"
     master_key="${LITELLM_MASTER_KEY}"
   else
-    require_command openssl
-    master_key="$(openssl rand -hex 24)"
+    existing_master_key_with_sentinel="$({
+      kubectl -n "${NS_OPERATOR}" get secret "${DEMO_SECRET}" \
+        -o jsonpath='{.data.LITELLM_MASTER_KEY}' 2>/dev/null | decode_base64 2>/dev/null || true
+      printf '.'
+    })"
+    existing_master_key="${existing_master_key_with_sentinel%.}"
+    if valid_litellm_master_key "${existing_master_key}"; then
+      master_key="${existing_master_key}"
+    else
+      require_command openssl
+      master_key="sk-$(openssl rand -hex 24)"
+    fi
   fi
 
   {
@@ -420,7 +449,7 @@ create_runtime_provider_secret() {
     --from-env-file=/dev/stdin \
     --dry-run=client \
     -o yaml | kubectl apply -f - >/dev/null
-  unset master_key
+  unset existing_master_key existing_master_key_with_sentinel master_key
   ok "Runtime Secret ${DEMO_SECRET} created without printing key values"
 }
 
@@ -500,9 +529,37 @@ prepare_real_demo() {
     --set agentic-operator.image.pullPolicy=IfNotPresent \
     --set litellm.enabled=true \
     --set litellm.replicaCount=1 \
+    --set-string litellm.resources.requests.memory=1Gi \
+    --set-string litellm.resources.limits.memory=2Gi \
     --set-string litellm.existingSecret="${DEMO_SECRET}" \
     --timeout "${HELM_TIMEOUT}" \
     --wait >/dev/null
+
+  kubectl apply -f - >/dev/null <<YAML
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${DEMO_RELEASE}-litellm-provider-egress
+  namespace: ${NS_OPERATOR}
+  labels:
+    app.kubernetes.io/component: networkpolicy
+    app.kubernetes.io/part-of: clawdlinux-booth-demo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: litellm
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 443
+          protocol: TCP
+YAML
+
+  kubectl -n "${NS_OPERATOR}" rollout restart deployment/"${DEMO_RELEASE}"-litellm >/dev/null
 
   wait_for_demo_components
   ok "Preparation complete. Run: $(basename "$0") --present"

--- a/tests/smoke/test_demo_booth_cli.sh
+++ b/tests/smoke/test_demo_booth_cli.sh
@@ -91,6 +91,8 @@ fi
 env_file="${TEST_TMP_DIR}/credentials.env"
 fake_bin="${TEST_TMP_DIR}/fake-bin"
 command_log="${TEST_TMP_DIR}/commands.log"
+captured_master_key_file="${TEST_TMP_DIR}/master-key.txt"
+network_policy_file="${TEST_TMP_DIR}/provider-egress.yaml"
 mkdir -p "${fake_bin}"
 file_openai='demo-file-openai-not-secret'
 environment_openai='demo-environment-openai-not-secret'
@@ -126,6 +128,17 @@ printf '\n' >>"${FAKE_COMMAND_LOG}"
 printf 'generated-test-master-key\n'
 EOF
 
+cat >"${fake_bin}/base64" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--decode" ]]; then
+  exit 64
+fi
+if [[ "${1:-}" == "-D" ]]; then
+  exec /usr/bin/base64 --decode
+fi
+exec /usr/bin/base64 "$@"
+EOF
+
 cat >"${fake_bin}/kubectl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -143,6 +156,11 @@ case "${args}" in
   *" get endpoints "*)
     printf '127.0.0.1\n'
     ;;
+  *" get secret "*"LITELLM_MASTER_KEY"*)
+    if [[ -n "${MOCK_EXISTING_MASTER_KEY:-}" ]]; then
+      printf '%s' "${MOCK_EXISTING_MASTER_KEY}" | base64
+    fi
+    ;;
   *" create namespace "*)
     printf 'apiVersion: v1\nkind: Namespace\nmetadata:\n  name: test\n'
     ;;
@@ -150,14 +168,23 @@ case "${args}" in
     secret_input="$(cat)"
     grep -Fqx "OPENAI_API_KEY=${EXPECTED_OPENAI_API_KEY}" <<<"${secret_input}"
     grep -Fqx "ANTHROPIC_API_KEY=${EXPECTED_ANTHROPIC_API_KEY}" <<<"${secret_input}"
+    master_key="$(sed -n 's/^LITELLM_MASTER_KEY=//p' <<<"${secret_input}")"
+    api_key="$(sed -n 's/^api-key=//p' <<<"${secret_input}")"
+    [[ "${master_key}" == sk-* && ${#master_key} -ge 19 && "${master_key}" == "${api_key}" ]]
+    if [[ -n "${CAPTURED_MASTER_KEY_FILE:-}" ]]; then
+      printf '%s' "${master_key}" >"${CAPTURED_MASTER_KEY_FILE}"
+    fi
     printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: test\n'
     ;;
   *" apply -f - "*)
-    cat >/dev/null
+    apply_input="$(cat)"
+    if grep -Fqx 'kind: NetworkPolicy' <<<"${apply_input}" && [[ -n "${NETWORK_POLICY_FILE:-}" ]]; then
+      printf '%s\n' "${apply_input}" >"${NETWORK_POLICY_FILE}"
+    fi
     ;;
 esac
 EOF
-chmod +x "${fake_bin}/kind" "${fake_bin}/helm" "${fake_bin}/openssl" "${fake_bin}/kubectl"
+chmod +x "${fake_bin}/kind" "${fake_bin}/helm" "${fake_bin}/openssl" "${fake_bin}/base64" "${fake_bin}/kubectl"
 
 set +e
 loaded_prepare_output="$(env \
@@ -166,6 +193,8 @@ loaded_prepare_output="$(env \
   OPENAI_API_KEY="${environment_openai}" \
   DEMO_ENV_FILE="${env_file}" \
   FAKE_COMMAND_LOG="${command_log}" \
+  CAPTURED_MASTER_KEY_FILE="${captured_master_key_file}" \
+  NETWORK_POLICY_FILE="${network_policy_file}" \
   EXPECTED_OPENAI_API_KEY="${environment_openai}" \
   EXPECTED_ANTHROPIC_API_KEY="${file_anthropic}" \
   PATH="${fake_bin}:/usr/bin:/bin" \
@@ -179,6 +208,83 @@ fi
 for status_line in 'OPENAI_API_KEY=available' 'ANTHROPIC_API_KEY=available'; do
   if ! grep -Fxq "${status_line}" <<<"${loaded_prepare_output}"; then
     printf 'prepare did not report credential availability: %s\n' "${status_line}" >&2
+    exit 1
+  fi
+done
+generated_master_key="$(<"${captured_master_key_file}")"
+if [[ "${generated_master_key}" != 'sk-generated-test-master-key' ]]; then
+  printf 'prepare did not generate the expected sk-prefixed master key\n' >&2
+  exit 1
+fi
+if grep -Fq "${generated_master_key}" <<<"${loaded_prepare_output}" || grep -Fq "${generated_master_key}" "${command_log}"; then
+  printf 'generated master key leaked into prepare output or command log\n' >&2
+  exit 1
+fi
+for helm_arg in \
+  '--set-string litellm.resources.requests.memory=1Gi' \
+  '--set-string litellm.resources.limits.memory=2Gi'; do
+  if ! grep -Fq -- "${helm_arg}" "${command_log}"; then
+    printf 'prepare did not pass LiteLLM memory argument: %s\n' "${helm_arg}" >&2
+    exit 1
+  fi
+done
+network_policy_contracts=(
+  'kind: NetworkPolicy'
+  '  name: clawdlinux-demo-litellm-provider-egress'
+  '      app.kubernetes.io/name: litellm'
+  '            cidr: 0.0.0.0/0'
+  '        - port: 443'
+  '          protocol: TCP'
+)
+for contract in "${network_policy_contracts[@]}"; do
+  if ! grep -Fxq -- "${contract}" "${network_policy_file}"; then
+    printf 'provider egress policy is missing contract: %s\n' "${contract}" >&2
+    exit 1
+  fi
+done
+
+reused_master_key='sk-existing-master-key-123456'
+: >"${command_log}"
+reuse_output="$(env \
+  -u LITELLM_MASTER_KEY \
+  OPENAI_API_KEY="${environment_openai}" \
+  ANTHROPIC_API_KEY="${file_anthropic}" \
+  DEMO_ENV_FILE="${TEST_TMP_DIR}/missing.env" \
+  MOCK_EXISTING_MASTER_KEY="${reused_master_key}" \
+  CAPTURED_MASTER_KEY_FILE="${captured_master_key_file}" \
+  NETWORK_POLICY_FILE="${network_policy_file}" \
+  FAKE_COMMAND_LOG="${command_log}" \
+  EXPECTED_OPENAI_API_KEY="${environment_openai}" \
+  EXPECTED_ANTHROPIC_API_KEY="${file_anthropic}" \
+  PATH="${fake_bin}:/usr/bin:/bin" \
+  "${DEMO_SCRIPT}" --prepare 2>&1)"
+if [[ "$(<"${captured_master_key_file}")" != "${reused_master_key}" ]]; then
+  printf 'prepare did not preserve a valid existing master key\n' >&2
+  exit 1
+fi
+if grep -Fq "${reused_master_key}" <<<"${reuse_output}" || grep -Fq "${reused_master_key}" "${command_log}"; then
+  printf 'reused master key leaked into prepare output or command log\n' >&2
+  exit 1
+fi
+
+malformed_master_keys=($'sk-existing-master-key\r' $'sk-existing-master-key\n')
+for malformed_master_key in "${malformed_master_keys[@]}"; do
+  : >"${command_log}"
+  env \
+    -u LITELLM_MASTER_KEY \
+    OPENAI_API_KEY="${environment_openai}" \
+    ANTHROPIC_API_KEY="${file_anthropic}" \
+    DEMO_ENV_FILE="${TEST_TMP_DIR}/missing.env" \
+    MOCK_EXISTING_MASTER_KEY="${malformed_master_key}" \
+    CAPTURED_MASTER_KEY_FILE="${captured_master_key_file}" \
+    NETWORK_POLICY_FILE="${network_policy_file}" \
+    FAKE_COMMAND_LOG="${command_log}" \
+    EXPECTED_OPENAI_API_KEY="${environment_openai}" \
+    EXPECTED_ANTHROPIC_API_KEY="${file_anthropic}" \
+    PATH="${fake_bin}:/usr/bin:/bin" \
+    "${DEMO_SCRIPT}" --prepare >/dev/null 2>&1
+  if [[ "$(<"${captured_master_key_file}")" != 'sk-generated-test-master-key' ]]; then
+    printf 'prepare must replace malformed existing master keys\n' >&2
     exit 1
   fi
 done
@@ -264,6 +370,28 @@ for unsafe_master_value in "${unsafe_master_values[@]}"; do
     exit 1
   fi
 done
+
+short_master_key='sk-too-short'
+: >"${command_log}"
+set +e
+short_master_output="$(env \
+  OPENAI_API_KEY=openai-placeholder \
+  ANTHROPIC_API_KEY=anthropic-placeholder \
+  LITELLM_MASTER_KEY="${short_master_key}" \
+  DEMO_ENV_FILE="${TEST_TMP_DIR}/missing.env" \
+  FAKE_COMMAND_LOG="${command_log}" \
+  PATH="${fake_bin}:/usr/bin:/bin" \
+  "${DEMO_SCRIPT}" --prepare 2>&1)"
+short_master_status=$?
+set -e
+if [[ ${short_master_status} -eq 0 ]] || ! grep -Fq 'contain at least 16 key characters' <<<"${short_master_output}"; then
+  printf 'prepare must reject short LITELLM master keys\n' >&2
+  exit 1
+fi
+if grep -Fq 'create secret generic' "${command_log}"; then
+  printf 'prepare must reject short master keys before Secret creation\n' >&2
+  exit 1
+fi
 
 fallback_root="${TEST_TMP_DIR}/fallback-root"
 fallback_bin="${TEST_TMP_DIR}/fallback-bin"


### PR DESCRIPTION
## What does this PR do?

Fixes fresh kind preparation and provider-backed booth runs.

- grants AgentCard controller RBAC with scoped subresource verbs
- disables unserved AgentWorkload admission routes by default
- keeps the runtime-sandbox pod webhook active
- gives LiteLLM 1Gi requested and 2Gi maximum memory
- preserves valid LiteLLM master keys across preparation runs
- reloads LiteLLM after Secret updates
- permits booth-only provider HTTPS from LiteLLM pods
- adds Helm and smoke regression checks

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/infrastructure

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (or relevant subset)
- [x] No private-repo content leaked into OSS core
- [x] Commit is signed off (`git commit -s`)
- [x] Documentation updated (not applicable)

## How to test

```bash
helm unittest charts
helm lint charts --set-string license.key=dev-license --set-string litellm.existingSecret=clawdlinux-demo-litellm
bash -n scripts/demo-booth.sh
bash tests/smoke/test_demo_booth_cli.sh
make test-controller
./scripts/demo-booth.sh --prepare
./scripts/demo-booth.sh --present --tamper-audit
```

Fresh kind rehearsal passed with live OpenAI and Anthropic calls. The backup recording also passed.

## Related issues

None.