### PR TITLE
fix(chart): use lowercase GHCR path

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -29,4 +29,4 @@ jobs:
         run: echo "$GITHUB_TOKEN" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
 
       - name: Push chart
-        run: helm push dist/*.tgz oci://ghcr.io/${{ github.repository_owner }}/agentic-operator-core
+        run: helm push dist/*.tgz oci://ghcr.io/clawdlinux/agentic-operator-core


### PR DESCRIPTION
## Summary

Use the lowercase GHCR namespace required by OCI references.

## Validation

The previous workflow failed with:

`invalid repository "Clawdlinux/agentic-operator-core/agentic-operator"`

The new path is:

`oci://ghcr.io/clawdlinux/agentic-operator-core`

The commit is signed off.