### PR TITLE
chore: ignore local agent tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ landing/dist/
 landing/.vercel/
 *.tsbuildinfo
 
+# Local agent tooling (installed caveman skills, not product code)
+.agents/
+skills-lock.json
+
 # Go workspace file
 go.work
 go.work.sum


### PR DESCRIPTION
Ignores .agents/ (installed caveman skills) and skills-lock.json. Local dev tooling, not product code.