### PR TITLE
fix(demo): address late booth review

### DIFF
--- a/charts/charts/litellm/templates/configmap.yaml
+++ b/charts/charts/litellm/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
         litellm_params:
           model: openai/gpt-4o-mini
           api_key: "os.environ/OPENAI_API_KEY"
-          {{- end }}
+      {{- end }}
       {{- range .Values.models }}
       - {{ toYaml . | nindent 8 | trim }}
       {{- end }}

--- a/tools/anf-snapshot/snapshot/snapshot.go
+++ b/tools/anf-snapshot/snapshot/snapshot.go
@@ -371,7 +371,7 @@ func estimateTokens(characters int) int {
 
 func validateLabel(name, value string, pattern *regexp.Regexp) error {
 	if !pattern.MatchString(value) {
-		return fmt.Errorf("%s is not compatible with the ANF summary contract", name)
+		return fmt.Errorf("%s %q is not compatible with the ANF summary contract", name, value)
 	}
 	return nil
 }

--- a/tools/anf-snapshot/snapshot/snapshot.go
+++ b/tools/anf-snapshot/snapshot/snapshot.go
@@ -27,6 +27,8 @@ var (
 	summaryNamespacePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 )
 
+const rejectedLabelPreviewRunes = 80
+
 // Lister provides the five sequential Kubernetes reads used by a snapshot.
 // The result is best-effort across calls rather than a transactional cluster view.
 type Lister interface {
@@ -371,7 +373,17 @@ func estimateTokens(characters int) int {
 
 func validateLabel(name, value string, pattern *regexp.Regexp) error {
 	if !pattern.MatchString(value) {
-		return fmt.Errorf("%s %q is not compatible with the ANF summary contract", name, value)
+		characters := []rune(value)
+		preview := value
+		if len(characters) > rejectedLabelPreviewRunes {
+			preview = string(characters[:rejectedLabelPreviewRunes]) + "..."
+		}
+		return fmt.Errorf(
+			"%s %q (characters=%d) is not compatible with the ANF summary contract",
+			name,
+			preview,
+			len(characters),
+		)
 	}
 	return nil
 }

--- a/tools/anf-snapshot/snapshot/snapshot_test.go
+++ b/tools/anf-snapshot/snapshot/snapshot_test.go
@@ -256,9 +256,26 @@ func TestCaptureRejectsUnsafeSummaryLabels(t *testing.T) {
 		if options.Cluster == "showcase-cluster" {
 			rejectedValue = options.Namespace
 		}
-		if !strings.Contains(err.Error(), strconv.Quote(rejectedValue)) {
+		if len([]rune(rejectedValue)) <= rejectedLabelPreviewRunes && !strings.Contains(err.Error(), strconv.Quote(rejectedValue)) {
 			t.Fatalf("Capture error %q does not include rejected value %q", err, rejectedValue)
 		}
+	}
+}
+
+func TestValidateLabelBoundsRejectedValue(t *testing.T) {
+	value := strings.Repeat("a", 10_000)
+	err := validateLabel("cluster", value, summaryClusterPattern)
+	if err == nil {
+		t.Fatal("validateLabel accepted oversized cluster")
+	}
+	if len(err.Error()) > 256 {
+		t.Fatalf("error length = %d, want at most 256: %q", len(err.Error()), err)
+	}
+	if !strings.Contains(err.Error(), "characters=10000") {
+		t.Fatalf("error does not include original character count: %q", err)
+	}
+	if strings.Contains(err.Error(), value) {
+		t.Fatal("error includes the full rejected value")
 	}
 }
 

--- a/tools/anf-snapshot/snapshot/snapshot_test.go
+++ b/tools/anf-snapshot/snapshot/snapshot_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -247,8 +248,16 @@ func TestCaptureRejectsUnsafeSummaryLabels(t *testing.T) {
 		{Cluster: "showcase-cluster", Namespace: "bad-", Clock: func() time.Time { return fixtureNow }},
 		{Cluster: "showcase-cluster", Namespace: strings.Repeat("a", 64), Clock: func() time.Time { return fixtureNow }},
 	} {
-		if _, err := Capture(context.Background(), newStaticLister(fixtureSource()), options); err == nil {
+		_, err := Capture(context.Background(), newStaticLister(fixtureSource()), options)
+		if err == nil {
 			t.Fatalf("Capture accepted unsafe summary label in %#v", options)
+		}
+		rejectedValue := options.Cluster
+		if options.Cluster == "showcase-cluster" {
+			rejectedValue = options.Namespace
+		}
+		if !strings.Contains(err.Error(), strconv.Quote(rejectedValue)) {
+			t.Fatalf("Capture error %q does not include rejected value %q", err, rejectedValue)
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Addresses late Copilot comments posted after #181 merged.

The LiteLLM template now aligns the closing conditional with its opening directive. Rendered config remains byte-identical with built-in OpenAI models enabled and disabled.

ANF summary validation errors now include a safely quoted 80-rune preview and the original character count. Control characters remain escaped, the parser-compatible grammar is unchanged, and unbounded inputs cannot create unbounded error strings.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/infrastructure

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (or relevant subset)
- [x] No private-repo content leaked into OSS core
- [x] Commit is signed off (`git commit -s`)
- [ ] Documentation updated (if applicable)

## How to test

```bash
helm unittest charts
helm lint charts --set license.key=test

cd tools/anf-snapshot
go test -race ./... -count=1
go vet ./...
go mod verify
```

Clean-checkout and canonical validation passed through `05ef62b`. The 10,000-character regression keeps the full diagnostic below 256 bytes.

## Related issues

Follow-up to #181.