### PR TITLE
docs: align public claims with implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-25
 
-Production-ready agent orchestration release with multi-agent demos, pluggable workflows, CLI onboarding, and landing page overhaul.
+Agent orchestration release with multi-agent examples, pluggable workflows, CLI onboarding, and landing page updates.
 
 ### Added
-- **Multi-Agent Swarm Example** — A2A agent discovery, OPA budget enforcement, autoApproveThreshold gating, Docker Compose with ollama local overlay (#60)
+- **Multi-Agent Swarm Example** — A2A agent discovery, persona tool checks, approval-threshold inputs, and Docker Compose with an Ollama overlay (#60)
 - **SRE Incident Response Example** — collaborationMode: delegation, 3-tier cost-aware model routing, adversarial tone remediator, hierarchical memory (#62)
 - **Pluggable Workflow Registry** — `@register_workflow` decorator, auto-discovery from built-in + custom dirs, `WORKFLOW_NAME` env var selection (#64)
 - **Code Review Workflow** — Fan-out security/performance/style analysis agents
@@ -47,7 +47,7 @@ Production-ready agent orchestration release with multi-agent demos, pluggable w
 - Merge conflicts in multi-agent-swarm files after squash merge
 ## [0.1.1] - 2026-03-31
 
-Customer-ready release of Agentic Operator — Kubernetes-native multi-agent orchestration framework.
+Initial Kubernetes-native multi-agent orchestration feature release.
 
 ### Added
 - **AgentPersona CRD** — First-class Kubernetes resource for agent identity (Role, Tone, MemoryScope, SystemPrompt, ToolProfile)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 <h1 align="center">Clawdlinux Operator</h1>
 
 <p align="center">
-  <strong>Air-gapped governance and attestation for AI agents on Kubernetes.</strong>
+  <strong>In-cluster governance for AI agents on Kubernetes.</strong>
 </p>
 
 <p align="center">
-  A tamper-evident attestation artifact and a zero-egress seal for every agent run. Air-gapped, verifiable offline, runtime-agnostic. Plus gVisor isolation, audit trails, and FinOps.
+  Runtime-agnostic workload contracts, isolation and egress configuration, model-cost evidence, and offline-verifiable audit primitives.
 </p>
 
 <p align="center">
@@ -47,37 +47,40 @@ Platform teams running AI agents on Kubernetes face the same regulated-ops quest
 
 Who can the agent call? Which runtime isolates it? What did it cost? What did it do? Can an auditor replay it later?
 
-Clawdlinux is a governance plane that answers those questions. It adds regulated controls around any agent workload.
+Clawdlinux is building the in-cluster governance boundary around those workloads. It does not replace the agent runtime.
 
-The wedge: Clawdlinux emits a signed, tamper-evident attestation artifact for each run and applies a zero-egress seal at the network boundary. The artifact is hash-chained and verifiable offline with `audit-verify`, so an auditor can replay what an agent did months later inside an air-gapped cluster. The same seal and attestation contract applies to a Clawdlinux AgentWorkload, a CNCF runtime, or your own labeled pods. This is the part most agent runtimes leave to you. Clawdlinux ships it in-cluster.
+The repository currently ships the `AgentWorkload` lifecycle, runtime adapters, admission mutation, generated network-policy objects, model routing and cost paths, and HMAC hash-chain verification primitives. These components have different integration depth. The current controller does not yet emit a complete signed artifact from each run.
 
-| Capability | What Clawdlinux provides |
+The target contract connects caller identity, declared access, action policy, approval, cost, outcome, and independently verifiable evidence in one transaction. That target is the product direction, not a claim about the current end-to-end path.
+
+| Capability | Current repository state |
 |---|---|
-| Runtime isolation | gVisor `RuntimeClass` injection for labeled pods |
-| Audit | Tamper-evident audit chain |
-| Cost | Per-workload budget and chargeback hooks |
+| Runtime isolation | gVisor `RuntimeClass` mutation for labeled pods; nodes must provide `runsc` |
+| Network controls | Default-deny and allow-list policy generation; enforcement depends on the cluster CNI |
+| Audit | HMAC hash-chain and JSONL verifier; automatic same-run capture is not connected |
+| Cost | Per-workload usage and estimated-cost paths plus chargeback hooks |
 | Context | ANF view snapshots (internal tooling): `agentctl` renders token-minimal Kubernetes and agent state for the model |
-| Delivery | Air-gapped install path and offline licensing |
+| Delivery | Helm packaging and offline JWT validation; full air-gapped install testing remains a release gate |
 | Orchestration | Argo Workflows DAG orchestration |
 
 ### Supported runtimes
 
-Clawdlinux works with any Kubernetes agent runtime:
+Clawdlinux currently registers 3 Kubernetes runtime adapters:
 
 - **Clawdlinux AgentWorkload** (built-in CRD)
 - **CNCF agent runtimes** like kagent
 - **Custom agent pods** with the right labels
 
-The runtime handles agent lifecycle, tools, and model dispatch. Clawdlinux handles isolation, audit, spend, and compliance. Use both.
+The runtime handles agent lifecycle, tools, and model dispatch. Clawdlinux supplies workload, policy, isolation, cost, and evidence primitives around it. A production integration must map those controls to the customer's identity, network, storage, and compliance program.
 
 | Problem | Clawdlinux |
 |---------|-----------------|
 | Agent sprawl across namespaces | Single `AgentWorkload` CRD per agent |
-| No network boundaries | Cilium FQDN egress policies auto-applied |
+| No network boundaries | Kubernetes and optional Cilium policy objects generated from reviewed configuration |
 | Invisible costs | Per-workload token metering + cost attribution |
 | Manual DAG wiring | Argo Workflows orchestrates agent steps |
 | Vendor lock-in | Any LLM via LiteLLM proxy routing |
-| Cloud-only runtimes | Full air-gapped, offline-first deployment |
+| Cloud-only control planes | Self-managed, in-cluster deployment with offline licensing support |
 
 ### Runtime sandbox for labeled pods
 
@@ -99,24 +102,14 @@ No fork required. No custom build required. Works with any pod that carries the 
 
 ## Demo
 
+```bash
+kubectl apply -f config/samples/agentworkload_demo.yaml
+kubectl -n agentic-system get agentworkloads -w
 ```
-$ kubectl apply -f agentworkload.yaml
-agentworkload.agentic.clawdlinux.org/research-run created
 
-$ kubectl get agentworkload research-run -w
-NAME           PHASE       AGE
-research-run   Pending     0s
-research-run   Isolating   2s    # namespace + cilium policy applied
-research-run   Running     5s    # argo workflow launched
-research-run   Completed   47s   # artifacts retained in minio
-
-$ kubectl logs -n aw-research-run agent-pod --tail=5
-[agent] analyzing Q1 2026 technology trends...
-[agent] sources: arxiv, github trending, HN front page
-[agent] cost: $0.0023 (gpt-4o-mini) | tokens: 1,847 in / 892 out
-[agent] output written to minio://research-run/report.md
-[agent] run complete — 42s wall time
-```
+For the reproducible evidence demo, use
+[`docs/SHOWCASE-DEMO-WALKTHROUGH.md`](docs/SHOWCASE-DEMO-WALKTHROUGH.md).
+It labels current-run, configuration-only, and prior-run evidence separately.
 
 ---
 
@@ -160,7 +153,11 @@ kind create cluster --name agentic-operator
 kubectl apply -f config/crd/agentworkload_crd.yaml
 helm dependency build ./charts
 helm upgrade --install agentic-operator ./charts \
-  --namespace agentic-system --create-namespace
+  --namespace agentic-system --create-namespace \
+  --set license.key=dev-only-not-a-valid-license
+
+# The development license value is packaging-only in OSS mode.
+# Do not use it in production.
 
 # Deploy your first agent
 kubectl apply -f config/agentworkload_example.yaml
@@ -177,52 +174,27 @@ kubectl -n agentic-system get agentworkloads -w
 
 ```mermaid
 flowchart LR
-    subgraph clients["Users"]
-        PE["Platform Engineer<br/>(kubectl / agentctl)"]
-        AUD["Auditor<br/>(audit-verify, offline)"]
-    end
-
-    API["Kubernetes<br/>API Server"]
-
-    subgraph plane["Clawdlinux governance plane"]
-        OP["Clawdlinux Operator<br/>(license, OPA, cost)"]
-        RT["Runtime Adapter<br/>(spec.orchestration.type)"]
-        ARGO["Argo Workflows"]
-        POD["BYO Pod"]
-        KAGENT["kagent Agent"]
-        PODS["Agent Pods<br/>(gVisor, egress-sealed)"]
-        PROXY["LiteLLM Proxy"]
-    end
-
-    LLMEP["Approved<br/>LLM Endpoint"]
-    MINIO[("MinIO<br/>Artifact Store")]
-    CHAIN[("Audit Chain<br/>WORM, hash-chained")]
-    REKOR["Sigstore Rekor<br/>(optional)"]
-
-    PE -->|Applies AgentWorkload| API
-    AUD -->|Fetches chain checkpoint| API
-    API -->|Watch events| OP
-    OP -->|Selects runtime| RT
-    RT -->|argo| ARGO
-    RT -->|pod| POD
-    RT -->|kagent| KAGENT
-    OP -->|Injects gVisor, seals egress| PODS
-    ARGO --> PODS
-    POD --> PODS
-    KAGENT --> PODS
-    PODS -->|LLM calls| PROXY
-    PROXY -.->|LLM: inference| LLMEP
-    PODS -->|Writes artifacts| MINIO
-    OP -->|Appends signed events| CHAIN
-    OP -.->|Rekor: mirrors head| REKOR
-
-    classDef plane fill:#ede9fe,stroke:#7c3aed,color:#1e1b4b;
-    classDef clients fill:#dcfce7,stroke:#16a34a,color:#052e16;
-    class OP,RT,ARGO,POD,KAGENT,PODS,PROXY plane;
-    class PE,AUD clients;
+  USER["Platform engineer or orchestrator"] --> API["Kubernetes API"]
+  API --> OP["Clawdlinux operator"]
+  OP --> REG["Runtime registry"]
+  REG --> ARGO["Argo adapter"]
+  REG --> POD["Pod adapter"]
+  REG --> KAGENT["kagent adapter"]
+  OP --> COST["CostReporter interface"]
+  OP --> STATUS["AgentWorkload status"]
+  LABELS["Governance labels"] --> ADMISSION["gVisor admission mutation"]
+  LABELS --> NETPOL["Network-policy objects"]
+  AUDIT["Audit hash-chain primitives"] --> VERIFY["audit-verify JSONL verifier"]
 ```
 
-The operator picks the execution runtime from `spec.orchestration.type` (Argo, a BYO pod, or a kagent Agent) through a pluggable adapter, then seals every agent pod (gVisor sandbox, default-deny egress to an approved allow-list) and appends a signed, hash-chained record of every run. The seal and attestation are identical across runtimes because they are enforced at the pod and network layer, not the scheduler. An auditor verifies the record offline, months later, with `audit-verify`.
+The operator selects `argo`, `pod`, or `kagent` through `pkg/runtime.Registry`.
+Adapters stamp shared governance labels. The admission webhook and network-policy
+templates consume those labels. Actual sandboxing requires gVisor on the nodes.
+Network enforcement depends on the cluster CNI.
+
+The audit package and offline JSONL verifier are implemented. The controller does
+not yet append each run event into that chain. Durable storage, production signing
+keys, and independently verified checkpoints remain integration work.
 
 ---
 
@@ -233,39 +205,36 @@ The operator picks the execution runtime from `spec.orchestration.type` (Argo, a
 | **AgentWorkload CRD** | Declarative spec for agent objective, model, quotas, egress rules |
 | **Controller** | Reconciles workloads → namespaces, network policies, workflows, artifacts |
 | **Argo Integration** | Agent steps execute as DAG nodes with retries and timeouts |
-| **Cilium Policies** | FQDN-based egress lock-down auto-generated per workload |
-| **LiteLLM Routing** | Cost-aware model selection across providers (OpenAI, Anthropic, Cloudflare) |
-| **MinIO Artifacts** | Per-workload bucket for prompts, logs, outputs, audit trails |
+| **Network policy** | Default-deny and allow-list policy templates; optional Cilium FQDN policy |
+| **Model Routing** | Operator classifier plus optional LiteLLM multi-provider proxy |
+| **MinIO** | Optional in-cluster object storage subchart; same-run audit bundling is not connected |
 | **Multi-tenancy** | Namespace isolation with quota enforcement per tenant |
-| **Cost Attribution** | Per-workload usage metering and cost-attribution hooks for chargeback reporting |
+| **Cost Attribution** | CostReporter interface, no-op default, and in-memory demo reporter |
 | **Python Agent Runtime** | Batteries-included agent framework with tool integrations |
 
 ---
 
-## Product Editions
+## Project Status
 
-| | Community | Enterprise |
-|---|---|---|
-| **License** | Apache 2.0 — free forever | Contact for pricing |
-| **Deployment** | Self-managed | Managed + self-managed |
-| **Air-gapped support** | ✅ | ✅ |
-| **AgentWorkload CRD** | ✅ | ✅ |
-| **Argo DAG orchestration** | ✅ | ✅ |
-| **Cilium egress policies** | ✅ | ✅ |
-| **Cost attribution hooks** | ✅ | ✅ |
-| **Managed upgrades** | — | ✅ |
-| **Dedicated control plane** | — | ✅ |
-| **Private registry & SSO** | — | ✅ |
-| **SLA + incident response** | — | ✅ |
-| **FedRAMP / HIPAA advisory** | — | ✅ |
+| Available in this repository | Target product work |
+|---|---|
+| AgentWorkload CRD and runtime adapters | Actor identity propagated into every run |
+| Argo DAG and BYO pod execution | Universal tool-call mediation |
+| Admission mutation and policy-object generation | Enforcing-cluster packet tests |
+| Model routing and cost-reporting interfaces | Durable cost and chargeback integration |
+| Audit hashing, signing, and JSONL verification | Same-run capture, durable storage, and external checkpoints |
 
-Enterprise inquiries: [shreyanshsancheti09@gmail.com](mailto:shreyanshsancheti09@gmail.com?subject=Enterprise%20Inquiry)
+Clawdlinux does not claim compliance certification. It provides technical
+controls that customers can map into their own security and compliance program.
 
 ---
 
 ## Security & Sandbox
 
-Clawdlinux ships **default-deny egress NetworkPolicies** for every agent namespace (Helm-toggleable via `networkPolicy.enabled`, default true). It can also create a gVisor `RuntimeClass` and register a pod mutating webhook for labeled agent pods. See [docs/07-security.md](docs/07-security.md) for details.
+The Helm chart renders default-deny egress NetworkPolicies for selected pods
+when `networkPolicy.enabled=true`. It can also create a gVisor `RuntimeClass`
+and register a mutating webhook for labeled pods. The cluster must provide an
+enforcing CNI and install `runsc`. See [docs/07-security.md](docs/07-security.md).
 
 ---
 
@@ -303,13 +272,18 @@ assets/                 Branding assets (logo, etc.)
 
 ## Open Source Boundary
 
-This repository is the **open-source core**. It contains everything needed to run agent workloads on Kubernetes, including full air-gapped support.
+This repository is the **open-source core**. It supports self-managed Kubernetes
+deployment and offline JWT validation. A reproducible full air-gap installation
+test remains a release gate.
 
 The [private companion](https://github.com/Clawdlinux/agentic-operator-private) adds enterprise features built on top of the core's cost-attribution primitives:
 - License validation and trial enforcement
 - External billing system integrations (e.g. OpenMeter, Stripe, internal chargebacks)
 - Production DOKS deployment overlays
-- FedRAMP / HIPAA compliance overlays
+- Customer-specific security and compliance integrations
+
+Neither repository alone makes a deployment compliant with a named framework.
+Scope, controls, operations, and independent assessment remain customer-specific.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,14 +6,16 @@
 
 ## What's New in v0.2.0
 
-This release adds production-ready multi-agent demos, a pluggable workflow engine, CLI onboarding, and per-workload cost attribution — everything needed to deploy and manage AI agent fleets on Kubernetes in air-gapped environments.
+This release adds multi-agent examples, a pluggable workflow registry, CLI onboarding, and an in-memory cost reporter for evaluation.
+
+These release notes describe the v0.2.0 feature set. They do not claim production readiness, full air-gap validation, durable chargeback, real OPA execution, or same-run signed evidence.
 
 ---
 
-## ✨ Highlights
+## Highlights
 
-### Multi-Agent Demos (Production-Ready)
-- **Research Swarm** — A2A agent discovery, persona tool_profile blocking, OPA budget enforcement, autoApproveThreshold gating. Docker Compose with ollama local overlay for fully offline operation.
+### Multi-Agent Examples
+- **Research Swarm** — A2A agent discovery, persona `toolProfile` checks, approval-threshold inputs, and a local Ollama overlay.
 - **SRE Incident Response** — `collaborationMode: delegation`, 3-tier cost-aware model routing (cheap triage → mid analysis → expensive remediation), adversarial tone on remediator, hierarchical memory. 4 alert scenarios included.
 
 ### Pluggable Workflow Registry
@@ -43,7 +45,7 @@ This release adds production-ready multi-agent demos, a pluggable workflow engin
 
 ## 🚀 Quick Start
 
-### Multi-Agent Swarm (fully offline with Ollama)
+### Multi-Agent Swarm With Local Ollama
 
 ```bash
 cd examples/multi-agent-swarm
@@ -78,8 +80,11 @@ agentctl workflows          # list available workflows
 ### Helm
 
 ```bash
-helm repo add agentic https://clawdlinux.github.io/agentic-operator-core
-helm install agentic-operator agentic/agentic-operator
+git clone https://github.com/Clawdlinux/agentic-operator-core.git
+cd agentic-operator-core
+helm dependency build ./charts
+helm upgrade --install clawdlinux ./charts \
+  --namespace agentic-system --create-namespace
 ```
 
 ### agentctl
@@ -114,7 +119,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the complete list of changes since v0.1.1.
 - Distroless containers, non-root user
 - Credential sanitizer in logs (OpenAI, GitHub, AWS, JWT, bearer tokens)
 - Prompt injection sanitization on scraped content
-- OPA-gated action execution with default-deny policies
+- In-process action evaluator and separate Rego policy assets
 - See [SECURITY.md](SECURITY.md) for vulnerability disclosure (48h SLA)
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,14 +8,17 @@ Enterprises in regulated industries cannot ship AI agents to production. Not bec
 
 ## The vision
 
-Every agent run on Kubernetes leaves a signed, tamper-evident, offline-verifiable attestation artifact, and runs inside a declared egress boundary, regardless of which runtime executes it. Clawdlinux is that governance plane: air-gapped by default, runtime-agnostic by design, delivered as one Helm chart.
+The target product makes each governed Kubernetes agent run leave signed, offline-verifiable evidence and execute inside a declared egress boundary. Clawdlinux is building that runtime-agnostic governance plane for customer-owned clusters.
+
+The current repository ships separate audit, admission, network-policy, runtime,
+and cost components. Same-run capture and enforcement parity are not complete.
 
 ## How we got here
 
 - **Feb 2026.** Project started as an enterprise agent-swarm orchestration platform (operator, AgentWorkload CRD, Argo DAGs, multi-tenancy, licensing, cost tracking). Initial wedge idea: visual market analysis for hedge funds needing zero data leakage.
 - **Mar to Apr 2026.** Core platform hardened: Cilium FQDN egress generation, LiteLLM routing, MinIO artifacts, Python LangGraph runtime with A2A, full-cycle integration tests, Helm umbrella chart.
 - **May 2026.** ACP (Agent Contract Protocol) spun out as its own repo and spec. Benchmarks landed: 64.7% to 97.4% token reduction vs raw MCP, one round trip. Briefly explored a consumer AgentOS direction; reversed within the month. Enterprise K8s is the business.
-- **Jun 2026.** Positioning locked: we sell the attestation and governance plane, not a runtime. CNCF runtimes are supported, not competed with. Runtime adapter interface shipped so AgentWorkload, BYO pods, and external runtimes get the same seal and attestation. ACP repositioned from token compression to governed execution contracts. gVisor RuntimeClass injector and offline audit-verify shipped.
+- **Jun 2026.** Positioning locked: we sell the governance and evidence plane, not a runtime. Runtime adapters, gVisor mutation, and offline JSONL verification primitives shipped. Governance parity and same-run capture remained incomplete.
 - **Jul 2026.** Demo gate (`scripts/demo-booth.sh`) reproducible on kind. Focus: validation conversations and the Jul 22 Agentic Summit booth. Fintech is the anchor vertical.
 
 ## Scope note
@@ -32,7 +35,7 @@ Strong CNCF base runtimes for agents on Kubernetes exist and are improving. Claw
 - [x] Multi-tenant namespace isolation with quota enforcement
 - [x] Python agent runtime with tool integrations
 - [x] A2A (Agent-to-Agent) communication protocol
-- [x] Production hardening: staticcheck, secret scanning, CI gates
+- [x] Quality gates: staticcheck, secret scanning, and CI checks
 - [x] Helm chart with subchart dependencies
 - [x] Full-cycle integration test suite
 
@@ -40,10 +43,10 @@ Strong CNCF base runtimes for agents on Kubernetes exist and are improving. Claw
 
 - [x] `agentctl` CLI for workload management
 - [x] MCP server (`agentctl mcp serve`) for agent-callable provisioning ([#140](https://github.com/Clawdlinux/agentic-operator-core/issues/140))
-- [x] Tamper-evident audit chain with offline `audit-verify`
+- [x] HMAC hash-chain and offline JSONL `audit-verify`
 - [x] gVisor RuntimeClass + pod admission injector for labeled agent pods
 - [x] Runtime adapter interface (AgentWorkload, BYO pods, external runtimes)
-- [x] OPA policy library for common agent guardrails
+- [x] Rego policy samples and an in-process Go action evaluator
 - [x] Grafana observability and per-workload cost dashboards
 - [x] Reproducible booth demo gate on kind
 
@@ -51,11 +54,13 @@ Strong CNCF base runtimes for agents on Kubernetes exist and are improving. Claw
 
 Priority order. Validation before features.
 
-- [ ] 10 real conversations with named platform/security engineers by Jul 15 (kill criterion for everything below it)
+- [ ] 10 qualified platform/security conversations by Sep 15, including 3 active production-review blockers and 1 scoped design-partner engagement. This is the one-time reset of the missed Jul 15 criterion.
 - [ ] Jul 22 Agentic Summit booth demo, fintech use case
 - [ ] Air-gapped install smoke test in CI
 - [ ] Webhook admission controller for CRD validation
 - [ ] Per-runtime sandbox label guide
+- [ ] Same-run audit capture with durable storage and production key custody
+- [ ] Runtime governance-label parity and enforcing-CNI packet tests
 - [ ] ACP RemoteMCPServer wrapper example
 - [ ] Homebrew tap for agentctl
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.2.x   | Supported |
+| 0.1.x   | Best effort |
 
 ## Reporting a Vulnerability
 
@@ -13,15 +14,15 @@ responsibly. **Do not open a public GitHub issue.**
 
 ### How to report
 
-1. Email **<placeholder>** with a description of the vulnerability.
+1. Use [GitHub private vulnerability reporting](https://github.com/Clawdlinux/agentic-operator-core/security/advisories/new).
 2. Include steps to reproduce, affected versions, and potential impact.
-3. We will acknowledge receipt within **48 hours**.
-4. We aim to provide a fix or mitigation within **7 days** for critical issues.
+3. We aim to acknowledge receipt within 2 business days.
+4. Fix and disclosure timelines depend on severity, exploitability, and coordinated disclosure needs.
 
 ### What to expect
 
-- A confirmation email within 48 hours.
-- Regular updates on the status of your report.
+- A private acknowledgement through GitHub Security Advisories.
+- Updates when triage status or disclosure timing changes.
 - Credit in the release notes (unless you prefer anonymity).
 
 ### Scope

--- a/charts/charts/clawdlinux-observability/Chart.yaml
+++ b/charts/charts/clawdlinux-observability/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: clawdlinux-observability
 description: |
-  Air-gapped, OpenTelemetry-native observability stack for Clawdlinux
+  Self-managed, OpenTelemetry-native observability stack for Clawdlinux
   agentic workloads. Deploys a curated bundle of OTel Collector + Tempo +
   Prometheus + Grafana + ClickHouse + Qdrant with pre-built dashboards
   that understand AgentWorkload CRDs, ACP manifest IDs, and LangGraph
@@ -13,10 +13,8 @@ description: |
     * full          — sharded ClickHouse, Mimir for metrics, Loki for logs,
       multi-replica Grafana with persistence.
 
-  This is the OPEN-SOURCE bundle. The proprietary Audit layer
-  (deterministic replay, hash-chained tamper-evident log, autonomous
-  failure clustering) ships as a separate sub-chart and requires a
-  Clawdlinux Audit license.
+  The chart also creates audit table schemas and optional analyzer resources.
+  Automatic same-run audit capture and deterministic replay are not connected.
 
 type: application
 version: 0.1.0
@@ -35,7 +33,6 @@ keywords:
   - genai
   - agents
   - audit
-  - compliance
 icon: https://clawdlinux.org/icons/audit.svg
 
 # We deliberately do NOT pull upstream charts as `dependencies:` — operators

--- a/charts/charts/clawdlinux-observability/README.md
+++ b/charts/charts/clawdlinux-observability/README.md
@@ -1,18 +1,15 @@
-# Clawdlinux Audit — Observability bundle
+# Clawdlinux Observability Bundle
 
-> Compliance-native, air-gapped observability for AI agents on Kubernetes.
+> Self-managed observability components for AI workloads on Kubernetes.
 
 This directory is the OSS observability layer of [agentic-operator](../../).
 It deploys an opinionated bundle of OpenTelemetry Collector, Tempo, Prometheus,
 Grafana, ClickHouse, and Qdrant, wired together with curated dashboards for
-`AgentWorkload` CRDs, ACP manifests, and LangGraph node execution. On top of
-the bundle sits the proprietary **Audit** layer — tamper-evident hash-chained
-ledger, deterministic replay, and an autonomous failure-clustering analyzer.
+`AgentWorkload` CRDs, ACP manifests, and LangGraph node execution.
 
-The wedge is **compliance**, not developer experience. Hedge funds, banks, and
-defence integrators cannot ship their agent traces to LangChain's cloud
-LangSmith Engine; everything in this chart runs entirely inside the customer's
-cluster with zero external network calls.
+The chart creates ClickHouse audit-table schemas and optional analyzer resources.
+It does not connect the operator to a durable audit writer. Deterministic replay,
+regulator-ready reports, and automatic same-run evidence remain target work.
 
 ---
 
@@ -29,17 +26,16 @@ cluster with zero external network calls.
 | ClickHouse | Analytical trace queries + the `agent_audit_v1` tamper-evident table |
 | Qdrant | Vector store for clustering & similarity search |
 
-### Commercial Audit tier
+### Optional and target components
 
 | Component | Role |
 |---|---|
-| `audit-analyzer` CronJob | Embeds error spans → HDBSCAN cluster → local LLM summarises into `IssueCard` JSON published to `/issues` |
+| `audit-analyzer` CronJob | Optional deployment resource; validate the configured image and feature set separately |
 | Replay engine *(roadmap)* | Reproduce historical agent decisions bit-for-bit |
 | Compliance report templates *(roadmap)* | SR 11-7, SOC 2, GDPR Art. 30, SEC 17a-4 |
 
-The OSS bundle ships the audit-log primitives (chain hasher, recorder, verifier
-CLI). The commercial tier adds the GUI compliance reports and the replay
-engine. Both run in the same cluster; the analyzer is gated by
+The repository ships chain, recorder, and verifier primitives. The only backend
+implementation in this tree is in-memory. The analyzer is gated by
 `auditAnalyzer.enabled`.
 
 ---
@@ -95,8 +91,7 @@ semantic conventions (`gen_ai.system`, `gen_ai.usage.input_tokens`,
 
 ## Tamper-evident audit log
 
-Every consequential agent action is recorded into ClickHouse table
-`agent_audit_v1` with this row layout:
+The chart creates an `agent_audit_v1` table with this row layout:
 
 ```
 seq UInt64               (monotonic, per tenant)
@@ -114,9 +109,8 @@ signer_kid LowCardinality(String)
 signature FixedString(32)    = HMAC-SHA256(signing_key, entry_hash)
 ```
 
-A separate table `audit_checkpoints_v1` records periodic head observations
-that are also published to a Kubernetes ConfigMap (`clawd-audit-head`) and,
-optionally, to a Sigstore Rekor instance for off-cluster anchoring.
+The chart also creates an `audit_checkpoints_v1` table. No publisher in this
+repository writes checkpoints to that table, a ConfigMap, or Sigstore Rekor.
 
 The verifier CLI walks the entire chain offline:
 
@@ -132,7 +126,7 @@ go build -o bin/audit-verify ./cmd/audit-verify
 # → exit 0 = clean, 1 = tamper detected, 2 = config error
 ```
 
-Tamper-detection is exhaustively tested in `pkg/audit/audit_test.go`, covering:
+Focused tests in `pkg/audit/audit_test.go` cover:
 
 - payload mutation
 - `prev_hash` rewrites (insertion / deletion attempts)
@@ -146,7 +140,7 @@ Tamper-detection is exhaustively tested in `pkg/audit/audit_test.go`, covering:
 
 ## Failure clustering analyzer (commercial)
 
-Once nightly:
+The target analyzer flow is:
 
 1. Pulls last 24h of error spans from ClickHouse.
 2. Builds a stable trace fingerprint (agent + workload + tool sequence + error).
@@ -200,6 +194,5 @@ agents/audit_analyzer/  # Clustering pipeline + FastAPI surface + Dockerfile
 
 ## License
 
-Apache 2.0 for the OSS bundle. The `audit-analyzer` image is also Apache 2.0
-but its commercial tier features (replay engine, regulator-ready compliance
-report templates) require a separate Clawdlinux Audit license.
+Repository source and chart templates are Apache 2.0. Validate any configured
+external image and commercial feature terms separately.

--- a/charts/charts/clawdlinux-observability/values.yaml
+++ b/charts/charts/clawdlinux-observability/values.yaml
@@ -151,16 +151,14 @@ qdrant:
     limits:   { cpu: "1000m", memory: "1Gi" }
 
 # ---------------------------------------------------------------------------
-# Audit log — tamper-evident, hash-chained ClickHouse table.
-# Open-source schema and verifier; advanced tier ships the Rekor checkpoint
-# integration and the GUI compliance reports.
+# Audit substrate. The chart creates ClickHouse schemas only.
+# No controller writer or checkpoint publisher is connected in this repository.
 # ---------------------------------------------------------------------------
 auditLog:
   enabled: true
   # Bootstrap job that creates the agent_audit_v1 table on first install.
   schemaBootstrap: true
-  # Where the Merkle head checkpoint is published. Always written to a
-  # ConfigMap in the operator namespace; optionally mirrored to Rekor.
+  # Reserved configuration for a future checkpoint publisher.
   checkpoint:
     configMapName: clawd-audit-head
     intervalSeconds: 300
@@ -170,9 +168,8 @@ auditLog:
     url: ""
 
 # ---------------------------------------------------------------------------
-# Audit Analyzer — clustering service.
-# This is the proprietary surface; runs only when a Clawdlinux Audit
-# license key is provided. Default: disabled in OSS install.
+# Optional analyzer deployment. Default: disabled.
+# Validate the configured image and feature set separately.
 # ---------------------------------------------------------------------------
 auditAnalyzer:
   enabled: false

--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -1,169 +1,86 @@
-# Quick Start Guide
+# Quick Start
 
-Get the Agentic Kubernetes Operator running in your cluster in under 5 minutes.
+Install Clawdlinux from the local umbrella chart and inspect one workload.
 
 ## Prerequisites
 
-- Kubernetes cluster (1.28+)
-- Helm 3.x
-- `kubectl` configured for your cluster
-- A Cloudflare account (free tier works) OR any OpenAI-compatible API
+- Kubernetes 1.27 or later.
+- Helm 3.
+- `kubectl` configured for the target cluster.
+- A container registry or locally loaded operator image.
+- Optional model credentials for workloads that call an external provider.
 
-## 1. Install the Operator
+## 1. Clone And Validate
 
 ```bash
-# Clone and install from local chart
 git clone https://github.com/Clawdlinux/agentic-operator-core.git
 cd agentic-operator-core
 
-# Install with default config (license key optional for OSS)
-helm install agentic-operator ./charts/agentic-operator \
+helm dependency build ./charts
+helm lint ./charts
+```
+
+## 2. Install
+
+```bash
+helm upgrade --install clawdlinux ./charts \
   --namespace agentic-system \
-  --create-namespace
+  --create-namespace \
+  --set license.key=dev-only-not-a-valid-license
 ```
 
-## 2. Configure an LLM Provider
+The chart currently requires a nonempty packaging value. The open-source
+reconciler uses a no-op validator, so this development value is not a license or
+security control. Never use it for a production deployment.
 
-### Option A: Cloudflare Workers AI (Free Tier Available)
+## 3. Verify Components
 
 ```bash
-# Create secret with your Cloudflare credentials
-kubectl create secret generic cloudflare-workers-ai-token \
-  --namespace agentic-system \
-  --from-literal=api-token="$CF_API_TOKEN"
-
-# Install with Cloudflare enabled
-helm upgrade agentic-operator agentic/agentic-operator \
-  --namespace agentic-system \
-  --set cloudflareAI.enabled=true \
-  --set cloudflareAI.accountId="$CF_ACCOUNT_ID"
+kubectl -n agentic-system get deployments,pods
+kubectl get crd agentworkloads.agentic.clawdlinux.org
+kubectl -n agentic-system get deployments
 ```
 
-### Option B: OpenAI
+Deployment names depend on the Helm release name. Select the operator deployment
+from the final command before reading its logs.
+
+## 4. Review A Workload Contract
+
+Start with a sample and inspect it before applying:
 
 ```bash
-kubectl create secret generic openai-api-key \
-  --namespace agentic-system \
-  --from-literal=api-key="$OPENAI_API_KEY"
+kubectl apply --dry-run=server \
+  -f config/samples/agentworkload_demo.yaml
 ```
 
-### Option C: Any OpenAI-Compatible API (vLLM, LocalAI, Ollama)
+Check these fields:
+
+- `spec.objective`
+- `spec.orchestration.type`
+- `spec.providers` and `spec.modelMapping`
+- `spec.persona.toolProfile`
+- resource and timeout limits
+- policy mode and approval settings
+
+Apply only after configuring the referenced provider endpoint and Secret:
 
 ```bash
-kubectl create secret generic custom-llm-key \
-  --namespace agentic-system \
-  --from-literal=api-key="$API_KEY"
+kubectl apply -f config/samples/agentworkload_demo.yaml
+kubectl -n agentic-system get agentworkloads -w
 ```
 
-## 3. Deploy Your First Workload
+## What This Proves
 
-```yaml
-# Save as my-first-workload.yaml
-apiVersion: agentic.clawdlinux.org/v1alpha1
-kind: AgentWorkload
-metadata:
-  name: market-analysis
-  namespace: agentic-system
-spec:
-  modelStrategy: cost-aware
-  taskClassifier: default
-  
-  providers:
-    - name: my-llm
-      type: openai-compatible
-      endpoint: https://api.cloudflare.com/client/v4/accounts/YOUR_ACCOUNT_ID/ai/v1
-      apiKeySecret:
-        name: cloudflare-workers-ai-token
-        key: api-token
-  
-  modelMapping:
-    validation: my-llm/@cf/meta/llama-2-7b-chat-int8
-    analysis: my-llm/@cf/meta/llama-2-7b-chat-int8
-    reasoning: my-llm/@cf/meta/llama-2-7b-chat-int8
-  
-  objective: "Analyze Q1 2026 technology sector trends for AAPL, MSFT, GOOGL."
-```
+The quickstart proves chart installation, CRD availability, admission, and the
+selected runtime path. It does not prove packet enforcement, full air-gap
+operation, same-run signed evidence, or compliance with a named framework.
 
-```bash
-kubectl apply -f my-first-workload.yaml
-```
-
-## 4. Monitor
-
-```bash
-# Watch workload status
-kubectl get agentworkload -n agentic-system -w
-
-# View operator logs
-kubectl logs -f -n agentic-system -l app=agentic-operator
-
-# Check evaluation metrics (Phase 4)
-# Quality scores, success rates, cost tracking — all in Prometheus
-kubectl port-forward -n monitoring svc/prometheus 9090:9090
-# Open http://localhost:9090 and query:
-#   agentic_eval_quality_score
-#   agentic_eval_success_total
-#   agentic_eval_cost_usd_total
-```
-
-## 5. View in Grafana
-
-```bash
-kubectl port-forward -n monitoring svc/grafana 3000:3000
-# Open http://localhost:3000 (admin / admin)
-# Import dashboard from: config/grafana/agent-performance-dashboard.json
-```
-
-## What Happens Under the Hood
-
-```
-1. You create an AgentWorkload CR
-2. Operator detects it and starts reconciliation
-3. Task classifier analyzes your objective (validation/analysis/reasoning)
-4. Model router selects the best model for the task type
-5. Provider makes the API call (with retry + circuit breaker protection)
-6. Quality scorer evaluates the response (relevance, hallucination, completeness)
-7. Metrics are recorded to Prometheus
-8. Workload status is updated with results
-```
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────┐
-│ Your Kubernetes Cluster                     │
-├─────────────────────────────────────────────┤
-│                                             │
-│  AgentWorkload CR → Operator                │
-│                     ├─ License Check        │
-│                     ├─ Task Classification   │
-│                     ├─ Model Routing         │
-│                     ├─ LLM API Call          │
-│                     │  (with retry + CB)     │
-│                     ├─ Quality Evaluation    │
-│                     └─ Prometheus Metrics    │
-│                                             │
-│  Providers: Cloudflare │ OpenAI │ Custom    │
-│  Monitoring: Prometheus + Grafana           │
-│  Logging: Loki + Promtail                   │
-│                                             │
-└─────────────────────────────────────────────┘
-```
-
-## Troubleshooting
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| Workload stuck in "Reconciling" | No LLM provider configured | Add provider + secret |
-| 401 Authentication error | Invalid API token | Regenerate token, update secret |
-| 400 "No such model" | Wrong model name | Use full model ID (e.g. `@cf/meta/llama-2-7b-chat-int8`) |
-| Circuit breaker open | Provider failing repeatedly | Wait 60s, check provider health |
-| Quality score < 50 | Poor LLM response | Try a larger model or refine objective |
+For the evidence demo, follow
+[SHOWCASE-DEMO-WALKTHROUGH.md](./SHOWCASE-DEMO-WALKTHROUGH.md).
 
 ## Next Steps
 
-- [Architecture overview](./04-architecture.md)
-- [Cost-aware model routing](./06-cost-management.md)
-- [Security & threat model](./security/threat-model.md)
-- [Helm values reference](../charts/values.yaml)
-- [Project README](../README.md)
+- [Configuration](./03-configuration.md)
+- [Architecture](./04-architecture.md)
+- [Security](./07-security.md)
+- [Cost Management](./06-cost-management.md)

--- a/docs/02-installation.md
+++ b/docs/02-installation.md
@@ -1,73 +1,76 @@
-# Installation Guide
+# Installation
 
-Complete installation instructions for production deployments.
+This repository currently supports installation from its local Helm chart.
+Do not use `helm.agentic.io`; no public chart repository exists at that address.
 
-## System Requirements
+## Requirements
 
-**Kubernetes:**
-- Version: 1.24 or later
-- API Groups: `agentic.clawdlinux.org`, `rbac.authorization.k8s.io`
+- Kubernetes 1.27 or later.
+- Helm 3.
+- `kubectl` access with permission to create CRDs and cluster-scoped RBAC.
+- Storage classes for any enabled stateful subcharts.
+- Network access or mirrored images for enabled components.
 
-**Resources:**
-- CPU: 2 cores (operator pod)
-- Memory: 2Gi (operator pod)
-- Storage: etcd/database backend
+Optional controls require additional cluster support:
 
-**Network:**
-- Outbound HTTPS for LLM provider APIs
-- Optional: Prometheus scrape access
+- gVisor mutation requires `runsc` and a working `RuntimeClass`.
+- NetworkPolicy enforcement requires an enforcing CNI.
+- Cilium FQDN policy requires Cilium.
+- External model calls require approved credentials and egress.
 
-## Step 1: Add Helm Repository
-
-```bash
-helm repo add agentic https://helm.agentic.io
-helm repo update
-```
-
-## Step 2: Create Namespace
+## Install From Source
 
 ```bash
-kubectl create namespace agentic-system
-```
+git clone https://github.com/Clawdlinux/agentic-operator-core.git
+cd agentic-operator-core
 
-## Step 3: Install Operator
-
-```bash
-helm install agentic-operator agentic/agentic-operator \
+helm dependency build ./charts
+helm upgrade --install clawdlinux ./charts \
   --namespace agentic-system \
-  --values values.yaml
+  --create-namespace \
+  --set license.key=dev-only-not-a-valid-license
 ```
 
-See `Configuration` for values.yaml options.
+The chart currently requires a nonempty `license.key`. The open-source
+reconciler defaults to a no-op validator. Use the development value only for
+local evaluation.
 
-## Step 4: Verify Installation
+Use a reviewed values file for production:
 
 ```bash
-# Check operator deployment
-kubectl get deployments -n agentic-system
-
-# Check CRDs registered
-kubectl get crd | grep agentic
-
-# View operator logs
-kubectl logs -n agentic-system -l app=agentic-operator -f
+helm upgrade --install clawdlinux ./charts \
+  --namespace agentic-system \
+  --create-namespace \
+  --values ./my-values.yaml \
+  --set license.key="$CLAWDLINUX_LICENSE_JWT"
 ```
 
-## Step 5: Configure Secrets
+Production license tokens can be generated with `cmd/generate-license` when the
+required signing material and commercial terms are available. Do not commit a
+token to a values file.
 
-Store provider API keys as Kubernetes secrets:
+## Verify
 
 ```bash
-kubectl create secret generic cloudflare-workers-ai-token \
-  --from-literal=api-token=YOUR_API_KEY \
-  -n agentic-system
+helm status clawdlinux -n agentic-system
+kubectl -n agentic-system get deployments,pods,services
+kubectl get crd | grep agentic.clawdlinux.org
 ```
+
+## Air-Gapped Environments
+
+The chart supports image repository overrides and offline JWT validation.
+A production air-gap deployment must mirror every enabled image and dependency.
+The repository does not yet run a complete air-gap installation smoke test in CI.
 
 ## Uninstall
 
 ```bash
-helm uninstall agentic-operator -n agentic-system
-kubectl delete namespace agentic-system
+helm uninstall clawdlinux -n agentic-system
 ```
 
-For more details, see `Configuration`.
+Helm does not automatically delete CRDs or persistent volumes. Review retained
+resources before deleting namespaces or storage.
+
+See [Configuration](./03-configuration.md) before changing runtime, network,
+storage, model, or observability settings.

--- a/docs/03-configuration.md
+++ b/docs/03-configuration.md
@@ -1,87 +1,83 @@
-# Configuration Guide
+# Configuration
 
-Configure Clawdlinux for your environment.
+Use [`charts/values.yaml`](../charts/values.yaml) and
+[`charts/values.schema.json`](../charts/values.schema.json) as the source of
+truth for Helm settings.
 
-## Helm Values
+## Runtime Selection
 
-```yaml
-# values.yaml
-operator:
-  replicas: 1
-  image:
-    repository: ghcr.io/Clawdlinux/agentic-operator-core
-    tag: latest
-  resources:
-    requests:
-      cpu: 500m
-      memory: 512Mi
-    limits:
-      cpu: 2
-      memory: 2Gi
+`AgentWorkload.spec.orchestration.type` selects a registered runtime:
 
-metrics:
-  enabled: true
-  serviceMonitor:
-    enabled: true
+- `argo`: default multi-step DAG execution.
+- `pod`: bring-your-own single pod.
+- `kagent`: unstructured `kagent.dev/v1alpha2` Agent adapter.
 
-license:
-  # Set to your license key (optional)
-  key: ""
-  # Check license validity interval
-  validationInterval: 24h
+Adding a runtime requires a `runtime.RuntimeAdapter` implementation and registry
+registration. Do not add runtime-specific branches to the reconciler.
 
-opa:
-  # Default policy for workloads
-  defaultPolicy: strict
+## Runtime Sandbox
 
-providers:
-  # Configure available LLM providers
-  cloudflare:
-    enabled: true
-    endpoint: https://api.cloudflare.com/client/v4
-  openai:
-    enabled: true
-    endpoint: https://api.openai.com/v1
-```
-
-## Environment Variables
-
-```bash
-# Operator configuration
-AGENTIC_LOG_LEVEL=info
-AGENTIC_RECONCILE_INTERVAL=30s
-AGENTIC_METRICS_PORT=8080
-
-# License validation
-AGENTIC_LICENSE_KEY=<your-key>
-AGENTIC_LICENSE_CHECK_INTERVAL=24h
-```
-
-## Provider Configuration
-
-Configure LLM providers:
+The admission webhook mutates labeled pods:
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
 metadata:
-  name: agentic-providers
-  namespace: agentic-system
-data:
-  providers.yaml: |
-    providers:
-      - name: cloudflare-workers-ai
-        type: openai-compatible
-        endpoint: https://api.cloudflare.com/client/v4/accounts/...
-        models:
-          - llama-2-7b-chat-int8
-          - mistral-7b-instruct
-      - name: openai
-        type: openai
-        endpoint: https://api.openai.com/v1
-        models:
-          - gpt-4
-          - gpt-4-turbo
+  labels:
+    agentic.clawdlinux.org/runtime-sandbox: gvisor
 ```
 
-For details on each provider, see `Configuration`.
+The pod receives `runtimeClassName: gvisor` when it does not already specify a
+runtime class. The nodes must have a working `runsc` installation.
+
+## Network Policy
+
+The umbrella chart renders a default-deny egress policy when
+`networkPolicy.enabled=true`. It selects pods in the release namespace by label.
+
+Optional Cilium FQDN policy requires:
+
+```yaml
+networkPolicy:
+  cilium:
+    enabled: true
+```
+
+Policy objects are configuration. Packet enforcement depends on the cluster CNI.
+
+## Action Policy
+
+`AgentWorkload.spec.opaPolicy` selects strict or permissive behavior in the
+legacy in-process Go evaluator. The direct action path does not execute Rego.
+
+Rego samples under `pkg/opa` and `config/policies` are integration assets.
+
+## Model Routing
+
+Provider endpoints and Secret references belong in the AgentWorkload spec.
+LiteLLM may be enabled as an in-cluster multi-provider proxy.
+
+Never place provider keys in a ConfigMap or committed values file.
+
+## Cost Reporting
+
+The open-source operator defaults to `NoOpCostReporter`.
+Enable the in-memory reporter only for local evaluation:
+
+```text
+AGENTIC_COST_TRACKING=memory
+```
+
+The in-memory reporter is volatile and unsuitable for billing or chargeback.
+
+## Licensing
+
+Offline JWT validation is available when a production validator is configured.
+The open-source reconciler defaults to a no-op validator.
+
+## Observability
+
+The optional observability chart deploys OTel Collector, Tempo, Prometheus,
+Grafana, ClickHouse, and Qdrant components. Audit table creation does not mean
+the controller writes same-run audit rows.
+
+See [Security](./07-security.md), [Cost Management](./06-cost-management.md),
+and [Architecture](./04-architecture.md) before production use.

--- a/docs/04-architecture.md
+++ b/docs/04-architecture.md
@@ -4,9 +4,9 @@ System design and components.
 
 ## Overview
 
-Clawdlinux is a Kubernetes operator that runs autonomous AI agent workloads
-under governance: sandboxed, egress-sealed, cost-attributed, and recorded in a
-tamper-evident audit chain that an auditor can verify offline.
+Clawdlinux is a Kubernetes operator for governed agent workloads. The current
+repository provides runtime adapters, admission and network configuration,
+cost-reporting paths, workload status, and offline audit verification primitives.
 
 ```mermaid
 flowchart LR
@@ -18,36 +18,33 @@ flowchart LR
     API["Kubernetes<br/>API Server"]
 
     subgraph plane["Clawdlinux governance plane"]
-        OP["Clawdlinux Operator<br/>(license, OPA, cost)"]
+        OP["Clawdlinux Operator<br/>(license, policy, cost)"]
         RT["Runtime Adapter<br/>(spec.orchestration.type)"]
         ARGO["Argo Workflows"]
         POD["BYO Pod"]
         KAGENT["kagent Agent"]
-        PODS["Agent Pods<br/>(gVisor, egress-sealed)"]
+        PODS["Agent Pods<br/>(governance-labeled)"]
         PROXY["LiteLLM Proxy"]
     end
 
     LLMEP["Approved<br/>LLM Endpoint"]
-    MINIO[("MinIO<br/>Artifact Store")]
-    CHAIN[("Audit Chain<br/>WORM, hash-chained")]
-    REKOR["Sigstore Rekor<br/>(optional)"]
+    AUDIT["Audit primitives<br/>(separate path)"]
+    VERIFY["audit-verify<br/>(JSONL)"]
 
     PE -->|Applies AgentWorkload| API
-    AUD -->|Fetches chain checkpoint| API
+    AUD -->|Verifies an exported chain| VERIFY
     API -->|Watch events| OP
     OP -->|Selects runtime| RT
     RT -->|argo| ARGO
     RT -->|pod| POD
     RT -->|kagent| KAGENT
-    OP -->|Injects gVisor, seals egress| PODS
+    OP -->|Applies governance labels| PODS
     ARGO --> PODS
     POD --> PODS
     KAGENT --> PODS
     PODS -->|LLM calls| PROXY
     PROXY -.->|LLM: inference| LLMEP
-    PODS -->|Writes artifacts| MINIO
-    OP -->|Appends signed events| CHAIN
-    OP -.->|Rekor: mirrors head| REKOR
+    AUDIT --> VERIFY
 
     classDef plane fill:#ede9fe,stroke:#7c3aed,color:#1e1b4b;
     classDef clients fill:#dcfce7,stroke:#16a34a,color:#052e16;
@@ -55,17 +52,14 @@ flowchart LR
     class PE,AUD clients;
 ```
 
-The Platform Engineer applies an `AgentWorkload`. The operator watches the API
-server and picks the execution runtime from `spec.orchestration.type` through a
-pluggable adapter: an Argo DAG for multi-step jobs, a bring-your-own single pod
-for simple ones, or a kagent Agent. Whichever runs, the operator injects a
-gVisor sandbox and a default-deny egress seal onto the agent pods, because that
-governance is enforced at the pod and network layer, not the scheduler. Agent
-pods reach only the approved LLM endpoint (via the LiteLLM proxy) and write
-artifacts to MinIO. Every consequential action is appended to a hash-chained,
-HMAC-signed audit chain, with the chain head optionally mirrored to Sigstore
-Rekor. An auditor fetches the published checkpoint and verifies the whole chain
-offline with `audit-verify`, no trust in the cluster required.
+The Platform Engineer applies an `AgentWorkload`. The operator selects an Argo,
+pod, or kagent adapter from `spec.orchestration.type`. Adapters stamp shared
+governance labels. The admission webhook and network-policy templates consume
+those labels.
+
+Actual gVisor isolation requires `runsc` on the nodes. Network enforcement
+depends on the cluster CNI. The audit package and JSONL verifier are implemented,
+but the controller does not append each workload event into the chain.
 
 ## Runtimes and the adapter contract
 
@@ -79,15 +73,14 @@ in `pkg/runtime`.
   pod image comes from the `CLAWDLINUX_AGENT_IMAGE` env var.
 - `kagent`: runs the workload as a kagent `Agent` (`kagent.dev/v1alpha2`) in BYO
   mode, created through the unstructured client with no Go dependency on kagent.
-  Requires kagent installed in the cluster. Same image source, same seal.
+  Requires kagent installed in the cluster. The adapter applies shared governance labels.
 
-All three stamp the same governance labels onto their pods through a shared
-helper, so the gVisor sandbox and the default-deny egress policy apply
-identically. Engineering rule: never hardcode a runtime in the controller. Add a
-runtime by implementing `runtime.RuntimeAdapter` and registering it in the
-registry, not by adding a branch in `Reconcile`. Governance is applied at the pod
-and network layer, so every adapter is governed identically without per-adapter
-seal code.
+All three stamp shared governance labels through one helper. Those labels opt
+pods into common admission and network configuration. Enforcement still depends
+on the customer's node runtime and CNI.
+
+Never hardcode a runtime in the controller. Add a runtime by implementing
+`runtime.RuntimeAdapter` and registering it in the registry.
 
 ## Components
 
@@ -104,31 +97,28 @@ Provisions and manages tenants:
 - Namespace creation
 - Secret distribution
 - RBAC configuration
-- Quota enforcement
-- SLA monitoring
+- CPU, memory, and pod ResourceQuota creation
+- Tenant status updates
 
 ### License Validator
-Enforces licensing:
-- JWT verification
-- Tier validation
-- Seat limits
-- Expiry checks
+License validation interface:
+- No-op by default in the open-source reconciler
+- Offline JWT validation when a production validator is configured
 
 ### Cost Tracker
-Tracks token usage:
-- Per-provider accounting
-- Monthly aggregation
-- Quota enforcement
-- Billing metrics
+Cost reporting interface:
+- No-op by default
+- Volatile in-memory reporter for demos
+- Durable reporting supplied by an external implementation
 
 ## Data Flow
 
-1. **Workload Creation** → AgentWorkload CRD submitted
-2. **Validation** → License check, policy evaluation
-3. **Classification** → Task categorized (analysis/reasoning/validation)
-4. **Routing** → Model selected based on strategy
-5. **Execution** → Provider API called
-6. **Evaluation** → Quality scored
-7. **Completion** → Status updated, metrics recorded
+1. **Workload Creation**: AgentWorkload CRD submitted.
+2. **Validation**: license and configured budget interfaces checked.
+3. **Runtime path**: `argo`, `pod`, or `kagent` adapter selected when configured.
+4. **Legacy direct path**: task classified, model routed, and action evaluated.
+5. **Completion**: workload status and available metrics updated.
+
+Audit capture is not part of either complete path today.
 
 For detailed flows, see respective controller documentation.

--- a/docs/05-multi-tenancy.md
+++ b/docs/05-multi-tenancy.md
@@ -4,12 +4,15 @@ Complete guide to multi-tenant provisioning and management.
 
 ## Overview
 
-The Tenant CRD enables automatic provisioning of complete tenant environments:
+The Tenant controller provisions selected namespace resources:
 - Isolated Kubernetes namespaces
 - Per-tenant secrets for provider access
 - RBAC with service accounts and roles
 - Resource quotas and limits
-- SLA monitoring
+- Tenant status fields for later operational integrations
+
+Review the generated RBAC before production use. The tenant service account can
+list Secrets in its namespace.
 
 ## Tenant Lifecycle
 
@@ -89,8 +92,10 @@ agentic-system/cloudflare-workers-ai-token
 agentic-customer-acme/cloudflare-workers-ai-token (copy)
 ```
 
-### Network Isolation (Optional)
-NetworkPolicy restricts inter-namespace traffic:
+### Network Isolation
+
+The Tenant CRD exposes `spec.networkPolicy`, but the current tenant reconciler
+does not create the following policy automatically. Treat this as an example:
 ```yaml
 kind: NetworkPolicy
 metadata:
@@ -126,10 +131,12 @@ quotas:
 
 ### Enforcement
 
-Operator enforces quotas:
-- **Pod limit**: Can't create more pods than maxWorkloads
-- **CPU/Memory**: Limited by ResourceQuota
-- **Monthly tokens**: Tracked and enforced monthly
+The tenant reconciler creates a Kubernetes `ResourceQuota`:
+- `maxWorkloads` maps to a pod-count quota.
+- `cpuLimit` maps to total CPU quota.
+- `memoryLimit` maps to total memory quota.
+
+`maxConcurrent` and `maxMonthlyTokens` are not enforced by this ResourceQuota.
 
 View quota usage:
 ```bash
@@ -144,7 +151,8 @@ Track per-tenant costs:
 kubectl get tenant acme-corp -o json | jq '.status.tokensUsedThisMonth'
 ```
 
-Costs are automatically calculated per provider and aggregated.
+The current tenant reconciler does not populate that field. Use a durable
+`CostReporter` and aggregation integration before relying on tenant chargeback.
 
 ## Delete Tenant
 
@@ -152,18 +160,16 @@ Costs are automatically calculated per provider and aggregated.
 kubectl delete tenant acme-corp
 ```
 
-This removes:
-- ✅ Namespace and all workloads
-- ✅ RBAC roles and bindings
-- ✅ Resource quotas
-- ✅ Secrets
+The current reconciler does not implement finalizer-based cleanup. Deleting a
+Tenant does not guarantee deletion of its namespace, RBAC, quotas, or Secrets.
+Inventory and remove retained resources explicitly.
 
 ## Best Practices
 
 1. **Use descriptive names** - `acme-corp`, not `tenant1`
 2. **Set realistic quotas** - Don't set limits too low
-3. **Monitor SLA** - Set appropriate SLATarget
-4. **Enable NetworkPolicy** - For production multi-tenancy
+3. **Define SLA monitoring externally** - `slaTarget` is not a complete SLO system
+4. **Apply NetworkPolicy explicitly** - Confirm the CNI enforces it
 5. **Rotate secrets** - Update provider tokens quarterly
 
 For examples, see `Examples`.

--- a/docs/06-cost-management.md
+++ b/docs/06-cost-management.md
@@ -1,10 +1,14 @@
 # Cost Management
 
-Track, control, and optimize AI workload costs.
+Estimate and expose AI workload usage through the `CostReporter` interface.
+
+The open-source operator defaults to `NoOpCostReporter`. Cost is not recorded or
+enforced unless another reporter is configured. `MemoryCostReporter` is intended
+for demos and local evaluation. Its data is lost when the process restarts.
 
 ## Token Tracking
 
-Every workload execution is metered:
+With a configured reporter, successful model calls can record prompt and completion tokens:
 
 ```yaml
 Status:
@@ -13,7 +17,7 @@ Status:
       Message: "routed to cloudflare-workers-ai/llama-2-7b (input:100 tokens, output:250 tokens)"
 ```
 
-Input + output tokens are captured for billing.
+These values support estimated cost. They are not a billing ledger.
 
 ## Per-Provider Costs
 
@@ -29,7 +33,7 @@ OpenAI:
   - gpt-4-turbo: $0.01 / 1K prompt, $0.03 / 1K completion
 ```
 
-## Cost-Aware Routing
+## Routing
 
 Model selection optimizes for cost:
 
@@ -37,18 +41,20 @@ Model selection optimizes for cost:
 modelStrategy: cost-aware
 ```
 
-Operator selects cheapest provider that meets quality thresholds.
+Routing and cost reporting are separate paths. Do not treat the in-memory estimate
+as a production provider invoice.
 
 ## Budget Enforcement
 
-Tenants have monthly token quotas:
+Tenant CRDs expose token quotas. Production enforcement requires the relevant
+controller and reporter integration.
 
 ```yaml
 quotas:
   maxMonthlyTokens: 10000000
 ```
 
-Once reached, workloads are rejected:
+Configured budget reporters may reject workloads after a limit is reached:
 ```
 Error: Monthly token budget exceeded for tenant
 ```
@@ -69,10 +75,10 @@ kubectl get agentworkload -A -o json | \
 
 ## Optimization Tips
 
-1. **Use cost-aware routing** - Balances cost and quality
-2. **Right-size quotas** - Set realistic monthly limits
-3. **Monitor trends** - Watch for cost spikes
-4. **Batch requests** - Fewer, larger requests vs many small ones
-5. **Select efficient models** - Smaller models for simple tasks
+1. Configure a durable `CostReporter` before relying on chargeback.
+2. Validate model pricing against the provider contract.
+3. Set workload and tenant limits from measured usage.
+4. Alert on token, request, and estimated-cost changes.
+5. Reconcile estimates against provider invoices.
 
 See `Monitoring` for detailed cost dashboards.

--- a/docs/07-security.md
+++ b/docs/07-security.md
@@ -4,14 +4,11 @@ Enterprise security features and best practices.
 
 ## License Enforcement
 
-Operator validates JWT licenses:
+The open-source reconciler defaults to a no-op validator. Supplying
+`LICENSE_JWT` through Helm does not change that implementation.
 
-```bash
-# Set license key
-kubectl set env deployment/agentic-operator \
-  AGENTIC_LICENSE_KEY=YOUR_JWT_TOKEN \
-  -n agentic-system
-```
+A production validator must be injected through the `LicenceValidator`
+interface. The chart still requires a nonempty `license.key` packaging value.
 
 License includes:
 - Customer ID
@@ -21,10 +18,8 @@ License includes:
 - Feature flags
 - Expiry date
 
-Workloads rejected if:
-- ❌ License invalid/expired
-- ❌ Seat limit exceeded
-- ❌ Feature not enabled
+A configured production validator can reject expired licenses, workload limits,
+or disabled features.
 
 ## RBAC
 
@@ -36,59 +31,55 @@ Role: acme-corp-workload-manager
 RoleBinding: acme-corp-workload-binding
 ```
 
-Permissions:
-- ✅ Create/manage AgentWorkloads in namespace
-- ✅ Read secrets in namespace
-- ❌ Access other namespaces
-- ❌ Modify cluster resources
+Intended permissions:
+- `[x]` Create and manage AgentWorkloads in the assigned namespace.
+- `[x]` Get and list Secrets in the tenant namespace.
+- `[ ]` Access other tenant namespaces.
+- `[ ]` Modify unrelated cluster resources.
 
-## OPA Policies
+Verify rendered Roles and bindings against the customer's tenancy model before production use.
 
-Workloads evaluated against policies:
+## Action Policy And Rego Assets
+
+The legacy direct-action path uses an in-process Go evaluator selected by:
 
 ```yaml
 opaPolicy: strict
 ```
 
-Policies enforce:
-- Security constraints
-- Resource usage
-- API rate limits
-- Data retention
+It evaluates action type, caller-supplied confidence, cluster health, and strict
+or permissive mode. Read-only actions use a separate allow path.
 
-Define custom policies in ConfigMap.
+The repository also ships Rego samples in a ConfigMap. The direct action path
+does not execute those Rego files or call a real OPA engine today. Treat them as
+policy assets and integration examples.
 
 ## Network Isolation
 
-NetworkPolicies restrict traffic:
+NetworkPolicy objects can restrict selected traffic when the cluster CNI enforces them.
+The Tenant `spec.networkPolicy` field is not consumed by the current tenant
+reconciler. Apply tenant policies separately.
 
-```yaml
-networkPolicy: true  # In Tenant spec
-```
-
-Automatically creates:
-- Pod-to-pod isolation
-- Namespace segregation
-- Egress filtering
+The chart renders a default-deny egress policy for selected operator pods.
 
 The umbrella Helm chart ships a default-deny egress NetworkPolicy
 ([`charts/templates/networkpolicy.yaml`](../charts/templates/networkpolicy.yaml))
-for any pod labeled `app.kubernetes.io/part-of: agentic-operator`. Toggle via
+for pods labeled `app.kubernetes.io/part-of: agentic-operator`. Toggle via
 `networkPolicy.enabled` (default `true`). Allow-listed: kube-dns, the
 in-cluster LiteLLM proxy, Postgres, MinIO, Browserless (when enabled), and
 external OPA (when configured). Operator-supplied additions go under
 `networkPolicy.additionalAllowedHosts`. Verified by helm-unittest in
 [`charts/tests/networkpolicy_test.yaml`](../charts/tests/networkpolicy_test.yaml).
-This closes [issue #129](https://github.com/Clawdlinux/agentic-operator-core/issues/129).
+Managed workload namespaces require separate policy application and matching labels.
+Optional Cilium FQDN policies require Cilium and explicit chart configuration.
 
 ## Sandbox Technology
 
-Agent code runs untrusted by definition — both because the agent's instructions
-come from end users (prompt injection surface) and because tool outputs may
-contain hostile content. Clawdlinux sandboxes agent pods at the syscall layer so
-a successful container-escape primitive does not yield host kernel access.
+Agent code should be treated as untrusted because the agent's instructions
+come from end users and tool outputs may contain hostile content. Clawdlinux can
+select gVisor for labeled pods when the cluster has a working `runsc` runtime.
 
-**Default sandbox: gVisor** ([gvisor.dev](https://gvisor.dev/)). gVisor
+**Supported sandbox: gVisor** ([gvisor.dev](https://gvisor.dev/)). gVisor
 intercepts all syscalls in user space (the `runsc` runtime) and reimplements a
 restricted subset of the Linux ABI, eliminating direct exposure of the host
 kernel surface. The syscall allowlist is sourced from the upstream gVisor
@@ -99,12 +90,8 @@ plus the per-runtime additions documented in
 We do not maintain a fork — we deliberately track upstream so security fixes land
 without lag.
 
-**Opt-in sandbox: Kata Containers** ([katacontainers.io](https://katacontainers.io/))
-for full microVM isolation. Pick this when your threat model requires hardware
-virtualization boundaries (sovereign workloads, strictly-air-gapped tenants,
-multi-tenant clusters where one tenant's compromise must not leak into another's
-memory). Kata trades startup latency (~hundreds of ms vs. tens) for a
-qualitatively stronger isolation guarantee.
+Kata Containers may be evaluated separately when the customer requires a
+microVM boundary. The repository does not configure a Kata runtime path.
 
 > **Status:** the Helm chart can create the gVisor `RuntimeClass` and register a
 > pod mutating webhook. Pods opt in with the label
@@ -119,17 +106,17 @@ Best practices:
 1. **Store in Kubernetes Secrets** - Not ConfigMaps
 2. **Use RBAC** - Limit access to service accounts only
 3. **Rotate regularly** - Every 90 days
-4. **Audit access** - Enable secret audit logging
+4. **Audit access** - Enable Kubernetes API audit logging for Secret requests
 5. **Encrypt at rest** - Enable etcd encryption
 
 ```bash
-# View secret access
-kubectl get events --field-selector involvedObject.kind=Secret
+# Confirm API audit configuration through your Kubernetes provider.
+# Kubernetes Events are not a Secret-access audit log.
 ```
 
-## Audit Logging
+## Audit Evidence
 
-Enable audit logging:
+Enable Kubernetes API audit logging through the cluster provider when required:
 
 ```yaml
 apiServer:
@@ -140,12 +127,14 @@ apiServer:
         resources: [tenants, agentworkloads]
 ```
 
+The repository also provides HMAC hash-chain and JSONL verification primitives.
+The controller does not automatically append each run event into that chain.
+
 ## Compliance
 
-Supports compliance frameworks:
-- ✅ SOC 2 Type II
-- ✅ HIPAA
-- ✅ PCI-DSS
-- ✅ GDPR
+Clawdlinux does not make a deployment compliant with a named framework.
+Customers may map configured controls and collected evidence to requirements
+such as SOC 2, HIPAA, PCI DSS, GDPR, DORA, or the EU AI Act.
 
-See `Monitoring` for audit logging setup.
+Applicability depends on the organization, data, role, jurisdiction, operating
+procedures, and independent assessment.

--- a/docs/08-api-reference.md
+++ b/docs/08-api-reference.md
@@ -1,66 +1,71 @@
 # API Reference
 
-Complete CRD specification.
+The generated CRDs are the source of truth:
 
-For versioning guarantees, deprecation windows, and breaking-change governance, see [API Compatibility Policy](./API_COMPATIBILITY_POLICY.md).
+- [`AgentWorkload`](../config/crd/bases/agentic.clawdlinux.org_agentworkloads.yaml)
+- [`AgentCard`](../config/crd/bases/agentic.clawdlinux.org_agentcards.yaml)
+- [`Tenant`](../config/crd/bases/agentic.clawdlinux.org_tenants.yaml)
 
-## Tenant CRD
+See [API Compatibility Policy](./API_COMPATIBILITY_POLICY.md) for versioning and deprecation rules.
 
-### Spec
+## AgentWorkload
 
-```yaml
-apiVersion: agentic.clawdlinux.org/v1alpha1
-kind: Tenant
-metadata:
-  name: <tenant-name>
-spec:
-  displayName: <string>              # Human-readable name
-  namespace: <string>                # K8s namespace
-  providers: [<string>]              # LLM providers
-  quotas:
-    maxWorkloads: <int>              # Concurrent workloads
-    maxConcurrent: <int>             # Parallel executions
-    maxMonthlyTokens: <int64>        # Token budget
-    cpuLimit: <string>               # CPU cores
-    memoryLimit: <string>            # RAM
-  slaTarget: <float>                 # SLA percentage
-  networkPolicy: <bool>              # Enable isolation
-```
+Important spec groups:
 
-### Status
+- Objective and legacy workflow: `objective`, `agents`, `workflowName`, `jobId`.
+- Runtime: `orchestration.type`, `workflowTemplateRef`.
+- Limits: `resources`, `timeouts`.
+- Models: `modelStrategy`, `taskClassifier`, `providers`, `modelMapping`.
+- Actions: `autoApproveThreshold`, `opaPolicy`.
+- Collaboration: `collaborationMode`, `agentRefs`, `persona`.
+- External integration: `mcpServerEndpoint`.
 
-```yaml
-status:
-  phase: <Pending|Provisioning|Active|Failed|Terminating>
-  conditions: [<Condition>]          # Ready, NamespaceCreated, etc
-  namespaceCreated: <bool>
-  secretsProvisioned: <bool>
-  rbacConfigured: <bool>
-  quotasEnforced: <bool>
-  networkPolicyActive: <bool>
-  workloadCount: <int>
-  tokensUsedThisMonth: <int64>
-  lastReconciliation: <Time>
-```
+Registered runtime types are `argo`, `pod`, and `kagent`.
 
-## AgentWorkload CRD
+`opaPolicy` selects strict or permissive behavior in the legacy in-process Go
+evaluator. It does not cause the direct action path to execute Rego.
 
-See `Examples` for complete specifications.
+Important status fields:
 
-### Fields
+- `phase`
+- `conditions`
+- `proposedActions`
+- `executedActions`
+- `argoWorkflow` and `argoPhase`
+- `workflowArtifacts`
+- `modelRoutingOperationID`
+- `agentStatuses`
 
-- `objective` - Task description
-- `modelStrategy` - fixed|cost-aware
-- `taskClassifier` - default
-- `autoApproveThreshold` - Quality threshold
-- `providers` - LLM provider configurations
-- `modelMapping` - Task category → model mapping
-- `opaPolicy` - strict|permissive
+The historical `argoWorkflow` field also stores pod and kagent execution references.
+Its `runtime` field identifies the selected adapter.
 
-### Status
+## Tenant
 
-- `phase` - Pending|Processing|Completed|Failed
-- `conditions` - Detailed status
-- `tokensUsed` - Input/output token count
+The Tenant spec includes namespace, provider names, resource quotas, an SLA target,
+and a network-policy flag.
 
-See full API at `/api/v1alpha1`.
+The current tenant reconciler creates:
+
+- the tenant namespace;
+- copies of named provider Secrets from `agentic-system`;
+- a service account, Role, and RoleBinding;
+- CPU, memory, and pod-count ResourceQuota entries.
+
+`maxConcurrent`, `maxMonthlyTokens`, `slaTarget`, and `networkPolicy` are API fields,
+but the current Tenant reconciler does not provide complete enforcement for them.
+
+Some Tenant status fields are reserved for later integrations and may remain at
+their zero value.
+
+## AgentCard
+
+AgentCard describes reusable capability metadata and endpoints. It does not by
+itself bind an external employee identity to an AgentWorkload request.
+
+## MCP Surface
+
+`agentctl mcp serve` exposes tools for creating, listing, inspecting, and deleting
+AgentWorkloads. See [agentctl MCP](./agentctl/mcp.md).
+
+Bearer-token authentication protects the trusted adapter. Individual actor
+identity propagation and full RBAC remain integration work.

--- a/docs/09-examples.md
+++ b/docs/09-examples.md
@@ -1,136 +1,50 @@
 # Examples
 
-Real-world usage examples.
+Use checked-in examples instead of copying stale provider or pricing values from documentation.
 
-## Example 1: Basic Multi-Tenant Setup
+## Governance And Demo Samples
 
-Create three customers with different quotas:
+- [`agentworkload_demo.yaml`](../config/samples/agentworkload_demo.yaml)
+- [`agentworkload_demo_allow.yaml`](../config/samples/agentworkload_demo_allow.yaml)
+- [`agentworkload_demo_deny.yaml`](../config/samples/agentworkload_demo_deny.yaml)
+- [`agentworkload_demo_runtime.yaml`](../config/samples/agentworkload_demo_runtime.yaml)
+- [`agentworkload-cost-aware-routing.yaml`](../config/samples/agentworkload-cost-aware-routing.yaml)
 
-```bash
-# ACME Corp - Large customer
-kubectl apply -f - << 'YAML'
-apiVersion: agentic.clawdlinux.org/v1alpha1
-kind: Tenant
-metadata:
-  name: acme-corp
-spec:
-  displayName: "ACME Corporation"
-  namespace: agentic-customer-acme
-  providers: [cloudflare-workers-ai, openai]
-  quotas:
-    maxWorkloads: 200
-    maxConcurrent: 50
-    maxMonthlyTokens: 100000000
-YAML
+## Collaboration Samples
 
-# BigCo - Medium customer
-kubectl apply -f - << 'YAML'
-apiVersion: agentic.clawdlinux.org/v1alpha1
-kind: Tenant
-metadata:
-  name: bigco
-spec:
-  displayName: "BigCo Inc"
-  namespace: agentic-customer-bigco
-  providers: [cloudflare-workers-ai]
-  quotas:
-    maxWorkloads: 50
-    maxConcurrent: 10
-    maxMonthlyTokens: 10000000
-YAML
+- [`agentworkload-persona-swarm.yaml`](../config/samples/agentworkload-persona-swarm.yaml)
+- [`agentworkload_demo_swarm.yaml`](../config/samples/agentworkload_demo_swarm.yaml)
+- [`a2a_team_example.yaml`](../config/samples/a2a_team_example.yaml)
 
-# Startup - Small customer
-kubectl apply -f - << 'YAML'
-apiVersion: agentic.clawdlinux.org/v1alpha1
-kind: Tenant
-metadata:
-  name: startup-xyz
-spec:
-  displayName: "StartupXYZ"
-  namespace: agentic-customer-startup
-  providers: [cloudflare-workers-ai]
-  quotas:
-    maxWorkloads: 10
-    maxConcurrent: 2
-    maxMonthlyTokens: 1000000
-YAML
-```
+## Workflow Examples
 
-## Example 2: Cost-Optimized Workload
+- [`research-swarm.yaml`](../config/examples/research-swarm.yaml)
+- [`code-review.yaml`](../config/examples/code-review.yaml)
+- [`doc-processor.yaml`](../config/examples/doc-processor.yaml)
 
-```yaml
-apiVersion: agentic.clawdlinux.org/v1alpha1
-kind: AgentWorkload
-metadata:
-  name: content-analysis
-  namespace: agentic-customer-acme
-spec:
-  objective: "Analyze blog content for engagement metrics"
-  modelStrategy: cost-aware      # Use cheapest viable model
-  taskClassifier: default
-  autoApproveThreshold: 0.8      # Lower threshold for cost optimization
-  providers:
-    - name: cloudflare-workers-ai
-      type: openai-compatible
-      endpoint: https://api.cloudflare.com/...
-  modelMapping:
-    analysis: cloudflare-workers-ai/llama-2-7b-chat-int8
-```
+## Safe Evaluation Pattern
 
-Cost savings: ~70% vs. GPT-4.
-
-## Example 3: High-Quality Analysis
-
-```yaml
-apiVersion: agentic.clawdlinux.org/v1alpha1
-kind: AgentWorkload
-metadata:
-  name: strategic-research
-  namespace: agentic-customer-acme
-spec:
-  objective: "Perform deep competitive analysis for Q2 strategy"
-  modelStrategy: fixed           # Use specific high-quality model
-  taskClassifier: default
-  autoApproveThreshold: 0.95     # Higher quality requirement
-  providers:
-    - name: openai
-      type: openai
-      endpoint: https://api.openai.com/v1
-  modelMapping:
-    analysis: openai/gpt-4-turbo
-    reasoning: openai/gpt-4-turbo
-```
-
-Quality focus: ~95% output quality.
-
-## Example 4: Monitoring Tenant Usage
+Review and dry-run a sample before applying it:
 
 ```bash
-# Get all tenants
-kubectl get tenants
-
-# Check specific tenant status
-kubectl describe tenant acme-corp
-
-# View tenant's workloads
-kubectl get agentworkload -n agentic-customer-acme
-
-# Monitor token usage
-kubectl get tenant acme-corp -o jsonpath='{.status.tokensUsedThisMonth}'
-
-# Watch workload progress
-kubectl get agentworkload -n agentic-customer-acme --watch
+kubectl apply --dry-run=server \
+  -f config/samples/agentworkload_demo.yaml
 ```
 
-## Example 5: Scale Tenant Quotas
+Check provider endpoints, Secret references, runtime type, tool profile, policy
+mode, resources, and timeouts.
+
+Apply only after replacing placeholders:
 
 ```bash
-# Increase ACME's monthly token budget
-kubectl patch tenant acme-corp --type merge -p \
-  '{"spec":{"quotas":{"maxMonthlyTokens":200000000}}}'
-
-# View changes
-kubectl describe tenant acme-corp
+kubectl apply -f config/samples/agentworkload_demo.yaml
+kubectl -n agentic-system get agentworkloads -w
 ```
 
-See Full API Reference for all options.
+## Important Limits
+
+- Sample confidence values are inputs to the Go policy evaluator. They are not an independent security score.
+- Pricing and cost outputs are estimates. Validate them against current provider pricing.
+- Tenant monthly token fields are not automatically aggregated by the Tenant reconciler.
+- NetworkPolicy and gVisor samples prove configuration. Enforcement requires CNI and node-runtime support.
+- The current demo verifies a prior-run audit fixture. It does not produce same-run signed evidence.

--- a/docs/10-troubleshooting.md
+++ b/docs/10-troubleshooting.md
@@ -1,100 +1,102 @@
 # Troubleshooting
 
-Common issues and solutions.
+## Start With Resource State
 
-## Tenant Provisioning Fails
+```bash
+kubectl -n agentic-system get deployments,pods
+kubectl -n agentic-system get agentworkloads
+kubectl -n agentic-system describe agentworkload <name>
+kubectl -n agentic-system get events --sort-by=.lastTimestamp
+```
 
-**Symptom:** Tenant status stuck in "Provisioning"
+Use the actual Helm release labels when selecting operator logs:
 
-**Diagnosis:**
+```bash
+kubectl -n agentic-system get deployments --show-labels
+kubectl -n agentic-system logs deployment/<operator-deployment>
+```
+
+## Tenant Stuck In Provisioning
+
+The Tenant controller reads provider Secrets from `agentic-system` using the name
+`<provider>-token` and copies them into the tenant namespace.
+
 ```bash
 kubectl describe tenant <name>
-kubectl logs -n agentic-system -l app=agentic-operator
+kubectl -n agentic-system get secret <provider>-token
+kubectl auth can-i create namespaces \
+  --as=system:serviceaccount:agentic-system:<operator-service-account>
 ```
 
-**Solutions:**
+Also verify permission to create ServiceAccounts, Roles, RoleBindings, Secrets,
+and ResourceQuotas.
 
-1. **Namespace creation permission**
-   ```bash
-   kubectl auth can-i create namespaces --as=system:serviceaccount:agentic-system:agentic-operator
-   ```
+## Workload Stuck Or Failed
 
-2. **Secret not found in agentic-system**
-   ```bash
-   kubectl get secrets -n agentic-system | grep cloudflare
-   ```
-   → Create missing secrets
-
-3. **RBAC role creation failed**
-   ```bash
-   kubectl get roles -n agentic-customer-*
-   ```
-   → Check operator logs for permission errors
-
-## Workload Never Completes
-
-**Symptom:** AgentWorkload stays in "Pending"
-
-**Diagnosis:**
 ```bash
-kubectl describe agentworkload <name> -n <namespace>
+kubectl -n <namespace> describe agentworkload <name>
+kubectl -n <namespace> get agentworkload <name> -o yaml
 ```
 
-**Solutions:**
+Check:
 
-1. **Provider secret missing**
-   ```bash
-   kubectl get secrets -n <namespace> | grep api-token
-   ```
+- referenced provider Secret and key;
+- `spec.orchestration.type`;
+- `CLAWDLINUX_AGENT_IMAGE` for pod and kagent adapters;
+- Argo or kagent installation when selected;
+- provider endpoint and model mapping;
+- `status.conditions`, `status.argoWorkflow`, and `status.argoPhase`.
 
-2. **License expired**
-   - Check operator logs for license validation errors
-   - Update license key
+## Policy Denial Or Pending Approval
 
-3. **Quality threshold too high**
-   - Lower `autoApproveThreshold`
-   - Check evaluation logs
+The legacy direct-action path may set `PolicyDenied` or `PendingApproval`.
+`opaPolicy` uses an in-process Go evaluator, not Rego execution.
 
-## High Costs
+Inspect proposed actions and conditions:
 
-**Symptom:** Token usage exceeds expectations
-
-**Solutions:**
-
-1. **Switch to cost-aware routing**
-   ```yaml
-   modelStrategy: cost-aware
-   ```
-
-2. **Lower quality threshold**
-   ```yaml
-   autoApproveThreshold: 0.7  # From 0.95
-   ```
-
-3. **Monitor per-workload costs**
-   ```bash
-   kubectl get agentworkload -A -o json | \
-     jq '.items[] | .status.conditions[0].message'
-   ```
-
-## Quota Exceeded
-
-**Symptom:** "Monthly token budget exceeded"
-
-**Solution:**
 ```bash
-# Increase quota
-kubectl patch tenant <name> --type merge -p \
-  '{"spec":{"quotas":{"maxMonthlyTokens":50000000}}}'
+kubectl -n <namespace> get agentworkload <name> \
+  -o jsonpath='{.status.proposedActions}{"\n"}{.status.conditions}{"\n"}'
 ```
 
-## Common Errors
+Direct MCP approval continuation is not connected end to end.
 
-| Error | Cause | Fix |
-|-------|-------|-----|
-| Secret not found | Secret in wrong namespace | Copy to tenant namespace |
-| Authorization denied | Insufficient RBAC | Check service account roles |
-| Provider error | API key invalid | Verify and rotate secrets |
-| OPA policy violation | Policy too strict | Review or relax policies |
+## Cost Shows Zero
 
-See API Reference for detailed error codes.
+The default `NoOpCostReporter` records nothing.
+For local evaluation, start the operator with the in-memory reporter:
+
+```text
+AGENTIC_COST_TRACKING=memory
+```
+
+The in-memory reporter resets on restart and is not suitable for billing.
+
+## gVisor Pod Does Not Start
+
+A labeled pod receives `runtimeClassName: gvisor`, but the node must provide a
+matching RuntimeClass and `runsc` installation.
+
+```bash
+kubectl get runtimeclass gvisor
+kubectl -n <namespace> describe pod <pod>
+```
+
+## NetworkPolicy Does Not Block Traffic
+
+Confirm:
+
+1. the policy selects the intended pod labels;
+2. the policy exists in the intended namespace;
+3. the cluster CNI enforces Kubernetes NetworkPolicy;
+4. optional Cilium policy is enabled and its selector matches.
+
+Policy-object presence alone does not prove packet enforcement.
+
+## Audit Verification
+
+`audit-verify` currently supports JSONL. The ClickHouse source adapter is a stub.
+The controller does not automatically emit a signed entry for every run.
+
+Use the checked-in fixture only as prior-run proof. See
+[SHOWCASE-DEMO-WALKTHROUGH.md](./SHOWCASE-DEMO-WALKTHROUGH.md).

--- a/docs/11-monitoring.md
+++ b/docs/11-monitoring.md
@@ -1,67 +1,51 @@
-# Monitoring & Observability
+# Monitoring And Observability
 
-Comprehensive monitoring setup.
+The operator exposes controller-runtime metrics plus optional routing and
+in-memory cost metrics. Enabled components determine which series exist.
 
 ## Prometheus Metrics
 
-Key metrics exported:
+Repository-defined routing metrics:
 
 ```
-# Workload metrics
-agentic_workload_total{phase}
-agentic_workload_duration_seconds{workload, tenant}
 agentic_model_routing_total{provider, model, task_category}
 agentic_tokens_used_total{provider, model, direction=input|output}
 agentic_estimated_cost_usd{provider}
 
-# Tenant metrics
-agentic_tenant_quota_usage{tenant, resource}
-agentic_tenant_active_workloads{tenant}
-agentic_tenant_tokens_monthly{tenant}
-
-# License metrics
-agentic_license_valid{valid=true|false}
-agentic_license_seats_used{tier}
-agentic_license_days_remaining
+# In-memory reporter metrics, only when enabled
+agentic_workload_cost_usd{workload, namespace}
+agentic_workload_tokens_total{workload, namespace, type}
+clawdlinux_agent_cost_dollars{workload, namespace, model}
 ```
+
+Metric label order may differ from this display order. Inspect `/metrics` in the
+deployed version before writing alerts.
 
 ## Grafana Dashboards
 
-Default dashboards provided:
-- Operator Health
-- Workload Overview
-- Cost Analysis
-- Per-Tenant Usage
-- Quality Metrics
+The optional observability chart includes Grafana provisioning and dashboard
+ConfigMaps. A sample PrometheusRule exists at:
 
-Prebuilt cost templates in this repo:
-- `config/grafana/dashboards/cost-by-workload.json`
 - `config/grafana/prometheus-rule-cost-alerts.yaml`
 
 Import steps:
-1. In Grafana, import `config/grafana/dashboards/cost-by-workload.json`.
-2. Map `DS_PROMETHEUS` and `DS_POSTGRES` datasource variables during import.
-3. Apply alert sample with `kubectl apply -f config/grafana/prometheus-rule-cost-alerts.yaml`.
+Apply the alert sample only after verifying its expressions against exported metrics:
 
-Access: `http://prometheus.agentic-system:3000`
+```bash
+kubectl apply -f config/grafana/prometheus-rule-cost-alerts.yaml
+```
+
+Use `kubectl get service` to find the release-specific Grafana service name.
 
 ## OpenTelemetry Traces
 
-Detailed traces in Loki:
+The optional OTel Collector can export traces to Tempo and ClickHouse.
 
 ```
-LogQL: {job="agentic-operator"} | json
+Trace and log storage depends on enabled chart components.
 ```
 
-Trace hierarchy:
-```
-workload-reconciliation
-├── task-classification
-├── model-routing
-├── provider-execution
-├── evaluation
-└── cost-calculation
-```
+The repository defines GenAI span helpers under `pkg/otel/genai`.
 
 ## Setting up Monitoring
 
@@ -91,21 +75,15 @@ workload-reconciliation
 Example alerts:
 
 ```yaml
-- alert: HighErrorRate
-  expr: rate(agentic_workload_errors[5m]) > 0.05
-
 - alert: CostOverBudget
-  expr: agentic_tenant_tokens_monthly > agentic_tenant_quota_max
-
-- alert: LicenseExpiring
-  expr: agentic_license_days_remaining < 30
+  expr: clawdlinux_agent_cost_dollars > 10
 ```
 
 Configure in `PrometheusRule` CRD.
 
 ## Logging
 
-Structured JSON logs:
+The operator uses structured logging. Available fields depend on the code path.
 
 ```json
 {
@@ -114,10 +92,7 @@ Structured JSON logs:
   "workload": "demo-analysis",
   "namespace": "agentic-demo",
   "event": "workload-completed",
-  "tokens_input": 100,
-  "tokens_output": 250,
-  "quality_score": 85,
-  "cost_usd": 0.05
+  "event": "workload-completed"
 }
 ```
 
@@ -131,11 +106,9 @@ kubectl logs -n agentic-system -l app=agentic-operator -f | jq '.'
 Operator provides health endpoints:
 
 ```bash
-# Readiness
-curl http://operator:8080/healthz/ready
-
-# Liveness
-curl http://operator:8080/healthz/alive
+# Readiness and liveness endpoints
+curl http://operator:8082/readyz
+curl http://operator:8082/healthz
 
 # Metrics
 curl http://operator:8080/metrics
@@ -145,14 +118,14 @@ Configure in Deployment:
 ```yaml
 livenessProbe:
   httpGet:
-    path: /healthz/alive
-    port: 8080
+    path: /healthz
+    port: 8082
   initialDelaySeconds: 30
 
 readinessProbe:
   httpGet:
-    path: /healthz/ready
-    port: 8080
+    path: /readyz
+    port: 8082
   initialDelaySeconds: 10
 ```
 

--- a/docs/12-contributing.md
+++ b/docs/12-contributing.md
@@ -1,114 +1,86 @@
 # Contributing
 
-Help improve Clawdlinux!
+See the repository-level [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution policy.
 
-## Development Setup
+## Setup
 
 ```bash
-# Clone repository
-git clone https://github.com/Clawdlinux/agentic-operator-core
-cd agentic-operator
+git clone https://github.com/Clawdlinux/agentic-operator-core.git
+cd agentic-operator-core
+make help
+```
 
-# Install tools
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+Use a supported Python version. The Makefile selects Python 3.12 when available.
 
-# Build
+## Common Targets
+
+```bash
 make build
-
-# Run locally
-make run
+make test
+make helm-lint
 ```
 
-## Code Organization
-
-```
-├── api/v1alpha1/              # CRD definitions
-├── internal/controller/        # Controllers (reconcilers)
-├── pkg/                        # Packages
-│   ├── multitenancy/
-│   ├── routing/
-│   ├── metrics/
-│   ├── license/
-│   ├── opa/
-│   └── ...
-├── config/                     # YAML configs
-├── docs/                       # Documentation
-└── Makefile                    # Build targets
-```
-
-## Making Changes
-
-1. **Create branch**
-   ```bash
-   git checkout -b feature/my-feature
-   ```
-
-2. **Make changes** and add tests
-
-3. **Run tests**
-   ```bash
-   make test
-   ```
-
-4. **Lint code**
-   ```bash
-   golangci-lint run
-   ```
-
-5. **Generate CRD updates**
-   ```bash
-   make generate
-   ```
-
-6. **Commit with meaningful message**
-   ```bash
-   git commit -m "feat: add new feature"
-   ```
-
-7. **Push and create PR**
-   ```bash
-   git push origin feature/my-feature
-   ```
-
-## Code Guidelines
-
-- Follow Go conventions
-- Add tests for new features (aim for >80% coverage)
-- Document public functions
-- Update docs/ if user-facing changes
-- Run `make fmt` before committing
-
-## Testing
+Before opening a pull request, run the canonical validation when your environment
+can install envtest assets:
 
 ```bash
-# Unit tests
-make test
-
-# Integration tests
-make test-integration
-
-# E2E tests
-make test-e2e
-
-# All tests
-make test-all
+make validate
 ```
 
-## Releases
+Useful focused targets:
 
-- Maintainers handle releases
-- Semantic versioning (MAJOR.MINOR.PATCH)
-- Changelog updated in CHANGELOG.md
+```bash
+make test-go
+make test-controller
+make test-anf-snapshot
+make test-python
+make lint
+make scan-secrets
+```
 
-## Getting Help
+Cluster tests require a configured cluster:
 
-- GitHub Issues - Report bugs, request features
-- GitHub Discussions - Questions and ideas
-- Email - contact@agentic.io
+```bash
+make test-smoke
+make test-e2e-cluster
+make test-cluster
+```
 
-## Code of Conduct
+Do not use undocumented targets such as `make run`, `make test-integration`, or
+`make test-all`; they do not exist in the current Makefile.
 
-Be respectful and inclusive. See CODE_OF_CONDUCT.md.
+## Runtime Changes
 
-Thank you for contributing!
+Runtime selection must go through `pkg/runtime.Registry`.
+
+To add a runtime:
+
+1. Implement `runtime.RuntimeAdapter`.
+2. Add compile-time interface checks and tests.
+3. Register it in `ensureRuntimeDefaults`.
+4. Document required cluster dependencies.
+5. Do not add runtime-specific branches to `Reconcile`.
+
+## Documentation Changes
+
+Public claims must distinguish:
+
+- implemented runtime behavior;
+- configuration proof;
+- prior-run fixtures;
+- target product behavior.
+
+Do not claim compliance certification, packet enforcement, same-run signed
+attestation, full air-gap proof, or customer adoption without supporting evidence.
+
+## Git Workflow
+
+Use a focused branch and signed-off commits:
+
+```bash
+git switch -c docs/my-change
+git commit -s -m "docs: describe the change"
+git push -u origin docs/my-change
+```
+
+Open a pull request and include the checks you ran.

--- a/docs/DEMO-PLAN.md
+++ b/docs/DEMO-PLAN.md
@@ -1,40 +1,11 @@
 # Demo Plan
 
-One demo, 10 to 12 minutes, runs entirely on a local kind cluster via `scripts/demo-booth.sh`. Written for the co-founder walkthrough and the Jul 22 booth. Everything here is reproducible today; no step depends on unshipped code.
+The canonical technical demo plan is
+[SHOWCASE-DEMO-WALKTHROUGH.md](./SHOWCASE-DEMO-WALKTHROUGH.md).
 
-## The story we are telling
+That walkthrough labels evidence as live, configuration-only, or prior-run and
+does not claim current packet enforcement, scheduled gVisor execution, real Rego
+evaluation, or same-run signed evidence.
 
-A regulated fintech platform team wants to run an analysis agent. Security will only sign off if three things are provable: the agent cannot do destructive work, cannot reach anything outside a declared allowlist, and every action is recorded in a way an auditor can verify offline later. We show all three, then break the audit trail on purpose and watch verification fail.
-
-## Prep (before the call, not during)
-
-```
-./scripts/demo-booth.sh --profile platform  # kind + operator + Argo + shared services
-./scripts/demo-booth.sh --cleanup  # to reset
-```
-
-Run it once the night before. It provisions the kind cluster (`clawdlinux-demo`), installs the operator, Argo, and shared services, and leaves evidence under `tests/harness/evidence/`. Use `--profile lean` if time or laptop capacity is constrained. Keep a recorded run (`--record`) as backup in case live wifi or Docker misbehaves.
-
-## Run of show
-
-1. Frame (1 min). "Agent runtimes are getting good. What blocks production in a bank is governance: identity, blast radius, cost, and proof. We wrap any agent workload with those controls. Here is the whole thing on my laptop, air-gap friendly."
-
-2. The manifest is the contract (2 min). Show `config/samples/agentworkload_demo_allow.yaml`. Point at the parts security cares about: `opaPolicy: strict`, the approval threshold, the declared endpoint. The review surface is a YAML file in a PR, not a prompt.
-
-3. Policy allow vs deny (2 min). Apply the allow workload (`objective: analyze quarterly revenue data`), it proceeds. Apply the deny workload (`objective: delete all production volumes`), OPA rejects it. Same policy, no model involved in the decision.
-
-4. Isolation and egress (2 min). Show the gVisor RuntimeClass injection and the generated NetworkPolicy. On kind, demonstrate that the Kubernetes-native controls exist and are reviewable. Do not claim live packet enforcement in this environment. Production clusters with Cilium enforce the declared FQDN boundary at the network layer.
-
-5. Cost (1 min). Show the per-workload cost metric. Every run has an owner and a price.
-
-6. The closer: tamper-evident audit (3 min). Use the checked-in signed artifact and demo key from [`_staging/booth/README.md`](../_staging/booth/README.md). Run `audit-verify --source jsonl --path _staging/booth/attestation-fallback.jsonl --key <demo-kid=base64-key>` for PASS. Create `/tmp/tampered.jsonl` with the documented `sed` command, then run the same verifier against it for FAIL. "This is what your auditor gets. They do not have to trust us or you. They recompute the chain offline."
-
-7. Optional, if audience is technical and time allows (`--with-swarm`): the three-agent swarm (`config/samples/agentworkload_demo_swarm.yaml`), scraper, synthesizer, report generator through an Argo DAG, same controls applied to a multi-agent run.
-
-## Talk track guardrails
-
-Do not name competitor runtimes as problems. Do not claim SPIFFE/multi-cluster, SOC 2, webhook validation, or an air-gapped CI gate; they are roadmap. If asked "does this work with runtime X": "the adapter interface covers our CRD, plain labeled pods, and external runtimes; the seal and attestation contract is the same for all three."
-
-## Failure modes and fallbacks
-
-Docker/kind flaky: play the recorded run, narrate live. Argo slow to schedule: use the lean profile, the policy and audit story does not need it. Question you cannot answer: "good question, that is exactly the kind of thing we gate the roadmap on, tell me more about your setup."
+For the short booth interaction and multi-agent organization diagram, use the
+external booth bundle under `/Users/sunny/clawdlinux/booth`.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -6,26 +6,30 @@ Status: living document, July 2026. If you read one doc about this project, read
 
 Enterprises want to run AI agents on their own Kubernetes clusters. Their security and compliance teams keep saying no, because nobody can answer four questions about an autonomous agent: who is it acting as, what can it reach, what did it cost, and can we prove what it did six months later.
 
-Clawdlinux is a governance plane that answers those questions for any agent workload on Kubernetes. It does not compete with agent runtimes. It wraps them.
+Clawdlinux is building a governance plane around agent workloads on Kubernetes. It does not compete with agent runtimes. It wraps them.
 
-The wedge is the combination of two controls in one self-hosted deployment:
+The target contract combines two controls in one self-hosted deployment:
 
-1. A signed, hash-chained attestation artifact for every agent run, verifiable offline with a small CLI (`audit-verify`). An auditor can replay what an agent did months later inside an air-gapped cluster.
-2. A zero-egress seal at the network boundary. The agent can only reach the FQDNs its manifest declares. Enforced by Cilium, not by prompting the model to behave.
+1. Same-run signed evidence that links identity, policy, approval, action, cost, and outcome.
+2. A declared egress boundary enforced by the customer's Kubernetes networking stack.
 
 Everything else (gVisor isolation, cost attribution, Argo orchestration, LiteLLM routing) supports that wedge.
 
+Today, the repository ships the audit hash-chain and JSONL verifier as separate primitives. It also generates network-policy objects and admission mutations. Automatic same-run capture, durable audit storage, production key custody, and packet-enforcement proof are not connected end to end.
+
 ## Architecture
 
-Everything in the governance plane runs inside one Kubernetes cluster, which can be fully air-gapped. The operator also runs the tenant controller (namespaces, RBAC, quotas), the offline JWT license validator, and the gVisor RuntimeClass injector. Runtime adapters (`pkg/runtime`) apply the same seal and attestation contract to our AgentWorkload CRD, BYO labeled pods, and external CNCF runtimes. Shared services (Argo, LiteLLM, MinIO, Postgres, Grafana, Browserless) ship as subcharts of one Helm umbrella chart.
+The governance components run inside the customer's Kubernetes cluster. The repository includes tenant controls, offline JWT validation, admission mutation, runtime adapters, and optional shared-service subcharts.
 
-Data flow for one run: AgentWorkload applied -> license and OPA policy check -> Cilium egress policy generated from the manifest's declared FQDNs -> Argo DAG executes agent pods (gVisor if labeled) -> every LLM call, tool call, and state transition appended to the audit chain -> cost recorded per workload -> signed attestation artifact written to MinIO -> chain head checkpointed.
+Current data flow: AgentWorkload applied -> license and budget checks -> runtime selected through `pkg/runtime.Registry` -> workload status and usage updated. Admission and network-policy components apply through Kubernetes configuration paths.
 
-Tamper anywhere in that record and `audit-verify` fails the chain. That is the demo moment.
+The audit package is not called by this reconciliation path. The booth separately verifies a prior-run JSONL fixture and labels it accordingly.
 
-## Why the audit chain is trustworthy
+## Audit primitive and limits
 
-Each event hash commits to the previous one (seq, timestamp, tenant, workload, actor, action, payload hash, prev hash, fixed binary encoding). Rows are HMAC-signed with a key held in a Kubernetes Secret. Storage is append-only with no UPDATE/DELETE grants. The chain head is published periodically to a ConfigMap and optionally mirrored to Sigstore Rekor. Verification is a pure function over bytes, so a third party recomputes the chain offline without trusting our server. Code: `pkg/audit`, CLI: `cmd/audit-verify`.
+Each entry hash commits to its sequence, timestamp, context, payload hash, and previous hash. Rows use HMAC-SHA256 with a caller-supplied key. `audit-verify` can verify JSONL entries offline.
+
+The only repository backend is in-memory. ClickHouse reading, Kubernetes key loading, automatic capture, restricted durable storage, and external checkpoint publishing are not implemented. A shared-key holder can rewrite and re-sign history. Tail truncation can pass without a trusted expected head.
 
 ## Anchor use case: compliance-bound market analysis at a financial institution
 
@@ -40,10 +44,10 @@ How they integrate, day one to day thirty:
 
 1. `helm install` the umbrella chart from an OCI artifact we hand them. Air-gapped clusters load images from the same bundle. No registry pulls, no license server callbacks (JWT verified offline).
 2. Point LiteLLM at their approved model endpoint. Nothing else in the stack knows or cares which model it is.
-3. Bring their agents. Three adoption paths, cheapest first: label existing pods (they get the gVisor seal and audit for free), wrap them in an AgentWorkload CRD (they also get Argo DAG orchestration, budgets, and routing), or run a supported CNCF runtime behind the adapter.
-4. Compliance officer gets a standing artifact: for each run, who ran it, what it touched, what it cost, signed and replayable. When the auditor shows up, they hand over a snapshot and the `audit-verify` binary instead of a week of log archaeology.
+3. Bring one bounded agent workload. Use a registered runtime adapter or opt labeled pods into supported admission controls.
+4. Map identity, policy, approval, storage, keys, and evidence retention to the customer's environment.
 
-What they get out of it, in their words: "we can finally say yes to the agent project" (platform lead), "blast radius is declared in a manifest I can review in a PR" (security), "evidence collection went from days to a command" (compliance), "I know what each agent costs per run" (whoever owns the cloud bill).
+The design-partner goal is measurable production-review evidence for one workload. It is not a blanket compliance claim.
 
 What we deliberately do not do: build another agent framework, host their data (there is no SaaS in the loop), or ask them to rewrite agents. Governance wraps what they have.
 
@@ -63,9 +67,9 @@ Two product repos plus a website, all under github.com/Clawdlinux.
 
 ## Honest state of the build
 
-Working today: CRD and reconciliation lifecycle, Argo DAG orchestration, Cilium egress policy generation, audit chain and offline verifier, gVisor injector, runtime adapters (AgentWorkload, BYO pods, Argo), LiteLLM routing, per-workload cost tracking, multi-tenancy with quotas, offline JWT licensing, Helm umbrella chart, agentctl with an MCP server mode, Grafana dashboards, the kind-based demo gate, ANF execution runtime reference server with measured benchmarks.
+Working today: CRD lifecycle, Argo DAG orchestration, network-policy generation, audit primitives, gVisor mutation, runtime adapters, model routing, cost interfaces, quotas, offline JWT validation, Helm packaging, MCP workload tools, dashboards, and the kind-based demo.
 
-Not done, do not claim it: webhook admission validation for the CRD, Homebrew tap, air-gapped install smoke test as CI, per-runtime sandbox label guide, multi-cluster identity federation (SPIFFE/SPIRE, RFC-0001, gated on 6 external use cases or 1 paying customer), SOC 2, managed SaaS. Enterprise billing and licensing internals live in a private repo; the OSS tree has boundary READMEs only.
+Not done, do not claim it: same-run audit capture, durable audit storage, external checkpoints, universal tool mediation, direct MCP approval continuation, actor identity propagation, enforcing-CNI proof, air-gap installation CI, SOC 2, or managed SaaS.
 
 The rule we run by: anything that smells like rebuilding the runtime layer sits behind a validation gate until a real deployment asks for it. See ROADMAP.md.
 

--- a/docs/PITCH-SCRIPT.md
+++ b/docs/PITCH-SCRIPT.md
@@ -13,7 +13,7 @@ Times are targets. If she interrupts with questions, good, let her. The deck is 
 "Agents work now. What does not work is getting them past a security review. These are not my numbers." Walk the rings left to right. Land on: "Gartner says 40 percent of these projects die, and names inadequate risk controls as a reason. Only 11 percent of production agents pass an independent security bar. The demand curve and the controls curve have a gap. That gap is the company."
 
 **Slide 3, Why now (90s).**
-"Four things happened at once. Strong open runtimes became available, so we no longer need to rebuild that layer. Incidents went from hypothetical to a bank self-reporting to its regulator. Fed guidance explicitly excludes agentic AI, so auditors are improvising. The buyers who need verifiable evidence most are also the ones that often cannot use a hosted control plane. We start with self-hosted and air-gapped deployments."
+"Four things happened at once. Strong open runtimes became available, so we no longer need to rebuild that layer. Incidents moved from hypothetical to reported operational failures. Platform and security teams now need identity, authorization, action control, cost, and evidence around agent workloads. We start with customer-owned Kubernetes deployments."
 
 **Slide 4, What we built (90s).**
 "Our target product is an in-cluster governance and attestation plane. The booth captures a live ANF snapshot and injects it into an AgentWorkload objective. That workload routes through LiteLLM to the Claude alias. It shows genuine tokens and nonzero cost evidence. It also shows webhook mutation simulation, NetworkPolicy object presence, and prior-run HMAC audit verification. The current path does not execute OPA. It does not prove packet enforcement, a scheduled gVisor workload, or current-run audit generation."
@@ -28,7 +28,7 @@ Walk the six target steps quickly. Say: "This slide describes the target product
 "Everything on this slide is in a public repo you can read tonight. 180 commits since February. The execution runtime numbers are measured, checked-in benchmarks, not projections: 64 to 97 percent context reduction against raw MCP, one round trip instead of up to 21."
 
 **Slide 8, Where we are (60s). Do not rush this one.**
-"Honest state: built but not validated. Pre-revenue, zero customers, and I have a kill criterion: ten real conversations with named platform and security engineers by July 15, or I stop building features until I have them. I am telling you this because if you join, your first job is making sure we never ship into a vacuum again."
+"Honest state: built but not validated. Pre-revenue, zero customers. The July 15 validation criterion passed without sufficient evidence, so it has been reset once: ten qualified conversations by September 15, with at least three active production-review blockers and one scoped design-partner engagement. We do not extend it again without a written decision review."
 
 **Slide 9, Roadmap (45s).**
 "The roadmap has gates, not wishes. SPIFFE federation, SOC 2, managed offering: all of it waits for a customer to pull it. The only committed work is validation and the July 22 booth."
@@ -100,14 +100,14 @@ These are product acceptance criteria. They are not outcomes from the current bo
 
 The demo is not the product. The demo is bait for a specific conversation. The high-value signal is not "cool demo", it is evidence someone would deploy or pay.
 
-**Signal ladder, weakest to strongest.** Compliment < asks technical questions < describes their own environment unprompted < names a specific blocked project < agrees to a follow-up with a named colleague < asks for the install bundle < agrees to a scoped pilot with dates. Everything below "describes their own environment" counts toward nothing. Your Jul 15 kill criterion counts only conversations where they talk about THEIR stack, not yours.
+**Signal ladder, weakest to strongest.** Compliment < asks technical questions < describes their own environment unprompted < names a specific blocked project < agrees to a follow-up with a named colleague < asks for the install bundle < agrees to a scoped pilot with dates. Everything below "describes their own environment" counts toward nothing. The Sep 15 validation criterion counts only conversations where they talk about THEIR stack, not yours.
 
 **The three questions to ask everyone who sees the demo.** Ask, then shut up:
 1. "Do you have an agent project that is stuck right now? What is it stuck on?" (Discovers whether the pain is real and whether it is governance-shaped.)
 2. "Who in your org would have to say yes to something like this, and what would they need to see?" (Maps the buying committee and gives you the artifact list for the pilot.)
-3. "If I gave you the air-gapped bundle Monday, what would stop you from installing it?" (Surfaces the real objection: procurement, priority, missing feature, or no actual pain.)
+3. "If we scoped one workload on one cluster Monday, what would stop you from testing it?" (Surfaces the real objection: procurement, priority, missing control, or no actual pain.)
 
-**The one CTA.** Free design-partner pilot for regulated enterprises, already on the website. Scope it tight when you offer it: "30 days, one use case, your cluster, we help install, you give us a weekly 30-minute call and an honest verdict." A tight scope is easier to say yes to and produces a reference or a lesson either way.
+**The one CTA.** Scope one design-partner evaluation tightly: "30 days, one use case, one cluster, explicit pass and fail criteria, and a weekly 30-minute review." Pricing and commercial terms follow qualified discovery. Do not promise full compliance or arbitrary agent coverage.
 
 **Disqualify fast.** No Kubernetes, no regulated pressure, or no stuck project: be polite, take nothing, move on. A pipeline of unqualified enthusiasm is how the last two engineering-over-validation cycles happened.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,209 +1,49 @@
-# Agentic Kubernetes Operator - Complete Documentation
+# Clawdlinux Documentation
 
-Welcome to the Agentic K8s Operator documentation. This guide covers everything you need to deploy and operate a production-grade autonomous agent infrastructure.
+Clawdlinux is an in-cluster governance layer for Kubernetes agent workloads.
+It does not replace the customer's agent runtime or orchestration system.
 
-## 📚 Documentation Structure
+## Start Here
 
-### Getting Started
-- **[Quick Start](./01-quickstart.md)** - Get up and running in 5 minutes
-- **[Installation](./02-installation.md)** - Detailed installation instructions
-- **[Configuration](./03-configuration.md)** - Configure operator behavior
+- [Quick Start](./01-quickstart.md): install the chart and inspect one workload contract.
+- [Installation](./02-installation.md): local chart installation and prerequisites.
+- [Configuration](./03-configuration.md): values, runtimes, policy, network, and cost settings.
+- [Architecture](./04-architecture.md): current components and runtime adapter contract.
+- [Security](./07-security.md): configured controls and enforcement prerequisites.
+- [API Reference](./08-api-reference.md): CRD source-of-truth links and implemented semantics.
+- [Troubleshooting](./10-troubleshooting.md): common failures and checks.
 
-### Core Concepts
-- **[Architecture](./04-architecture.md)** - System design and components
-- **[Multi-Tenancy](./05-multi-tenancy.md)** - Tenant provisioning & isolation
-- **[Cost Management](./06-cost-management.md)** - Token tracking & billing
-- **[Security](./07-security.md)** - RBAC, license enforcement, OPA policies
+## Evidence Boundaries
 
-### Operations
-- **[API Reference](./08-api-reference.md)** - Complete CRD documentation
-- **[Examples](./09-examples.md)** - Real-world use cases
-- **[Troubleshooting](./10-troubleshooting.md)** - Common issues & solutions
-- **[Monitoring](./11-monitoring.md)** - Prometheus, Grafana, logs
+Public demos and documentation use 4 labels:
 
-### Development
-- **[Contributing](./12-contributing.md)** - Contribute to the project
-- **[API Compatibility Policy](./API_COMPATIBILITY_POLICY.md)** - Public API versioning, compatibility, and deprecation policy
+- `LIVE TODAY`: executed by the current workload path.
+- `CONFIGURATION PROOF`: a mutation or policy object exists.
+- `PRIOR-RUN PROOF`: a stored fixture is verified now.
+- `TARGET PRODUCT`: intended integrated behavior that is not complete.
 
----
+## Current Repository Scope
 
-## 🎯 Quick Navigation
+Implemented components include:
 
-**First time?** → Start with [Quick Start](./01-quickstart.md)
+- AgentWorkload lifecycle and runtime adapters.
+- Argo, pod, and kagent runtime registration.
+- Admission mutation for labeled gVisor pods.
+- Default-deny and optional Cilium policy templates.
+- Model routing and cost-reporting interfaces.
+- HMAC hash-chain and JSONL verification primitives.
+- MCP tools for creating and inspecting AgentWorkloads.
 
-**Need multi-tenancy?** → Read [Multi-Tenancy](./05-multi-tenancy.md)
+The current controller does not generate a complete signed artifact from every
+run. Network enforcement requires the customer's CNI. gVisor requires `runsc`
+on the nodes. Rego policy assets are not executed by the direct action path.
 
-**Deploying to production?** → Follow [Installation](./02-installation.md) → [Configuration](./03-configuration.md) → [Security](./07-security.md)
+## Additional Guides
 
-**Troubleshooting issues?** → Check [Troubleshooting](./10-troubleshooting.md)
-
-**Want to contribute?** → See [Contributing](./12-contributing.md)
-
----
-
-## 📋 What is the Agentic Kubernetes Operator?
-
-The Agentic Kubernetes Operator is the open-source foundation for running autonomous AI agents at scale on Kubernetes. It provides enterprise-grade isolation, cost control, security, and observability for AI workloads on Kubernetes.
-
-It provides:
-
-✅ **Multi-tenant isolation** - Complete namespace isolation with RBAC
-✅ **Cost control** - Real-time token tracking and cost attribution
-✅ **Security** - License enforcement, OPA policies, network isolation
-✅ **Observability** - Prometheus metrics, OpenTelemetry traces, structured logs
-✅ **High availability** - Multi-provider failover, automatic retries
-✅ **Easy provisioning** - Single Tenant CRD for complete tenant setup
-
----
-
-## 🚀 Key Features
-
-### Autonomous Agent Execution
-- Deploy long-running AI agent workloads
-- Automatic task classification (analysis, reasoning, validation)
-- Multi-provider LLM routing with cost optimization
-- Quality evaluation pipeline with hallucination detection
-
-### Multi-Tenancy
-- Automatic namespace provisioning
-- Per-tenant resource quotas
-- Isolated provider secrets
-- RBAC-enforced access control
-
-### Cost Management
-- Real-time token counting
-- Per-provider cost tracking
-- Monthly budget enforcement
-- Cost-aware model routing
-
-### Enterprise Security
-- JWT license enforcement
-- OPA policy evaluation
-- Network policies for isolation
-- Audit logging
-
-### Production-Ready Operations
-- Horizontal Pod Autoscaling
-- Pod Disruption Budgets
-- Health checks and monitoring
-- Self-healing from failures
-
----
-
-## 📊 Architecture Overview
-
-```
-┌─────────────────────────────────────────────────────┐
-│           User / External Client                    │
-└────────────────────┬────────────────────────────────┘
-                     │
-        ┌────────────▼────────────┐
-        │   Kubernetes API        │
-        └────────────┬────────────┘
-                     │
-        ┌────────────▼────────────────────┐
-        │  Clawdlinux              │
-        │ (Controllers & Reconcilers)     │
-        └────────────┬────────────────────┘
-                     │
-    ┌────────────────┼────────────────────┐
-    │                │                    │
-┌───▼──┐        ┌───▼──┐          ┌─────▼────┐
-│Tenant│        │Agent │          │ License  │
-│Ctrl  │        │Work  │          │Validator │
-└──────┘        │load  │          └──────────┘
-                │Ctrl  │
-                └──────┘
-                    │
-    ┌───────────────┼───────────────┐
-    │               │               │
-┌───▼────┐  ┌──────▼─────┐  ┌─────▼────┐
-│CloudF  │  │  Providers │  │ Metrics  │
-│lare    │  │ (OpenAI,   │  │(Prom,    │
-│Workers │  │ LLaMA, etc)│  │Grafana)  │
-│AI      │  └────────────┘  └──────────┘
-└────────┘
-```
-
----
-
-## 📦 Installation Summary
-
-**Prerequisites:**
-- Kubernetes 1.24+
-- Helm 3.x
-- kubectl configured
-
-**Install with local chart source:**
-
-```bash
-git clone https://github.com/Clawdlinux/agentic-operator-core.git
-cd agentic-operator-core
-helm dependency build ./charts
-helm upgrade --install agentic-operator ./charts \
-  --namespace agentic-system \
-  --create-namespace
-```
-
-For cold-start-safe steps, see [Quick Start](./01-quickstart.md).
-
----
-
-## 🏢 Create Your First Tenant
-
-```yaml
-apiVersion: agentic.clawdlinux.org/v1alpha1
-kind: Tenant
-metadata:
-  name: customer-acme
-spec:
-  displayName: "ACME Corporation"
-  namespace: agentic-customer-acme
-  providers:
-    - cloudflare-workers-ai
-    - openai
-  quotas:
-    maxWorkloads: 100
-    maxConcurrent: 10
-    maxMonthlyTokens: 10000000
-  slaTarget: 99.5
-```
-
-Apply and watch:
-```bash
-kubectl apply -f tenant-acme.yaml
-kubectl get tenants --watch
-```
-
-The operator automatically provisions:
-- ✅ Namespace
-- ✅ Secrets (for provider access)
-- ✅ RBAC (service accounts, roles, bindings)
-- ✅ Resource quotas
-- ✅ Monitoring alerts
-
----
-
-## 🎯 Next Steps
-
-1. **[Installation](./02-installation.md)** - Set up your cluster
-2. **[Configuration](./03-configuration.md)** - Customize operator behavior
-3. **[Multi-Tenancy](./05-multi-tenancy.md)** - Provision your first tenant
-4. **[Monitoring](./11-monitoring.md)** - Set up observability
-5. **[Examples](./09-examples.md)** - Deploy sample workloads
-
----
-
-## 🆘 Need Help?
-
-- 📖 Check [Troubleshooting](./10-troubleshooting.md)
-- 💬 Open an issue on [GitHub](https://github.com/Clawdlinux/agentic-operator-core/issues)
-
----
-
-## 📄 License
-
-Apache License 2.0 - See LICENSE file in the repository.
-
-**Last Updated:** 2026-03-18  
-**Version:** v0.1.0
+- [Multi-Tenancy](./05-multi-tenancy.md)
+- [Cost Management](./06-cost-management.md)
+- [Examples](./09-examples.md): checked-in samples and evidence limits.
+- [Monitoring](./11-monitoring.md): exported metrics and optional observability components.
+- [Contributing](./12-contributing.md): current Make targets and runtime rules.
+- [API Compatibility Policy](./API_COMPATIBILITY_POLICY.md)
+- [Security Documentation](./security/README.md)

--- a/docs/SHOWCASE-DEMO-WALKTHROUGH.md
+++ b/docs/SHOWCASE-DEMO-WALKTHROUGH.md
@@ -132,7 +132,7 @@ The script injects this ANF into the scenario AgentWorkload. In-cluster LiteLLM 
 
 **Exact words to say:**
 
-"The product is the in-cluster governance and attestation layer around agent runtimes. Today's proof shows live Kubernetes context becoming ANF, Claude routing, measured usage, admission mutation, policy objects, and offline tamper detection. Full runtime enforcement and same-run signed attestation remain the next proof steps."
+"The target product is the in-cluster governance and evidence layer around agent runtimes. Today's proof shows live Kubernetes context becoming ANF, Claude routing, measured usage, admission mutation, policy objects, and prior-run tamper detection. Full runtime enforcement and same-run signed evidence remain the next proof steps."
 
 ### 4:40-5:00. Closing ask
 
@@ -216,7 +216,7 @@ Use these only for scheduled conversations. Do not use them for normal booth tra
 
 - Agents cross model, tool, and runtime boundaries.
 - Existing controls prove separate layers, not the full action trail.
-- Clawdlinux joins governance with tamper-evident receipts.
+- Clawdlinux is building the link between governance controls and verifiable receipts.
 
 ### Slide 2. Proof and ask
 
@@ -241,4 +241,4 @@ Protect the closing slide. Under time pressure, cut the opener slide first.
 
 ## One-line close
 
-"Clawdlinux makes agent actions governed, measured, and independently verifiable inside the cluster."
+"Clawdlinux connects workload context, model-cost evidence, control configuration, and prior-run verification. Full action governance remains target work."

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -12,5 +12,5 @@ Security guides, threat models, and identity architecture for Clawdlinux.
 ## Related
 
 - [Security policy](../../SECURITY.md) — vulnerability reporting and SLAs
-- [`docs/07-security.md`](../07-security.md) — runtime security guide (RBAC, OPA, license enforcement)
+- [`docs/07-security.md`](../07-security.md) — runtime security guide (RBAC, action policy, licensing, and enforcement prerequisites)
 - [RFC index](../rfcs/README.md) — open design proposals

--- a/docs/security/cross-cluster-identity.md
+++ b/docs/security/cross-cluster-identity.md
@@ -6,9 +6,9 @@ This document will hold the operational guide for configuring federated workload
 
 ## Current state
 
-Clawdlinux today issues per-cluster identity:
+Clawdlinux today relies on deployment-local identity mechanisms:
 
-- **Intra-cluster:** Kubernetes ServiceAccount tokens plus an operator-issued JWT for agent-to-agent (A2A) calls.
+- **Intra-cluster:** Kubernetes ServiceAccounts identify pods. The Python A2A server supports a configured bearer token, but the operator does not bind it to a workload identity.
 - **Cross-cluster:** No native mechanism. Operators must share static secrets, run Istio with a shared CA, or accept that agents in Cluster A cannot verifiably authenticate to Cluster B.
 
 ## What's coming

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -49,31 +49,31 @@ This document describes the security boundaries, threat vectors, and mitigations
 | Threat | Mitigation | Status |
 |--------|-----------|--------|
 | Modified agent pod image | Image pull policy + digest pinning (recommended) | Partial |
-| Tampered LLM responses | Response validation via OPA policy gates | Implemented |
+| Tampered LLM responses | No universal response-integrity control | Open |
 | Modified workflow state in PostgreSQL | TLS-only connections, DB credentials via secrets | Implemented |
 
 ### Repudiation
 
 | Threat | Mitigation | Status |
 |--------|-----------|--------|
-| Agent action without audit trail | Structured logging with persona (role, tone) on every line | Implemented |
-| Cost attribution disputes | Per-agent virtual keys with spend tracking in LiteLLM | Implemented |
-| CRD changes without tracking | Kubernetes audit log for all CRD CRUD operations | Implemented |
+| Agent action without audit trail | Audit primitives exist; automatic same-run capture is missing | Partial |
+| Cost attribution disputes | Reporter interface and volatile demo reporter | Partial |
+| CRD changes without tracking | Requires Kubernetes API audit configuration | Operator responsibility |
 
 ### Information Disclosure
 
 | Threat | Mitigation | Status |
 |--------|-----------|--------|
-| API keys in environment variables | Kubernetes Secrets (encrypted at rest) + Key Vault CSI | Implemented |
-| Cross-tenant data leakage | Namespace isolation + NetworkPolicy | Implemented |
-| LLM prompt data exposure | LiteLLM proxy does not log prompt content by default | Implemented |
-| Scraped content contains secrets | Content sanitization + hard token limit (200KB) | Implemented |
+| API keys in environment variables | Kubernetes Secrets; etcd encryption and external KMS are operator choices | Partial |
+| Cross-tenant data leakage | Namespace RBAC and selected NetworkPolicy objects | Partial |
+| LLM prompt data exposure | Depends on gateway and provider logging configuration | Operator responsibility |
+| Scraped content contains hostile instructions | Sanitization exists in one Python workflow, not universally | Partial |
 
 ### Denial of Service
 
 | Threat | Mitigation | Status |
 |--------|-----------|--------|
-| Runaway token consumption | Tenant quota: maxMonthlyTokens + per-agent spend limits | Implemented |
+| Runaway token consumption | Quota fields and reporter hooks; default reporter does not enforce | Partial |
 | Resource exhaustion | ResourceQuota + LimitRange per tenant namespace | Implemented |
 | Browserless session exhaustion | Concurrent session limits (default 5) + timeout (30s) | Implemented |
 
@@ -81,9 +81,9 @@ This document describes the security boundaries, threat vectors, and mitigations
 
 | Threat | Mitigation | Status |
 |--------|-----------|--------|
-| Agent escapes namespace | Pod Security Standards (restricted profile) | Implemented |
+| Agent escapes namespace | Namespace RBAC; gVisor mutation is opt-in and requires `runsc` | Partial |
 | Prompt injection via scraped content | `sanitize_scraped_content()` redacts injection patterns | Implemented |
-| Agent calls unauthorized tools | Persona `toolProfile` allow-list enforced at runtime | Implemented |
+| Agent calls unauthorized tools | `toolProfile` is enforced in selected runtime paths, not universally | Partial |
 | Tenant escalates to cluster admin | RBAC: tenant SA can only CRUD AgentWorkload in own namespace | Implemented |
 
 ## Network Security
@@ -95,7 +95,7 @@ Agent pods are restricted to allowlisted domains. Two layers of enforcement:
 1. **Vanilla Kubernetes NetworkPolicy** (default, ships with the Helm chart per
    [issue #129](https://github.com/Clawdlinux/agentic-operator-core/issues/129)).
    Toggle via `networkPolicy.enabled` (default `true`). Source:
-   [`charts/templates/networkpolicy.yaml`](../charts/templates/networkpolicy.yaml).
+   [`charts/templates/networkpolicy.yaml`](../../charts/templates/networkpolicy.yaml).
 2. **Cilium FQDN policy** (optional, eBPF-enforced). Adds domain-level egress
    allow-listing on top of the namespace-level NetworkPolicy. Gated behind
    `networkPolicy.cilium.enabled` (default `false`); requires the Cilium CNI.
@@ -107,23 +107,23 @@ Agent pods are restricted to allowlisted domains. Two layers of enforcement:
 - PostgreSQL (internal)
 - DNS (kube-dns)
 
-External domains must be explicitly allowlisted in the AgentWorkload spec or Tenant policy.
+External destinations require explicit chart or optional Cilium configuration.
 
 > **Note**: Cilium FQDN egress requires Cilium CNI. Vanilla Kubernetes installs use standard NetworkPolicy (namespace-level ingress/egress only) — that is what the chart ships by default.
 
-### No Third-Party OAuth
+### Identity Boundary
 
-All authentication uses Kubernetes-native mechanisms:
+Current workload paths primarily use Kubernetes-native mechanisms:
 - ServiceAccount tokens for pod identity
 - RBAC RoleBindings for authorization
-- No external OAuth providers in the auth chain
+- External actor identity propagation remains target integration work.
 
 ## Secrets Management
 
 | Environment | Method | Risk Level |
 |-------------|--------|------------|
 | Development (Docker Compose) | `.env` file (local only, gitignored) | Medium |
-| Production (Kubernetes) | K8s Secrets + Azure Key Vault CSI driver | Low |
+| Production (Kubernetes) | K8s Secrets; optional external KMS integration | Environment-specific |
 | CI/CD | GitHub Actions secrets | Low |
 
 **Policy**: No plaintext credentials in version control. All secrets via environment variables or mounted volumes.


### PR DESCRIPTION
## What does this PR do?

Align public documentation with the current repository and booth evidence boundaries.

- separates implemented components from the target governance transaction
- documents audit, policy, network, sandbox, cost, license, and tenant limits
- replaces stale install, API, examples, troubleshooting, monitoring, and contributing guidance
- removes production-readiness and compliance overclaims
- preserves runtime-neutral positioning

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] CI/infrastructure

## Checklist

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [x] relevant Go package tests pass
- [x] No private-repo content leaked into OSS core
- [x] Commit is signed off (`git commit -s`)
- [x] Documentation updated

## How to test

```bash
helm lint ./charts
helm template clawdlinux ./charts --namespace agentic-system \
  --set license.key=dev-only-not-a-valid-license >/dev/null
go test ./pkg/audit ./pkg/runtime ./pkg/opa ./pkg/finops ./pkg/mcp \
  ./internal/admission ./cmd/audit-verify
scripts/record-demo.sh --scenario all --verify-log demos/local/latest.log
```

Local Markdown links were checked across 33 public files.

## Related issues

Relates to the July 22 booth readiness review.