### PR TITLE
docs(contributing): document controller/envtest/kind dev loop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,10 @@
 - [ ] `go build ./...` passes
 - [ ] `go vet ./...` passes
 - [ ] `go test ./...` passes (or relevant subset)
+- [ ] `make test-controller` passes (if you changed the API or reconciler)
 - [ ] No private-repo content leaked into OSS core
 - [ ] Commit is signed off (`git commit -s`)
+- [ ] Commits are human-authored. No AI names in `Signed-off-by` or `Co-authored-by` trailers (the AI Attribution Guard rejects Claude, Copilot, Cursor, GPT-*, Codex, etc.)
 - [ ] Documentation updated (if applicable)
 
 ## How to test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,58 @@ Thank you for contributing to Agentic Operator.
 
 ## Development Setup
 
-1. Fork and clone the repository.
-2. Create a branch from `main`.
-3. Run local validation before opening a PR:
+### Prerequisites
+
+- Go 1.25+ and `make`.
+- Controller tests need nothing extra. `make test-controller` downloads the envtest binaries for you on first run.
+- End-to-end tests need a local cluster. `kind` is the default.
+- Python runtime code under `agents/` needs Python 3. The Makefile builds a venv for you.
+
+### Everyday loop
+
+Fork, clone, and branch from `main`. Then:
 
 ```bash
+# Fast unit tests (Go + ANF snapshot + Python)
+make test
+
+# Or just the Go unit tests
 go test ./...
 ```
 
-If your change touches Python runtime code under `agents/`, run the relevant Python tests as well.
+### Controller and CRD tests
+
+The reconciler tests run against envtest. This target installs the binaries on first run:
+
+```bash
+make test-controller
+```
+
+If you changed the API types, regenerate manifests and deepcopy code first:
+
+```bash
+make manifests generate
+```
+
+### End-to-end against a cluster
+
+These need a running cluster. `kind` works:
+
+```bash
+make test-cluster   # apply CRDs and run against the cluster
+make test-smoke     # smoke checks, including the demo CLI
+make test-e2e-cluster
+```
+
+### Before you open a PR
+
+Run the same gate CI runs:
+
+```bash
+make validate   # fmt-check, lint, controller + Go + ANF + Python tests, helm-lint
+```
+
+If your change touches Python runtime code under `agents/`, run `make test-python` as well.
 
 ## Pull Request Guidelines
 


### PR DESCRIPTION
CONTRIBUTING only told contributors to run `go test ./...`. That misses the controller tests, the envtest setup, and the kind e2e path, so a first-time contributor cannot reproduce CI locally.

Changes:
- CONTRIBUTING: add prerequisites and the real dev loop. make test, make test-controller (auto-installs envtest), make manifests generate after API changes, kind e2e targets (test-cluster/test-smoke/test-e2e-cluster), and make validate as the pre-PR gate.
- PR template: add a make test-controller checklist item and surface the AI Attribution Guard so contributors do not trip it on PR #1.

Docs only. No code or behavior change. Every make target referenced was verified to exist in the Makefile.