### PR TITLE
chore: fix landing ANF link and supersede Concord naming doc

### DIFF
--- a/landing/src/components/ProductsAcl.jsx
+++ b/landing/src/components/ProductsAcl.jsx
@@ -9,7 +9,7 @@ import {
 } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 
-const ACL_GITHUB = 'https://github.com/Clawdlinux/clawdlinux-acp';
+const ACL_GITHUB = 'https://github.com/Clawdlinux/agent-native-format';
 const OPERATOR_GITHUB = 'https://github.com/Clawdlinux/agentic-operator-core';
 
 const PRODUCTS = [

--- a/naming-decision.md
+++ b/naming-decision.md
@@ -1,5 +1,12 @@
 # Naming Decision — ACP protocol + Agentic Operator
 
+> **SUPERSEDED (2026-07-16).** The protocol recommendation below (`Concord`) was
+> never adopted. The protocol repo was repositioned to **Agent Native Format
+> (ANF)** in Clawdlinux/agent-native-format#22; see that repo's
+> `naming-decision.md` for the ratified decision. The operator advice below
+> still holds: keep the `agentic-operator-core` repo name. Text kept as
+> historical research.
+
 Date: 2026-06-16. Status: RESEARCH COMPLETE. Needs human approval (gate A2).
 Author: ralph loop, Lane A1.
 


### PR DESCRIPTION
Follow-up cleanup after the ANF reposition (Clawdlinux/agent-native-format#22, merged) and the doc reframe (#177, merged).

## Changed
- landing/src/components/ProductsAcl.jsx: ACL_GITHUB pointed at the dead clawdlinux-acp slug. Now agent-native-format.
- naming-decision.md: SUPERSEDED banner. The Concord protocol mark was never adopted; the protocol repo is now Agent Native Format. Operator naming advice (keep agentic-operator-core) kept as historical.

## Flagged, not changed
- The landing/ sub-app is still an older mirror of the main site (clawdlinux-website) with the pre-capabilities PRODUCT 01/02 framing. Whether operator-core should keep a separate landing deploy at all is an open question for a separate pass. This PR only fixes the broken link.

Docs + one string change. No Go code, telemetry, or CRDs touched.