### PR TITLE
chore: gitignore local Slack signal report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ _artifacts/
 _staging/
 video/booth-animated-loop.html
 video/booth-loop.tape
+docs/SLACK_SIGNAL_REPORT.md


### PR DESCRIPTION
docs/SLACK_SIGNAL_REPORT.md is local research (CNCF Slack pulls, permalinks, positioning notes). It was untracked; add it to .gitignore so it stays on disk and out of git. Nothing removed from history (it was never committed).