### PR TITLE
feat(chart): publish Helm package to GHCR

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -1,0 +1,32 @@
+name: Publish Helm chart
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "chart-v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Package chart
+        run: helm package charts --destination dist
+
+      - name: Log in to GHCR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Push chart
+        run: helm push dist/*.tgz oci://ghcr.io/${{ github.repository_owner }}/agentic-operator-core

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,19 +1,34 @@
 apiVersion: v2
 name: agentic-operator
-description: AI-native Kubernetes operator for agent workloads
+description: Runtime-agnostic Kubernetes governance for AI agents with isolation, egress policy, cost controls, and audit verification.
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
 keywords:
-  - ai
-  - agents
+  - ai-agents
+  - ai-governance
+  - agent-security
+  - air-gapped
+  - audit-logging
+  - egress-policy
+  - gvisor
   - kubernetes
-  - operator
-  - llm
-home: https://github.com/Clawdlinux/agentic-operator-core
+  - kubernetes-operator
+  - policy-as-code
+home: https://clawdlinux.org/products/operator
+icon: https://raw.githubusercontent.com/Clawdlinux/agentic-operator-core/main/assets/clawdlinux-favicon-192.png
+sources:
+  - https://github.com/Clawdlinux/agentic-operator-core
+annotations:
+  artifacthub.io/category: security
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://clawdlinux.org/products/operator
+    - name: Source
+      url: https://github.com/Clawdlinux/agentic-operator-core
 maintainers:
   - name: Shreyansh Jain
-    email: shreyansh@example.com
 dependencies:
   - name: agentic-operator
     version: "0.1.0"


### PR DESCRIPTION
## Summary

- Add Artifact Hub metadata to the umbrella Helm chart.
- Add a canonical icon, homepage, sources, keywords, and links.
- Publish tagged chart packages to GHCR as OCI Helm artifacts.

## Validation

- `helm lint charts` passes.
- `helm package charts` passes.
- Workflow YAML parses.
- Package publishing uses `GITHUB_TOKEN` with `packages: write`.

## Artifact Hub setup

After merge, create a `chart-v0.1.0` tag or dispatch the workflow.
Then add this OCI repository in Artifact Hub:

`oci://ghcr.io/clawdlinux/agentic-operator-core/agentic-operator`

Artifact Hub registration requires an authenticated control-panel action.