### PR TITLE
chore: ignore node_modules/dist/.vercel from landing app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,12 @@ profile.cov
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# Node / frontend build + deps (landing/ and agentctl-web have their own package.json)
+node_modules/
+landing/dist/
+landing/.vercel/
+*.tsbuildinfo
+
 # Go workspace file
 go.work
 go.work.sum


### PR DESCRIPTION
The landing/ frontend app has its own package.json. An npm install there created landing/node_modules (~14k files) which the stock Go .gitignore never covered, so the working tree showed 14,000+ untracked changes.

Adds node_modules/, landing/dist/, landing/.vercel/, and *.tsbuildinfo. Verified nothing under these paths was tracked, so no files are removed from git.