### PR TITLE
docs: frame ANF as internal tooling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The wedge: Clawdlinux emits a signed, tamper-evident attestation artifact for ea
 | Runtime isolation | gVisor `RuntimeClass` injection for labeled pods |
 | Audit | Tamper-evident audit chain |
 | Cost | Per-workload budget and chargeback hooks |
-| Context | Agent Native Format (ANF): token-minimal context for agents, plus a governed execution runtime over MCP |
+| Context | ANF view snapshots (internal tooling): `agentctl` renders token-minimal Kubernetes and agent state for the model |
 | Delivery | Air-gapped install path and offline licensing |
 | Orchestration | Argo Workflows DAG orchestration |
 


### PR DESCRIPTION
Softens the README capability-table Context row so ANF reads as internal tooling (agentctl view snapshots), not a marketed product/format. One line, docs only.